### PR TITLE
Connection icon not updating until mouseover

### DIFF
--- a/mRemoteNGTests/Connection/ConnectionInfoTests.cs
+++ b/mRemoteNGTests/Connection/ConnectionInfoTests.cs
@@ -1,4 +1,5 @@
 ﻿using mRemoteNG.Connection;
+using mRemoteNG.Connection.Protocol.SSH;
 using mRemoteNG.Container;
 using NUnit.Framework;
 
@@ -52,6 +53,24 @@ namespace mRemoteNGTests.Connection
             var secondConnection = new ConnectionInfo {Domain = TestDomain};
             _connectionInfo.CopyFrom(secondConnection);
             Assert.That(_connectionInfo.Domain, Is.EqualTo(secondConnection.Domain));
+        }
+
+        [Test]
+        public void PropertyChangedEventRaisedWhenOpenConnectionsChanges()
+        {
+            var eventWasCalled = false;
+            _connectionInfo.PropertyChanged += (sender, args) => eventWasCalled = true;
+            _connectionInfo.OpenConnections.Add(new ProtocolSSH2());
+            Assert.That(eventWasCalled);
+        }
+
+        [Test]
+        public void PropertyChangedEventArgsAreCorrectWhenOpenConnectionsChanges()
+        {
+            var nameOfModifiedProperty = "";
+            _connectionInfo.PropertyChanged += (sender, args) => nameOfModifiedProperty = args.PropertyName;
+            _connectionInfo.OpenConnections.Add(new ProtocolSSH2());
+            Assert.That(nameOfModifiedProperty, Is.EqualTo("OpenConnections"));
         }
     }
 }

--- a/mRemoteNGTests/Connection/Protocol/ProtocolListTests.cs
+++ b/mRemoteNGTests/Connection/Protocol/ProtocolListTests.cs
@@ -98,6 +98,14 @@ namespace mRemoteNGTests.Connection.Protocol
         }
 
         [Test]
