### PR TITLE
Fix BorderPen color when focused

### DIFF
--- a/mRemoteV1/UI/Controls/ListView.cs
+++ b/mRemoteV1/UI/Controls/ListView.cs
@@ -87,8 +87,13 @@ namespace mRemoteNG.UI.Controls
         private void BuildBorderPen()
         {
             if (Focused)
+            {
                 borderPen = new Pen(HighlightBorderColor);
-            borderPen = new Pen(InactiveHighlightBorderColor);
+            }
+            else
+            {
+                borderPen = new Pen(InactiveHighlightBorderColor);
+            }
         }
 
         private void BuildBrushes(DrawListViewItemEventArgs e)


### PR DESCRIPTION
Previously inactive color was always set, because of missing "else" keyword.