### PR TITLE
RDP Optional Minutes to Idle Timeout

### DIFF
--- a/mRemoteV1/Config/Serializers/DataTableDeserializer.cs
+++ b/mRemoteV1/Config/Serializers/DataTableDeserializer.cs
@@ -84,6 +84,7 @@ namespace mRemoteNG.Config.Serializers
             connectionInfo.RenderingEngine = (HTTPBase.RenderingEngine)Enum.Parse(typeof(HTTPBase.RenderingEngine), (string)dataRow["RenderingEngine"]);
             connectionInfo.ICAEncryptionStrength = (ProtocolICA.EncryptionStrength)Enum.Parse(typeof(ProtocolICA.EncryptionStrength), (string)dataRow["ICAEncryptionStrength"]);
             connectionInfo.RDPAuthenticationLevel = (ProtocolRDP.AuthenticationLevel)Enum.Parse(typeof(ProtocolRDP.AuthenticationLevel), (string)dataRow["RDPAuthenticationLevel"]);
+            connectionInfo.RDPMinutesToIdleTimeout = (int)dataRow["RDPMinutesToIdleTimeout"];
             connectionInfo.LoadBalanceInfo = (string)dataRow["LoadBalanceInfo"];
             connectionInfo.Colors = (ProtocolRDP.RDPColors)Enum.Parse(typeof(ProtocolRDP.RDPColors) ,(string)dataRow["Colors"]);
             connectionInfo.Resolution = (ProtocolRDP.RDPResolutions)Enum.Parse(typeof(ProtocolRDP.RDPResolutions), (string)dataRow["Resolution"]);
@@ -153,6 +154,7 @@ namespace mRemoteNG.Config.Serializers
             connectionInfo.Inheritance.Username = (bool)dataRow["InheritUsername"];
             connectionInfo.Inheritance.ICAEncryptionStrength = (bool)dataRow["InheritICAEncryptionStrength"];
             connectionInfo.Inheritance.RDPAuthenticationLevel = (bool)dataRow["InheritRDPAuthenticationLevel"];
+            connectionInfo.Inheritance.RDPMinutesToIdleTimeout = (bool)dataRow["RDPMinutesToIdleTimeout"];
             connectionInfo.Inheritance.LoadBalanceInfo = (bool)dataRow["InheritLoadBalanceInfo"];
             connectionInfo.Inheritance.PreExtApp = (bool)dataRow["InheritPreExtApp"];
             connectionInfo.Inheritance.PostExtApp = (bool)dataRow["InheritPostExtApp"];

--- a/mRemoteV1/Config/Serializers/DataTableSerializer.cs
+++ b/mRemoteV1/Config/Serializers/DataTableSerializer.cs
@@ -65,6 +65,7 @@ namespace mRemoteNG.Config.Serializers
             _dataTable.Columns.Add("RenderingEngine", typeof(string));
             _dataTable.Columns.Add("ICAEncryptionStrength", typeof(string));
             _dataTable.Columns.Add("RDPAuthenticationLevel", typeof(string));
+            _dataTable.Columns.Add("RDPMinutesToIdleTimeout", typeof(int));
             _dataTable.Columns.Add("Colors", typeof(string));
             _dataTable.Columns.Add("Resolution", typeof(string));
             _dataTable.Columns.Add("DisplayWallpaper", typeof(bool));
@@ -128,6 +129,7 @@ namespace mRemoteNG.Config.Serializers
             _dataTable.Columns.Add("InheritRenderingEngine", typeof(bool));
             _dataTable.Columns.Add("InheritICAEncryptionStrength", typeof(bool));
             _dataTable.Columns.Add("InheritRDPAuthenticationLevel", typeof(bool));
+            _dataTable.Columns.Add("InheritRDPMinutesToIdleTimeout", typeof(bool));
             _dataTable.Columns.Add("InheritUsername", typeof(bool));
             _dataTable.Columns.Add("InheritPreExtApp", typeof(bool));
             _dataTable.Columns.Add("InheritPostExtApp", typeof(bool));