+        public void IndexerSafelyHandlesUnknownObjects()
+        {
+            var protArray = new[] { _protocol1, _protocol2, _protocol3 };
+            _protocolList.AddRange(protArray);
+            Assert.That(_protocolList["unacceptablevalue"], Is.EqualTo(null));
+        }
+
+        [Test]
         public void RemovingNonexistantObjectFromListDoesNothing()
         {
             Assert.DoesNotThrow(()=> _protocolList.Remove(_protocol1));

--- a/mRemoteNGTests/Connection/Protocol/ProtocolListTests.cs
+++ b/mRemoteNGTests/Connection/Protocol/ProtocolListTests.cs
@@ -1,0 +1,199 @@
+﻿using System.Collections;
+using System.Collections.Specialized;
+using mRemoteNG.Connection.Protocol;
+using mRemoteNG.Connection.Protocol.SSH;
+using mRemoteNG.Connection.Protocol.Telnet;
+using mRemoteNG.Connection.Protocol.VNC;
+using NUnit.Framework;
+
+
+namespace mRemoteNGTests.Connection.Protocol
+{
+    public class ProtocolListTests
+    {
+        private ProtocolList _protocolList;
+        private ProtocolBase _protocol1;
+        private ProtocolBase _protocol2;
+        private ProtocolBase _protocol3;
+
+
+        [SetUp]
+        public void Setup()
+        {
+            _protocolList = new ProtocolList();
+            _protocol1 = new ProtocolTelnet();
+            _protocol2 = new ProtocolSSH2();
+            _protocol3 = new ProtocolVNC();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            _protocolList = null;
+            _protocol1 = null;
+            _protocol2 = null;
+            _protocol3 = null;
+        }
+
+        [Test]
+        public void EmptyWhenInitialized()
+        {
+            Assert.That(_protocolList.Count == 0);
+        }
+
+        [Test]
+        public void AddAddsObjectToList()
+        {
+            _protocolList.Add(_protocol1);
+            Assert.That(_protocolList[0] == _protocol1);
+        }
+
+        [Test]
+        public void AddRangeAddsAllObjects()
+        {
+            var protArray = new[] {_protocol1, _protocol2, _protocol3};
+            _protocolList.AddRange(protArray);
+            Assert.That(_protocolList, Is.EquivalentTo(protArray));
+        }
+
+        [Test]
+        public void CountUpdatesToReflectCurrentList()
+        {
+            var protArray = new[] { _protocol1, _protocol2, _protocol3 };
+            _protocolList.AddRange(protArray);
+            Assert.That(_protocolList.Count == protArray.Length);
+        }
+
+        [Test]
+        public void RemoveRemovesObjectFromList()
+        {
+            _protocolList.Add(_protocol1);
+            _protocolList.Remove(_protocol1);
+            Assert.That(_protocolList.Count == 0);
+        }
+
+        [Test]
+        public void ClearResetsList()
+        {
+            var protArray = new[] { _protocol1, _protocol2, _protocol3 };
+            _protocolList.AddRange(protArray);
+            _protocolList.Clear();
+            Assert.That(_protocolList.Count == 0);
+        }
+
+        [Test]
+        public void IntIndexerReturnsCorrectObject()
+        {
+            var protArray = new[] { _protocol1, _protocol2, _protocol3 };
+            _protocolList.AddRange(protArray);
+            Assert.That(_protocolList[1], Is.EqualTo(protArray[1]));
+        }
+
+        [Test]
+        public void ObjectIndexerReturnsCorrectObject()
+        {
+            var protArray = new[] { _protocol1, _protocol2, _protocol3 };
+            _protocolList.AddRange(protArray);
+            Assert.That(_protocolList[_protocol3], Is.EqualTo(_protocol3));
+        }
+
+        [Test]
+        public void RemovingNonexistantObjectFromListDoesNothing()
+        {
+            Assert.DoesNotThrow(()=> _protocolList.Remove(_protocol1));
+        }
+
+        [Test]
+        public void AddRaisesCollectionChangedEvent()
+        {
+            var eventWasCalled = false;
+            _protocolList.CollectionChanged += (sender, args) => eventWasCalled = true;
+            _protocolList.Add(_protocol1);
+            Assert.That(eventWasCalled);
+        }
+
+        [Test]
+        public void AddCollectionChangedEventContainsAddedObject()
+        {
+            IList nodeListFromEvent = new ArrayList();
+            _protocolList.CollectionChanged += (sender, args) => nodeListFromEvent = args.NewItems;
+            _protocolList.Add(_protocol1);
+            Assert.That(nodeListFromEvent, Is.EquivalentTo(new[] {_protocol1}));
+        }
+
+        [Test]
+        public void AddRangeCollectionChangedEventContainsAddedObjects()
+        {
+            var protArray = new[] { _protocol1, _protocol2, _protocol3 };
+            IList nodeListFromEvent = new ArrayList();
+            _protocolList.CollectionChanged += (sender, args) => nodeListFromEvent = args.NewItems;
+            _protocolList.AddRange(protArray);
+            Assert.That(nodeListFromEvent, Is.EquivalentTo(protArray));
+        }
+
+        [Test]
+        public void RemoveCollectionChangedEventContainsRemovedObject()
+        {
+            IList nodeListFromEvent = new ArrayList();
+            _protocolList.Add(_protocol1);
+            _protocolList.CollectionChanged += (sender, args) => nodeListFromEvent = args.OldItems;
+            _protocolList.Remove(_protocol1);
+            Assert.That(nodeListFromEvent, Is.EquivalentTo(new[] { _protocol1 }));
+        }
+
+        [Test]
+        public void AttemptingToRemoveNonexistantObjectDoesNotRaiseCollectionChangedEvent()
+        {
+            var eventWasCalled = false;
+            _protocolList.CollectionChanged += (sender, args) => eventWasCalled = true;
+            _protocolList.Remove(_protocol1);
+            Assert.That(eventWasCalled == false);
+        }
+
+        [Test]
+        public void ClearRaisesCollectionChangedEventWithCorrectAction()
+        {
+            var eventWasCalled = false;
+            _protocolList.CollectionChanged += (sender, args) => eventWasCalled = true;
+            _protocolList.Clear();
+            Assert.That(eventWasCalled);
+        }
+
+        [Test]
+        public void AddCollectionChangedEventHasCorrectAction()
+        {
+            NotifyCollectionChangedAction collectionChangedAction = NotifyCollectionChangedAction.Move;
+            _protocolList.CollectionChanged += (sender, args) => collectionChangedAction = args.Action;
+            _protocolList.Add(_protocol1);
+            Assert.That(collectionChangedAction == NotifyCollectionChangedAction.Add);
+        }
+
+        [Test]
+        public void AddRangeCollectionChangedEventHasCorrectAction()
+        {
+            NotifyCollectionChangedAction collectionChangedAction = NotifyCollectionChangedAction.Move;
+            _protocolList.CollectionChanged += (sender, args) => collectionChangedAction = args.Action;
+            _protocolList.AddRange(new []{_protocol1});
+            Assert.That(collectionChangedAction == NotifyCollectionChangedAction.Add);
+        }
+
+        [Test]
+        public void RemoveCollectionChangedEventHasCorrectAction()
+        {
+            NotifyCollectionChangedAction collectionChangedAction = NotifyCollectionChangedAction.Move;
+            _protocolList.Add(_protocol1);
+            _protocolList.CollectionChanged += (sender, args) => collectionChangedAction = args.Action;
+            _protocolList.Remove(_protocol1);
+            Assert.That(collectionChangedAction == NotifyCollectionChangedAction.Remove);
+        }
+
+        [Test]
+        public void ClearCollectionChangedEventHasCorrectAction()
+        {
+            NotifyCollectionChangedAction collectionChangedAction = NotifyCollectionChangedAction.Move;
+            _protocolList.CollectionChanged += (sender, args) => collectionChangedAction = args.Action;
+            _protocolList.Clear();
+            Assert.That(collectionChangedAction == NotifyCollectionChangedAction.Reset);
+        }
+    }
+}

--- a/mRemoteNGTests/Connection/Protocol/ProtocolListTests.cs
+++ b/mRemoteNGTests/Connection/Protocol/ProtocolListTests.cs
@@ -183,7 +183,7 @@ namespace mRemoteNGTests.Connection.Protocol
             NotifyCollectionChangedAction collectionChangedAction = NotifyCollectionChangedAction.Move;
             _protocolList.CollectionChanged += (sender, args) => collectionChangedAction = args.Action;
             _protocolList.Add(_protocol1);
-            Assert.That(collectionChangedAction == NotifyCollectionChangedAction.Add);
+            Assert.That(collectionChangedAction, Is.EqualTo(NotifyCollectionChangedAction.Add));
         }
 
         [Test]
