### PR TITLE
MR-874: 1.74 not working under Windows Professional 10 x64

### DIFF
--- a/CHANGELOG.TXT
+++ b/CHANGELOG.TXT
@@ -42,6 +42,7 @@
 	
 	Fixes:
 	------
+    MR-874: Added work-around to installer to ignore installation prerequisites
 	MR-884: Slow startup in some scnearios checking authenticode certificate
 	MR-872: Crash in External Tools when arguments aren't quoted
 	MR-854: crashes when right clicking on connection tab

--- a/InstallerProjects/Installer/Includes/Config.wxi
+++ b/InstallerProjects/Installer/Includes/Config.wxi
@@ -18,6 +18,7 @@
   <?define RequiredDotNetFrameworkVersion = "$(var.RequiredDotNetFrameworkMajorVersion).$(var.RequiredDotNetFrameworkMinorVersion)" ?>
   <?define RDP80KB = "KB2592687" ?>
   <?define RDP81KB = "KB2923545" ?>
+  <?define IGNOREPREREQUISITES = 0 ?>
   
   <?if $(var.Platform) = x64 ?>
     <?define ProductNameWithPlatform = "$(var.ProductName) (64 bit)" ?>

--- a/InstallerProjects/Installer/mRemoteNGV1.wxs
+++ b/InstallerProjects/Installer/mRemoteNGV1.wxs
@@ -38,19 +38,19 @@
     </Condition>
     <!-- Windows 7 or higher required -->
     <Condition Message="!(loc.Install_OSVersionRequirement)">
-      <![CDATA[Installed OR (VersionNT >= 601) OR (VersionNT64 >= 601)]]>
+      <![CDATA[Installed OR (IGNOREPREREQUISITES = 1) OR (VersionNT >= 601) OR (VersionNT64 >= 601)]]>
     </Condition>
     <!-- If Windows 7, SP 1 is required -->
     <Condition Message="!(loc.Install_Win7RequiresSP1)">
-      <![CDATA[Installed OR (VersionNT >= 602 OR VersionNT64 >= 602) OR ((VersionNT = 601 OR VersionNT64 = 601) AND ServicePackLevel >= 1)]]>
+      <![CDATA[Installed OR (IGNOREPREREQUISITES = 1) OR (VersionNT >= 602 OR VersionNT64 >= 602) OR ((VersionNT = 601 OR VersionNT64 = 601) AND ServicePackLevel >= 1)]]>
     </Condition>
     <!-- .Net Framework Version Condition -->
     <Condition Message="!(loc.Install_NeedDotNetFrameworkVersion)">
-      <![CDATA[Installed OR WIX_IS_NETFRAMEWORK_40_OR_LATER_INSTALLED = 1]]>
+      <![CDATA[Installed OR (IGNOREPREREQUISITES = 1) OR WIX_IS_NETFRAMEWORK_40_OR_LATER_INSTALLED = 1]]>
     </Condition>
     <!-- If Win7, require RDP 8.0 update (KB2592687) -->
     <Condition Message="!(loc.Install_RDP80Requirement)">
-      <![CDATA[Installed OR (VersionNT >= 602 OR VersionNT64 >= 602) OR ((VersionNT = 601 OR VersionNT64 = 601) ]]>AND ($(var.RDP80KB) = 1 OR $(var.RDP81KB) = 1))
+      <![CDATA[Installed OR (IGNOREPREREQUISITES = 1) OR (VersionNT >= 602 OR VersionNT64 >= 602) OR ((VersionNT = 601 OR VersionNT64 = 601) ]]>AND ($(var.RDP80KB) = 1 OR $(var.RDP81KB) = 1))
     </Condition>
     
     


### PR DESCRIPTION
mrenoteNG ist not working after i installed the msi-file. The event protocol says:

`Name der fehlerhaften Anwendung: mRemoteNG.exe, Version: 1.74.6023.15437, Zeitstempel: 0x57728afa
Name des fehlerhaften Moduls: KERNELBASE.dll, Version: 6.2.10586.306, Zeitstempel: 0x571afb9a
Ausnahmecode: 0xe0434f4d
Fehleroffset: 0x000bdae8
ID des fehlerhaften Prozesses: 0x%9
Startzeit der fehlerhaften Anwendung: 0x%10
Pfad der fehlerhaften Anwendung: %11
Pfad des fehlerhaften Moduls: %12
Berichtskennung: %13
Vollständiger Name des fehlerhaften Pakets: %14
Anwendungs-ID, die relativ zum fehlerhaften Paket ist: %15`

do u need any more informatione?