@@ -200,6 +202,7 @@ namespace mRemoteNG.Config.Serializers
             dataRow["RenderingEngine"] = connectionInfo.RenderingEngine;
             dataRow["ICAEncryptionStrength"] = connectionInfo.ICAEncryptionStrength;
             dataRow["RDPAuthenticationLevel"] = connectionInfo.RDPAuthenticationLevel;
+            //dataRow["RDPMinutesToIdleTimeout"] = connectionInfo.RDPMinutesToIdleTimeout;
             dataRow["LoadBalanceInfo"] = connectionInfo.LoadBalanceInfo;
             dataRow["Colors"] = connectionInfo.Colors;
             dataRow["Resolution"] = connectionInfo.Resolution;
@@ -270,6 +273,7 @@ namespace mRemoteNG.Config.Serializers
                 dataRow["InheritUsername"] = connectionInfo.Inheritance.Username;
                 dataRow["InheritICAEncryptionStrength"] = connectionInfo.Inheritance.ICAEncryptionStrength;
                 dataRow["InheritRDPAuthenticationLevel"] = connectionInfo.Inheritance.RDPAuthenticationLevel;
+                //dataRow["InheritRDPMinutesToIdleTimeout"] = connectionInfo.Inheritance.RDPMinutesToIdleTimeout;
                 dataRow["InheritLoadBalanceInfo"] = connectionInfo.Inheritance.LoadBalanceInfo;
                 dataRow["InheritPreExtApp"] = connectionInfo.Inheritance.PreExtApp;
                 dataRow["InheritPostExtApp"] = connectionInfo.Inheritance.PostExtApp;
@@ -325,6 +329,7 @@ namespace mRemoteNG.Config.Serializers
                 dataRow["InheritUsername"] = false;
                 dataRow["InheritICAEncryptionStrength"] = false;
                 dataRow["InheritRDPAuthenticationLevel"] = false;
+                //dataRow["InheritRDPMinutesToIdleTimeout"] = false;
                 dataRow["InheritLoadBalanceInfo"] = false;
                 dataRow["InheritPreExtApp"] = false;
                 dataRow["InheritPostExtApp"] = false;

--- a/mRemoteV1/Config/Serializers/XmlConnectionNodeSerializer.cs
+++ b/mRemoteV1/Config/Serializers/XmlConnectionNodeSerializer.cs
@@ -67,6 +67,7 @@ namespace mRemoteNG.Config.Serializers
             element.Add(new XAttribute("RenderingEngine", connectionInfo.RenderingEngine));
             element.Add(new XAttribute("ICAEncryptionStrength", connectionInfo.ICAEncryptionStrength));
             element.Add(new XAttribute("RDPAuthenticationLevel", connectionInfo.RDPAuthenticationLevel));
+            element.Add(new XAttribute("RDPMinutesToIdleTimeout", connectionInfo.RDPMinutesToIdleTimeout));
             element.Add(new XAttribute("LoadBalanceInfo", connectionInfo.LoadBalanceInfo));
             element.Add(new XAttribute("Colors", connectionInfo.Colors));
             element.Add(new XAttribute("Resolution", connectionInfo.Resolution));
@@ -159,6 +160,7 @@ namespace mRemoteNG.Config.Serializers
                 element.Add(new XAttribute("InheritUsername", connectionInfo.Inheritance.Username.ToString()));
                 element.Add(new XAttribute("InheritICAEncryptionStrength", connectionInfo.Inheritance.ICAEncryptionStrength.ToString()));
                 element.Add(new XAttribute("InheritRDPAuthenticationLevel", connectionInfo.Inheritance.RDPAuthenticationLevel.ToString()));