@@ -192,7 +192,7 @@ namespace mRemoteNGTests.Connection.Protocol
             NotifyCollectionChangedAction collectionChangedAction = NotifyCollectionChangedAction.Move;
             _protocolList.CollectionChanged += (sender, args) => collectionChangedAction = args.Action;
             _protocolList.AddRange(new []{_protocol1});
-            Assert.That(collectionChangedAction == NotifyCollectionChangedAction.Add);
+            Assert.That(collectionChangedAction, Is.EqualTo(NotifyCollectionChangedAction.Add));
         }
 
         [Test]
@@ -202,7 +202,7 @@ namespace mRemoteNGTests.Connection.Protocol
             _protocolList.Add(_protocol1);
             _protocolList.CollectionChanged += (sender, args) => collectionChangedAction = args.Action;
             _protocolList.Remove(_protocol1);
-            Assert.That(collectionChangedAction == NotifyCollectionChangedAction.Remove);
+            Assert.That(collectionChangedAction, Is.EqualTo(NotifyCollectionChangedAction.Remove));
         }
 
         [Test]

--- a/mRemoteNGTests/Connection/Protocol/ProtocolListTests.cs
+++ b/mRemoteNGTests/Connection/Protocol/ProtocolListTests.cs
@@ -159,12 +159,22 @@ namespace mRemoteNGTests.Connection.Protocol
         }
 
         [Test]
-        public void ClearRaisesCollectionChangedEventWithCorrectAction()
+        public void ClearRaisesCollectionChangedEvent()
+        {
+            var eventWasCalled = false;
+            _protocolList.Add(_protocol1);
+            _protocolList.CollectionChanged += (sender, args) => eventWasCalled = true;
+            _protocolList.Clear();
+            Assert.That(eventWasCalled);
+        }
+
+        [Test]
+        public void ClearDoesntRaiseCollectionChangedEventWhenNoObjectsRemoved()
         {
             var eventWasCalled = false;
             _protocolList.CollectionChanged += (sender, args) => eventWasCalled = true;
             _protocolList.Clear();
-            Assert.That(eventWasCalled);
+            Assert.That(eventWasCalled == false);
         }
 
         [Test]
@@ -199,9 +209,10 @@ namespace mRemoteNGTests.Connection.Protocol
         public void ClearCollectionChangedEventHasCorrectAction()
         {
             NotifyCollectionChangedAction collectionChangedAction = NotifyCollectionChangedAction.Move;
+            _protocolList.Add(_protocol1);
             _protocolList.CollectionChanged += (sender, args) => collectionChangedAction = args.Action;
             _protocolList.Clear();
-            Assert.That(collectionChangedAction == NotifyCollectionChangedAction.Reset);
+            Assert.That(collectionChangedAction, Is.EqualTo(NotifyCollectionChangedAction.Reset));
         }
     }
 }

