### PR TITLE
Added Post-Build command to compiler for LargeAddressAware

### DIFF
--- a/mRemoteV1/mRemoteV1.vbproj
+++ b/mRemoteV1/mRemoteV1.vbproj
@@ -1182,6 +1182,10 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.VisualBasic.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>call "$(DevEnvDir)..\..\vc\vcvarsall.bat" x86
+"$(DevEnvDir)..\..\vc\bin\EditBin.exe" "$(TargetPath)" /LARGEADDRESSAWARE</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
This Post-Build command will fix the windows 2012R2 issues that are limiting the number of open RDP connections to these servers.