+                element.Add(new XAttribute("InheritRDPMinutesToIdleTimeout", connectionInfo.Inheritance.RDPMinutesToIdleTimeout.ToString()));
                 element.Add(new XAttribute("InheritLoadBalanceInfo", connectionInfo.Inheritance.LoadBalanceInfo.ToString()));
                 element.Add(new XAttribute("InheritPreExtApp", connectionInfo.Inheritance.PreExtApp.ToString()));
                 element.Add(new XAttribute("InheritPostExtApp", connectionInfo.Inheritance.PostExtApp.ToString()));
@@ -214,6 +216,7 @@ namespace mRemoteNG.Config.Serializers
                 element.Add(new XAttribute("InheritUsername", false.ToString()));
                 element.Add(new XAttribute("InheritICAEncryptionStrength", false.ToString()));
                 element.Add(new XAttribute("InheritRDPAuthenticationLevel", false.ToString()));
+                element.Add(new XAttribute("InheritRDPMinutesToIdleTimeout", false.ToString()));
                 element.Add(new XAttribute("InheritLoadBalanceInfo", false.ToString()));
                 element.Add(new XAttribute("InheritPreExtApp", false.ToString()));
                 element.Add(new XAttribute("InheritPostExtApp", false.ToString()));

--- a/mRemoteV1/Config/Serializers/XmlConnectionsDeserializer.cs
+++ b/mRemoteV1/Config/Serializers/XmlConnectionsDeserializer.cs
@@ -487,8 +487,8 @@ namespace mRemoteNG.Config.Serializers
                 {
                     connectionInfo.SoundQuality = (ProtocolRDP.RDPSoundQuality)Tools.MiscTools.StringToEnum(typeof(ProtocolRDP.RDPSoundQuality), Convert.ToString(xmlnode.Attributes["SoundQuality"].Value));
                     connectionInfo.Inheritance.SoundQuality = bool.Parse(xmlnode.Attributes["InheritSoundQuality"].Value);
-                    connectionInfo.RDPMinutesToIdleTimeout = Convert.ToInt32(xmlnode.Attributes["RDPMinutesToIdleTimeout"].Value);
-                    connectionInfo.Inheritance.RDPMinutesToIdleTimeout = bool.Parse(xmlnode.Attributes["InheritRDPMinutesToIdleTimeout"].Value);
+                    connectionInfo.RDPMinutesToIdleTimeout = Convert.ToInt32(xmlnode.Attributes["RDPMinutesToIdleTimeout"].Value ?? "0");
+                    connectionInfo.Inheritance.RDPMinutesToIdleTimeout = bool.Parse(xmlnode.Attributes["InheritRDPMinutesToIdleTimeout"].Value ?? "False");
                 }
             }
             catch (Exception ex)

--- a/mRemoteV1/Config/Serializers/XmlConnectionsDeserializer.cs
+++ b/mRemoteV1/Config/Serializers/XmlConnectionsDeserializer.cs
@@ -487,8 +487,8 @@ namespace mRemoteNG.Config.Serializers
                 {
                     connectionInfo.SoundQuality = (ProtocolRDP.RDPSoundQuality)Tools.MiscTools.StringToEnum(typeof(ProtocolRDP.RDPSoundQuality), Convert.ToString(xmlnode.Attributes["SoundQuality"].Value));
                     connectionInfo.Inheritance.SoundQuality = bool.Parse(xmlnode.Attributes["InheritSoundQuality"].Value);
-                    connectionInfo.RDPMinutesToIdleTimeout = Convert.ToInt32(xmlnode.Attributes["RDPMinutesToIdleTimeout"].Value ?? "0");
-                    connectionInfo.Inheritance.RDPMinutesToIdleTimeout = bool.Parse(xmlnode.Attributes["InheritRDPMinutesToIdleTimeout"].Value ?? "False");
+                    connectionInfo.RDPMinutesToIdleTimeout = Convert.ToInt32(xmlnode.Attributes["RDPMinutesToIdleTimeout"]?.Value ?? "0");
+                    connectionInfo.Inheritance.RDPMinutesToIdleTimeout = bool.Parse(xmlnode.Attributes["InheritRDPMinutesToIdleTimeout"]?.Value ?? "False");
                 }
             }
             catch (Exception ex)