--- a/mRemoteNGTests/mRemoteNGTests.csproj
+++ b/mRemoteNGTests/mRemoteNGTests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Config\Serializers\RemoteDesktopConnectionManagerDeserializerTests.cs" />
     <Compile Include="Connection\AbstractConnectionInfoDataTests.cs" />
     <Compile Include="Connection\ConnectionInfoComparerTests.cs" />
+    <Compile Include="Connection\Protocol\ProtocolListTests.cs" />
     <Compile Include="Tools\ExternalToolsArgumentParserTests.cs" />
     <Compile Include="Tree\ConnectionTreeDragAndDropHandlerTests.cs" />
     <Compile Include="Tree\ConnectionTreeModelTests.cs" />

--- a/mRemoteV1/Connection/ConnectionInfo.cs
+++ b/mRemoteV1/Connection/ConnectionInfo.cs
@@ -30,7 +30,7 @@ namespace mRemoteNG.Connection
         public ConnectionInfoInheritance Inheritance { get; set; }
 
 	    [Browsable(false)]
-        public ProtocolList OpenConnections { get; set; }
+	    public ProtocolList OpenConnections { get; protected set; }
 
 	    [Browsable(false)]
         public bool IsContainer { get; set; }
@@ -83,14 +83,13 @@ namespace mRemoteNG.Connection
             newConnectionInfo.CopyFrom(this);
 			newConnectionInfo.ConstantID = MiscTools.CreateConstantID();
             newConnectionInfo.SetParent(Parent);
-			newConnectionInfo.OpenConnections = new ProtocolList();
 		    newConnectionInfo.Inheritance = Inheritance.Clone();
 			return newConnectionInfo;
 		}
 
-	    public void CopyFrom(ConnectionInfo sourceConnectionInfo)
+	    public void CopyFrom(AbstractConnectionInfoData sourceConnectionInfo)
 	    {
-	        var properties = typeof(ConnectionInfo).GetProperties();
+	        var properties = typeof(AbstractConnectionInfoData).GetProperties();
 	        foreach (var property in properties)
 	        {
 	            var remotePropertyValue = property.GetValue(sourceConnectionInfo, null);
@@ -319,9 +318,15 @@ namespace mRemoteNG.Connection
         private void SetNonBrowsablePropertiesDefaults()
         {
             Inheritance = new ConnectionInfoInheritance(this);
-            OpenConnections = new ProtocolList();
+            SetNewOpenConnectionList();
             PositionID = 0;
         }
+
+	    protected void SetNewOpenConnectionList()
+	    {
+	        OpenConnections = new ProtocolList();
+	        OpenConnections.CollectionChanged += (sender, args) => RaisePropertyChangedEvent(this, new PropertyChangedEventArgs("OpenConnections"));
+	    }
         #endregion
-	}
+    }
 }

