### PR TITLE
Added RDP.TransportSettings2.GatewayCredSharing = 0 to fix a bug where selecting use different credentials

### DIFF
--- a/mRemoteV1/Connection/Connection.Protocol.RDP.vb
+++ b/mRemoteV1/Connection/Connection.Protocol.RDP.vb
@@ -176,6 +176,9 @@ Namespace Connection
                                 RDP.TransportSettings.GatewayUsername = Me.Info.Username
                                 RDP.TransportSettings.GatewayPassword = Me.Info.Password
                                 RDP.TransportSettings.GatewayDomain = Me.Info.Domain
+			    ElseIf Me.Info.RDGatewayUseConnectionCredentials = RDGatewayUseConnectionCredentials.SmartCard Then
+                                RDP.TransportSettings2.GatewayCredsSource = 1
+                                RDP.TransportSettings2.GatewayCredSharing = 0
                             Else
                                 RDP.TransportSettings.GatewayUsername = Me.Info.RDGatewayUsername
                                 RDP.TransportSettings.GatewayPassword = Me.Info.RDGatewayPassword
@@ -533,6 +536,8 @@ Namespace Connection
                 No = 0
                 <LocalizedDescription("strUseSameUsernameAndPassword")> _
                 Yes = 1
+		<LocalizedDescription("strUseSmartCard")> _
+		SmartCard = 2
             End Enum
 #End Region
 

--- a/mRemoteV1/Language/Resources.de.resx
+++ b/mRemoteV1/Language/Resources.de.resx
@@ -1424,6 +1424,9 @@ mRemoteNG wird nun geschlossen und die Installation gestartet.</value>
   <data name="strUseDifferentUsernameAndPassword" xml:space="preserve">
     <value>Anderen Benutzernamen und Passwort verwenden</value>
   </data>
+  <data name="strUseSmartCard" xml:space="preserve">
+    <value>Verwenden einer Smart Card</value>
+  </data>
   <data name="strUseSameUsernameAndPassword" xml:space="preserve">
     <value>Selben Benutzer und Passwort verwenden</value>
   </data>

--- a/mRemoteV1/Language/Resources.fr.resx
+++ b/mRemoteV1/Language/Resources.fr.resx
@@ -1137,6 +1137,9 @@
   <data name="strUseDifferentUsernameAndPassword" xml:space="preserve">
     <value>Utilisez un autre nom d'utilisateur et mot de passe</value>
   </data>
+  <data name="strUseSmartCard" xml:space="preserve">
+    <value>Utilisez une carte à puce</value>
+  </data>
   <data name="strUseSameUsernameAndPassword" xml:space="preserve">
     <value>Utilisez le mÃªme nom d'utilisateur et mot de passe</value>
   </data>

--- a/mRemoteV1/My Project/Resources.resx
+++ b/mRemoteV1/My Project/Resources.resx
@@ -1741,6 +1741,9 @@ mRemoteNG will now quit and begin with the installation.</value>
   <data name="strUseDifferentUsernameAndPassword" xml:space="preserve">
     <value>Use a different username and password</value>
   </data>
+  <data name="strUseSmartCard" xml:space="preserve">
+    <value>Use a Smart Card</value>
+  </data>
   <data name="strUseSameUsernameAndPassword" xml:space="preserve">
     <value>Use the same username and password</value>
   </data>


### PR DESCRIPTION
Added RDP.TransportSettings2.GatewayCredSharing = 0 to fix a bug where selecting use different credentials still uses SSO signin and does not pass the different set of credentials.