--- a/mRemoteV1/Config/Serializers/XmlConnectionsDeserializer.cs
+++ b/mRemoteV1/Config/Serializers/XmlConnectionsDeserializer.cs
@@ -487,6 +487,8 @@ namespace mRemoteNG.Config.Serializers
                 {
                     connectionInfo.SoundQuality = (ProtocolRDP.RDPSoundQuality)Tools.MiscTools.StringToEnum(typeof(ProtocolRDP.RDPSoundQuality), Convert.ToString(xmlnode.Attributes["SoundQuality"].Value));
                     connectionInfo.Inheritance.SoundQuality = bool.Parse(xmlnode.Attributes["InheritSoundQuality"].Value);
+                    connectionInfo.RDPMinutesToIdleTimeout = Convert.ToInt32(xmlnode.Attributes["RDPMinutesToIdleTimeout"].Value);
+                    connectionInfo.Inheritance.RDPMinutesToIdleTimeout = bool.Parse(xmlnode.Attributes["InheritRDPMinutesToIdleTimeout"].Value);
                 }
             }
             catch (Exception ex)

--- a/mRemoteV1/Connection/AbstractConnectionInfoData.cs
+++ b/mRemoteV1/Connection/AbstractConnectionInfoData.cs
@@ -30,6 +30,7 @@ namespace mRemoteNG.Connection
         private ProtocolICA.EncryptionStrength _icaEncryption;
         private bool _useConsoleSession;
         private ProtocolRDP.AuthenticationLevel _rdpAuthenticationLevel;
+        private int _rdpMinutesToIdleTimeout;
         private string _loadBalanceInfo;
         private HTTPBase.RenderingEngine _renderingEngine;
         private bool _useCredSsp;
@@ -223,6 +224,15 @@ namespace mRemoteNG.Connection
         {
             get { return GetPropertyValue("RDPAuthenticationLevel", _rdpAuthenticationLevel); }
             set { SetField(ref _rdpAuthenticationLevel, value, "RDPAuthenticationLevel"); }
+        }
+
+        [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 3),
+            LocalizedAttributes.LocalizedDisplayName("strPropertyNameMinutesToIdleTimeout"),
+            LocalizedAttributes.LocalizedDescription("strPropertyDescriptionMinutesToIdleTimeout")]
+        public virtual int RDPMinutesToIdleTimeout
+        {
+            get { return GetPropertyValue("RDPMinutesToIdleTimeout", _rdpMinutesToIdleTimeout); }
+            set { SetField(ref _rdpMinutesToIdleTimeout, value, "RDPMinutesToIdleTimeout"); }
         }
 
         [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 3),

--- a/mRemoteV1/Connection/AbstractConnectionInfoData.cs
+++ b/mRemoteV1/Connection/AbstractConnectionInfoData.cs
@@ -227,8 +227,8 @@ namespace mRemoteNG.Connection
         }
 
         [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 3),