--- a/mRemoteV1/Connection/Protocol/ProtocolList.cs
+++ b/mRemoteV1/Connection/Protocol/ProtocolList.cs
@@ -6,37 +6,28 @@ namespace mRemoteNG.Connection.Protocol
 {
 	public class ProtocolList : CollectionBase
 	{
-        #region Public Properties
-        public ProtocolBase this[object Index]
+        public ProtocolBase this[object index]
 		{
 			get
 			{
-				if (Index is ProtocolBase)
-                    return (ProtocolBase)Index;
-				else
-					return ((ProtocolBase) (List[Convert.ToInt32(Index)]));
+			    var @base = index as ProtocolBase;
+			    if (@base != null)
+                    return @base;
+			    return ((ProtocolBase) (List[Convert.ToInt32(index)]));
 			}
 		}
 				
-        public new int Count
-		{
-			get
-			{
-				return List.Count;
-			}
-		}
-        #endregion
+        public new int Count => List.Count;
+
 				
-        #region Public Methods
-		public ProtocolBase Add(ProtocolBase cProt)
+		public void Add(ProtocolBase cProt)
 		{
-			this.List.Add(cProt);
-			return cProt;
+			List.Add(cProt);
 		}
 				
 		public void AddRange(ProtocolBase[] cProt)
 		{
-			foreach (ProtocolBase cP in cProt)
+			foreach (var cP in cProt)
 			{
 				List.Add(cP);
 			}
@@ -46,7 +37,7 @@ namespace mRemoteNG.Connection.Protocol
 		{
 			try
 			{
-				this.List.Remove(cProt);
+				List.Remove(cProt);
 			}
 			catch (Exception)
 			{
@@ -55,8 +46,7 @@ namespace mRemoteNG.Connection.Protocol
 				
 		public new void Clear()
 		{
-			this.List.Clear();
+			List.Clear();
 		}
-        #endregion
 	}
 }

--- a/mRemoteV1/Connection/Protocol/ProtocolList.cs
+++ b/mRemoteV1/Connection/Protocol/ProtocolList.cs
@@ -14,7 +14,9 @@ namespace mRemoteNG.Connection.Protocol
 			    var @base = index as ProtocolBase;
 			    if (@base != null)
                     return @base;
-			    return (ProtocolBase) List[Convert.ToInt32(index)];
+			    if (index is int)
+			        return (ProtocolBase) List[Convert.ToInt32(index)];
+			    return null;
 			}
 		}
 				

--- a/mRemoteV1/Connection/Protocol/ProtocolList.cs
+++ b/mRemoteV1/Connection/Protocol/ProtocolList.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections;
+using System.Collections.Specialized;
 
 
 namespace mRemoteNG.Connection.Protocol
 {
-	public class ProtocolList : CollectionBase
+	public class ProtocolList : CollectionBase, INotifyCollectionChanged
 	{
         public ProtocolBase this[object index]
 		{
@@ -13,7 +14,7 @@ namespace mRemoteNG.Connection.Protocol
 			    var @base = index as ProtocolBase;
 			    if (@base != null)
                     return @base;
-			    return ((ProtocolBase) (List[Convert.ToInt32(index)]));
+			    return (ProtocolBase) List[Convert.ToInt32(index)];
 			}
 		}
 				
@@ -23,7 +24,8 @@ namespace mRemoteNG.Connection.Protocol
 		public void Add(ProtocolBase cProt)
 		{
 			List.Add(cProt);
-		}
+            RaiseCollectionChangedEvent(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, cProt));
+        }
 				
 		public void AddRange(ProtocolBase[] cProt)
 		{
@@ -31,6 +33,7 @@ namespace mRemoteNG.Connection.Protocol
 			{
 				List.Add(cP);
 			}
+            RaiseCollectionChangedEvent(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, cProt));
 		}
 				
 		public void Remove(ProtocolBase cProt)
@@ -38,7 +41,8 @@ namespace mRemoteNG.Connection.Protocol
 			try
 			{
 				List.Remove(cProt);
-			}
+                RaiseCollectionChangedEvent(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, cProt));
+            }
 			catch (Exception)
 			{
 			}
@@ -47,6 +51,13 @@ namespace mRemoteNG.Connection.Protocol
 		public new void Clear()
 		{
 			List.Clear();
+            RaiseCollectionChangedEvent(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 		}
-	}
+
+	    public event NotifyCollectionChangedEventHandler CollectionChanged;
+	    private void RaiseCollectionChangedEvent(object sender, NotifyCollectionChangedEventArgs args)
+	    {
+	        CollectionChanged?.Invoke(sender, args);
+	    }
+    }
 }

--- a/mRemoteV1/Connection/Protocol/ProtocolList.cs
+++ b/mRemoteV1/Connection/Protocol/ProtocolList.cs
@@ -52,6 +52,7 @@ namespace mRemoteNG.Connection.Protocol
 				
 		public new void Clear()
 		{
+            if (Count == 0) return;
 			List.Clear();
             RaiseCollectionChangedEvent(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 		}

--- a/mRemoteV1/UI/Window/ConnectionTreeWindow.cs
+++ b/mRemoteV1/UI/Window/ConnectionTreeWindow.cs
@@ -240,7 +240,8 @@ namespace mRemoteNG.UI.Window
         private void HandleCollectionPropertyChanged(object sender, PropertyChangedEventArgs propertyChangedEventArgs)
         {
             //TODO for some reason property changed events are getting triggered twice for each changed property. should be just once. cant find source of duplication
-            if (propertyChangedEventArgs.PropertyName != "Name") return;
+            var property = propertyChangedEventArgs.PropertyName;
+            if (property != "Name" && property != "OpenConnections") return;
             var senderAsConnectionInfo = sender as ConnectionInfo;
             if (senderAsConnectionInfo != null)
                 RefreshTreeObject(senderAsConnectionInfo);


### PR DESCRIPTION
Implemented INotifyCollectionChanged in ProtocolList and hooked those events up to the ConnectionInfo.PropertyChanged event. The TreeListview will refresh the tree node when it receives a a notice that the OpenConnections property has changed (its list contents have changed, to be specific.)

This resolves #141 