-            LocalizedAttributes.LocalizedDisplayName("strPropertyNameMinutesToIdleTimeout"),
-            LocalizedAttributes.LocalizedDescription("strPropertyDescriptionMinutesToIdleTimeout")]
+            LocalizedAttributes.LocalizedDisplayName("strPropertyNameRDPMinutesToIdleTimeout"),
+            LocalizedAttributes.LocalizedDescription("strPropertyDescriptionRDPMinutesToIdleTimeout")]
         public virtual int RDPMinutesToIdleTimeout
         {
             get { return GetPropertyValue("RDPMinutesToIdleTimeout", _rdpMinutesToIdleTimeout); }

--- a/mRemoteV1/Connection/ConnectionInfo.cs
+++ b/mRemoteV1/Connection/ConnectionInfo.cs
@@ -248,6 +248,7 @@ namespace mRemoteNG.Connection
             ICAEncryptionStrength = (ProtocolICA.EncryptionStrength) Enum.Parse(typeof(ProtocolICA.EncryptionStrength), Settings.Default.ConDefaultICAEncryptionStrength);
             UseConsoleSession = Settings.Default.ConDefaultUseConsoleSession;
             RDPAuthenticationLevel = (ProtocolRDP.AuthenticationLevel) Enum.Parse(typeof(ProtocolRDP.AuthenticationLevel), Settings.Default.ConDefaultRDPAuthenticationLevel);
+            RDPMinutesToIdleTimeout = Settings.Default.ConDefaultRDPMinutesToIdleTimeout;
             LoadBalanceInfo = Settings.Default.ConDefaultLoadBalanceInfo;
             RenderingEngine = (HTTPBase.RenderingEngine) Enum.Parse(typeof(HTTPBase.RenderingEngine), Settings.Default.ConDefaultRenderingEngine);
             UseCredSsp = Settings.Default.ConDefaultUseCredSsp;

--- a/mRemoteV1/Connection/ConnectionInfoInheritance.cs
+++ b/mRemoteV1/Connection/ConnectionInfoInheritance.cs
@@ -83,9 +83,14 @@ namespace mRemoteNG.Connection
 		[LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 4), 
 		LocalizedAttributes.LocalizedDisplayNameInheritAttribute("strPropertyNameAuthenticationLevel"), 
 		LocalizedAttributes.LocalizedDescriptionInheritAttribute("strPropertyDescriptionAuthenticationLevel"), 
-		TypeConverter(typeof(MiscTools.YesNoTypeConverter))]public bool RDPAuthenticationLevel {get; set;}
-				
-		[LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 4), 
+		TypeConverter(typeof(MiscTools.YesNoTypeConverter))]public bool RDPAuthenticationLevel {get; set; }
+
+        [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 4),
+        LocalizedAttributes.LocalizedDisplayNameInheritAttribute("strPropertyName"),
+        LocalizedAttributes.LocalizedDescriptionInheritAttribute("strPropertyDescription"),
+        TypeConverter(typeof(MiscTools.YesNoTypeConverter))]public bool RDPMinutesToIdleTimeout { get; set; }
+
+        [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 4), 
 		LocalizedAttributes.LocalizedDisplayNameInheritAttribute("strPropertyNameLoadBalanceInfo"), 
 		LocalizedAttributes.LocalizedDescriptionInheritAttribute("strPropertyDescriptionLoadBalanceInfo"), 
 		TypeConverter(typeof(MiscTools.YesNoTypeConverter))]public bool LoadBalanceInfo {get; set;}

--- a/mRemoteV1/Connection/ConnectionInfoInheritance.cs
+++ b/mRemoteV1/Connection/ConnectionInfoInheritance.cs
@@ -86,8 +86,8 @@ namespace mRemoteNG.Connection
 		TypeConverter(typeof(MiscTools.YesNoTypeConverter))]public bool RDPAuthenticationLevel {get; set; }
 
         [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 4),
-        LocalizedAttributes.LocalizedDisplayNameInheritAttribute("strPropertyName"),
-        LocalizedAttributes.LocalizedDescriptionInheritAttribute("strPropertyDescription"),
+        LocalizedAttributes.LocalizedDisplayNameInheritAttribute("strPropertyNameRDPMinutesToIdleTimeout"),
+        LocalizedAttributes.LocalizedDescriptionInheritAttribute("strPropertyDescriptionRDPMinutesToIdleTimeout"),
         TypeConverter(typeof(MiscTools.YesNoTypeConverter))]public bool RDPMinutesToIdleTimeout { get; set; }
 
         [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 4), 

--- a/mRemoteV1/Properties/Settings.Designer.cs
+++ b/mRemoteV1/Properties/Settings.Designer.cs
@@ -2350,5 +2350,29 @@ namespace mRemoteNG {
                 this["InhDefaultSoundQuality"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int ConDefaultRDPMinutesToIdleTimeout {
+            get {
+                return ((int)(this["ConDefaultRDPMinutesToIdleTimeout"]));
+            }
+            set {
+                this["ConDefaultRDPMinutesToIdleTimeout"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool InhDefaultRDPMinutesToIdleTimeout {
+            get {
+                return ((bool)(this["InhDefaultRDPMinutesToIdleTimeout"]));
+            }
+            set {
+                this["InhDefaultRDPMinutesToIdleTimeout"] = value;
+            }
+        }
     }
 }

--- a/mRemoteV1/Properties/Settings.settings
+++ b/mRemoteV1/Properties/Settings.settings
@@ -584,5 +584,11 @@
     <Setting Name="InhDefaultSoundQuality" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ConDefaultRDPMinutesToIdleTimeout" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="InhDefaultRDPMinutesToIdleTimeout" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/mRemoteV1/Resources/Language/Language.Designer.cs
+++ b/mRemoteV1/Resources/Language/Language.Designer.cs
@@ -4019,15 +4019,6 @@ namespace mRemoteNG {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The number of minutes for the RDP session to sit idle before automatically disconnecting (for no limit use 0).
-        /// </summary>
-        internal static string strPropertyDescriptionMinutesToIdleTimeout {
-            get {
-                return ResourceManager.GetString("strPropertyDescriptionMinutesToIdleTimeout", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to This is the name that will be displayed in the connections tree..
         /// </summary>
         internal static string strPropertyDescriptionName {
@@ -4123,6 +4114,15 @@ namespace mRemoteNG {
         internal static string strPropertyDescriptionRDGatewayUsername {
             get {
                 return ResourceManager.GetString("strPropertyDescriptionRDGatewayUsername", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The number of minutes for the RDP session to sit idle before automatically disconnecting (for no limit use 0).
+        /// </summary>
+        internal static string strPropertyDescriptionRDPMinutesToIdleTimeout {
+            get {
+                return ResourceManager.GetString("strPropertyDescriptionRDPMinutesToIdleTimeout", resourceCulture);
             }
         }
         
@@ -4505,15 +4505,6 @@ namespace mRemoteNG {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Minutes to Idle.
-        /// </summary>
-        internal static string strPropertyNameMinutesToIdleTimeout {
-            get {
-                return ResourceManager.GetString("strPropertyNameMinutesToIdleTimeout", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Name.
         /// </summary>
         internal static string strPropertyNameName {
@@ -4618,6 +4609,15 @@ namespace mRemoteNG {
         internal static string strPropertyNameRDGatewayUsername {
             get {
                 return ResourceManager.GetString("strPropertyNameRDGatewayUsername", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minutes to Idle.
+        /// </summary>
+        internal static string strPropertyNameRDPMinutesToIdleTimeout {
+            get {
+                return ResourceManager.GetString("strPropertyNameRDPMinutesToIdleTimeout", resourceCulture);
             }
         }
         

--- a/mRemoteV1/Resources/Language/Language.Designer.cs
+++ b/mRemoteV1/Resources/Language/Language.Designer.cs
@@ -4019,6 +4019,15 @@ namespace mRemoteNG {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The number of minutes for the RDP session to sit idle before automatically disconnecting.
+        /// </summary>
+        internal static string strPropertyDescriptionMinutesToIdleTimeout {
+            get {
+                return ResourceManager.GetString("strPropertyDescriptionMinutesToIdleTimeout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This is the name that will be displayed in the connections tree..
         /// </summary>
         internal static string strPropertyDescriptionName {
@@ -4492,6 +4501,15 @@ namespace mRemoteNG {
         internal static string strPropertyNameMACAddress {
             get {
                 return ResourceManager.GetString("strPropertyNameMACAddress", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minutes to Idle.
+        /// </summary>
+        internal static string strPropertyNameMinutesToIdleTimeout {
+            get {
+                return ResourceManager.GetString("strPropertyNameMinutesToIdleTimeout", resourceCulture);
             }
         }
         

--- a/mRemoteV1/Resources/Language/Language.Designer.cs
+++ b/mRemoteV1/Resources/Language/Language.Designer.cs
@@ -4019,7 +4019,7 @@ namespace mRemoteNG {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The number of minutes for the RDP session to sit idle before automatically disconnecting.
+        ///   Looks up a localized string similar to The number of minutes for the RDP session to sit idle before automatically disconnecting (for no limit use 0).
         /// </summary>
         internal static string strPropertyDescriptionMinutesToIdleTimeout {
             get {

--- a/mRemoteV1/Resources/Language/Language.resx
+++ b/mRemoteV1/Resources/Language/Language.resx
@@ -2421,10 +2421,10 @@ mRemoteNG will now quit and begin with the installation.</value>
   <data name="strDownloadPortable" xml:space="preserve">
     <value>Download</value>
   </data>
-  <data name="strPropertyDescriptionMinutesToIdleTimeout" xml:space="preserve">
+  <data name="strPropertyDescriptionRDPMinutesToIdleTimeout" xml:space="preserve">
     <value>The number of minutes for the RDP session to sit idle before automatically disconnecting (for no limit use 0)</value>
   </data>
-  <data name="strPropertyNameMinutesToIdleTimeout" xml:space="preserve">
+  <data name="strPropertyNameRDPMinutesToIdleTimeout" xml:space="preserve">
     <value>Minutes to Idle</value>
   </data>
 </root>

--- a/mRemoteV1/Resources/Language/Language.resx
+++ b/mRemoteV1/Resources/Language/Language.resx
@@ -2421,4 +2421,10 @@ mRemoteNG will now quit and begin with the installation.</value>
   <data name="strDownloadPortable" xml:space="preserve">
     <value>Download</value>
   </data>
+  <data name="strPropertyDescriptionMinutesToIdleTimeout" xml:space="preserve">
+    <value>The number of minutes for the RDP session to sit idle before automatically disconnecting</value>
+  </data>
+  <data name="strPropertyNameMinutesToIdleTimeout" xml:space="preserve">
+    <value>Minutes to Idle</value>
+  </data>
 </root>

--- a/mRemoteV1/Resources/Language/Language.resx
+++ b/mRemoteV1/Resources/Language/Language.resx
@@ -2422,7 +2422,7 @@ mRemoteNG will now quit and begin with the installation.</value>
     <value>Download</value>
   </data>
   <data name="strPropertyDescriptionMinutesToIdleTimeout" xml:space="preserve">
-    <value>The number of minutes for the RDP session to sit idle before automatically disconnecting</value>
+    <value>The number of minutes for the RDP session to sit idle before automatically disconnecting (for no limit use 0)</value>
   </data>
   <data name="strPropertyNameMinutesToIdleTimeout" xml:space="preserve">
     <value>Minutes to Idle</value>

--- a/mRemoteV1/Schemas/mremoteng_confcons_v2_6.xsd
+++ b/mRemoteV1/Schemas/mremoteng_confcons_v2_6.xsd
@@ -46,6 +46,7 @@
     <xs:attribute name="RenderingEngine" type="xs:string" use="required" />
     <xs:attribute name="ICAEncryptionStrength" type="xs:string" use="required" />
     <xs:attribute name="RDPAuthenticationLevel" type="xs:string" use="required" />
+    <xs:attribute name="RDPMinutesToIdleTimeout" type="xs:int" use="required" />
     <xs:attribute name="LoadBalanceInfo" type="xs:string" use="required" />
     <xs:attribute name="Colors" type="xs:string" use="required" />
     <xs:attribute name="Resolution" type="xs:string" use="required" />
@@ -114,6 +115,7 @@
     <xs:attribute name="InheritUsername" type="xs:boolean" use="optional" />
     <xs:attribute name="InheritICAEncryptionStrength" type="xs:boolean" use="optional" />
     <xs:attribute name="InheritRDPAuthenticationLevel" type="xs:boolean" use="optional" />
+    <xs:attribute name="InheritRDPMinutesToIdleTimeout" type="xs:boolean" use="optional" />
     <xs:attribute name="InheritLoadBalanceInfo" type="xs:boolean" use="optional" />
     <xs:attribute name="InheritPreExtApp" type="xs:boolean" use="optional" />
     <xs:attribute name="InheritPostExtApp" type="xs:boolean" use="optional" />

--- a/mRemoteV1/UI/Window/ConfigWindow.cs
+++ b/mRemoteV1/UI/Window/ConfigWindow.cs
@@ -812,6 +812,7 @@ namespace mRemoteNG.UI.Window
                     strHide.Add("RDGatewayUseConnectionCredentials");
                     strHide.Add("RDGatewayUsername");
                     strHide.Add("RDPAuthenticationLevel");
+                    strHide.Add("RDPMinutesToIdleTimeout");
                     strHide.Add("LoadBalanceInfo");
                     strHide.Add("RedirectDiskDrives");
                     strHide.Add("RedirectKeys");
@@ -910,7 +911,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUseConnectionCredentials");
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
-							strHide.Add("LoadBalanceInfo");
+                            strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
@@ -953,7 +955,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUseConnectionCredentials");
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
-							strHide.Add("LoadBalanceInfo");
+                            strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
@@ -995,7 +998,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUseConnectionCredentials");
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
-							strHide.Add("LoadBalanceInfo");
+                            strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
@@ -1038,7 +1042,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUseConnectionCredentials");
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
-							strHide.Add("LoadBalanceInfo");
+                            strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
@@ -1082,7 +1087,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUseConnectionCredentials");
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
-							strHide.Add("LoadBalanceInfo");
+                            strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
@@ -1126,7 +1132,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUseConnectionCredentials");
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
-							strHide.Add("LoadBalanceInfo");
+                            strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
@@ -1170,7 +1177,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUseConnectionCredentials");
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
-							strHide.Add("LoadBalanceInfo");
+                            strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
@@ -1212,7 +1220,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUseConnectionCredentials");
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
-							strHide.Add("LoadBalanceInfo");
+                            strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
@@ -1250,7 +1259,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUseConnectionCredentials");
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
-							strHide.Add("LoadBalanceInfo");
+                            strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
@@ -1291,7 +1301,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUseConnectionCredentials");
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
-							strHide.Add("LoadBalanceInfo");
+                            strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
@@ -1372,6 +1383,8 @@ namespace mRemoteNG.UI.Window
                             strHide.Add("ICAEncryptionStrength");
                         if (conI.Inheritance.RDPAuthenticationLevel)
                             strHide.Add("RDPAuthenticationLevel");
+                        if (conI.Inheritance.RDPMinutesToIdleTimeout)
+                            strHide.Add("RDPMinutesToIdleTimeout");
                         if (conI.Inheritance.LoadBalanceInfo)
                             strHide.Add("LoadBalanceInfo");
                         if (conI.Inheritance.Username)

--- a/mRemoteV1/app.config
+++ b/mRemoteV1/app.config
@@ -604,6 +604,12 @@
       <setting name="InhDefaultSoundQuality" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="ConDefaultRDPMinutesToIdleTimeout" serializeAs="String">
+        <value>0</value>
+      </setting>
+      <setting name="InhDefaultRDPMinutesToIdleTimeout" serializeAs="String">
+        <value>False</value>
+      </setting>
     </mRemoteNG.Settings>
   </userSettings>
   <applicationSettings>


### PR DESCRIPTION
Allow users to configure a number of minutes until the session will automatically disconnect them for inactivity.