### PR TITLE
RDP Minutes to Idle Timeout - Update 4

### DIFF
--- a/mRemoteV1/Config/Serializers/DataTableDeserializer.cs
+++ b/mRemoteV1/Config/Serializers/DataTableDeserializer.cs
@@ -85,6 +85,7 @@ namespace mRemoteNG.Config.Serializers
             connectionInfo.ICAEncryptionStrength = (ProtocolICA.EncryptionStrength)Enum.Parse(typeof(ProtocolICA.EncryptionStrength), (string)dataRow["ICAEncryptionStrength"]);
             connectionInfo.RDPAuthenticationLevel = (ProtocolRDP.AuthenticationLevel)Enum.Parse(typeof(ProtocolRDP.AuthenticationLevel), (string)dataRow["RDPAuthenticationLevel"]);
             connectionInfo.RDPMinutesToIdleTimeout = (int)dataRow["RDPMinutesToIdleTimeout"];
+            connectionInfo.RDPAlertIdleTimeout = (bool)dataRow["RDPAlertIdleTimeout"];
             connectionInfo.LoadBalanceInfo = (string)dataRow["LoadBalanceInfo"];
             connectionInfo.Colors = (ProtocolRDP.RDPColors)Enum.Parse(typeof(ProtocolRDP.RDPColors) ,(string)dataRow["Colors"]);
             connectionInfo.Resolution = (ProtocolRDP.RDPResolutions)Enum.Parse(typeof(ProtocolRDP.RDPResolutions), (string)dataRow["Resolution"]);
@@ -154,6 +155,7 @@ namespace mRemoteNG.Config.Serializers
             connectionInfo.Inheritance.Username = (bool)dataRow["InheritUsername"];
             connectionInfo.Inheritance.ICAEncryptionStrength = (bool)dataRow["InheritICAEncryptionStrength"];
             connectionInfo.Inheritance.RDPAuthenticationLevel = (bool)dataRow["InheritRDPAuthenticationLevel"];
+            connectionInfo.Inheritance.RDPAlertIdleTimeout = (bool)dataRow["RDPAlertIdleTimeout"];
             connectionInfo.Inheritance.RDPMinutesToIdleTimeout = (bool)dataRow["RDPMinutesToIdleTimeout"];
             connectionInfo.Inheritance.LoadBalanceInfo = (bool)dataRow["InheritLoadBalanceInfo"];
             connectionInfo.Inheritance.PreExtApp = (bool)dataRow["InheritPreExtApp"];

--- a/mRemoteV1/Config/Serializers/DataTableSerializer.cs
+++ b/mRemoteV1/Config/Serializers/DataTableSerializer.cs
@@ -66,6 +66,7 @@ namespace mRemoteNG.Config.Serializers
             _dataTable.Columns.Add("ICAEncryptionStrength", typeof(string));
             _dataTable.Columns.Add("RDPAuthenticationLevel", typeof(string));
             _dataTable.Columns.Add("RDPMinutesToIdleTimeout", typeof(int));
+            _dataTable.Columns.Add("RDPAlertIdleTimeout", typeof(bool));
             _dataTable.Columns.Add("Colors", typeof(string));
             _dataTable.Columns.Add("Resolution", typeof(string));
             _dataTable.Columns.Add("DisplayWallpaper", typeof(bool));
@@ -130,6 +131,7 @@ namespace mRemoteNG.Config.Serializers
             _dataTable.Columns.Add("InheritICAEncryptionStrength", typeof(bool));
             _dataTable.Columns.Add("InheritRDPAuthenticationLevel", typeof(bool));
             _dataTable.Columns.Add("InheritRDPMinutesToIdleTimeout", typeof(bool));
+            _dataTable.Columns.Add("InheritRDPAlertIdleTimeout", typeof(bool));
             _dataTable.Columns.Add("InheritUsername", typeof(bool));
             _dataTable.Columns.Add("InheritPreExtApp", typeof(bool));
             _dataTable.Columns.Add("InheritPostExtApp", typeof(bool));
@@ -203,6 +205,7 @@ namespace mRemoteNG.Config.Serializers
             dataRow["ICAEncryptionStrength"] = connectionInfo.ICAEncryptionStrength;
             dataRow["RDPAuthenticationLevel"] = connectionInfo.RDPAuthenticationLevel;
             //dataRow["RDPMinutesToIdleTimeout"] = connectionInfo.RDPMinutesToIdleTimeout;
+            //dataRow["RDPAlertIdleTimeout"] = connectionInfo.RDPAlertIdleTimeout;
             dataRow["LoadBalanceInfo"] = connectionInfo.LoadBalanceInfo;
             dataRow["Colors"] = connectionInfo.Colors;
             dataRow["Resolution"] = connectionInfo.Resolution;
@@ -274,6 +277,7 @@ namespace mRemoteNG.Config.Serializers
                 dataRow["InheritICAEncryptionStrength"] = connectionInfo.Inheritance.ICAEncryptionStrength;
                 dataRow["InheritRDPAuthenticationLevel"] = connectionInfo.Inheritance.RDPAuthenticationLevel;
                 //dataRow["InheritRDPMinutesToIdleTimeout"] = connectionInfo.Inheritance.RDPMinutesToIdleTimeout;
+                //dataRow["InheritRDPAlertIdleTimeout"] = connectionInfo.Inheritance.RDPAlertIdleTimeout;
                 dataRow["InheritLoadBalanceInfo"] = connectionInfo.Inheritance.LoadBalanceInfo;
                 dataRow["InheritPreExtApp"] = connectionInfo.Inheritance.PreExtApp;
                 dataRow["InheritPostExtApp"] = connectionInfo.Inheritance.PostExtApp;
@@ -330,6 +334,7 @@ namespace mRemoteNG.Config.Serializers
                 dataRow["InheritICAEncryptionStrength"] = false;
                 dataRow["InheritRDPAuthenticationLevel"] = false;
                 //dataRow["InheritRDPMinutesToIdleTimeout"] = false;
+                //dataRow["InheritRDPAlertIdleTimeout"] = false;
                 dataRow["InheritLoadBalanceInfo"] = false;
                 dataRow["InheritPreExtApp"] = false;
                 dataRow["InheritPostExtApp"] = false;

--- a/mRemoteV1/Config/Serializers/XmlConnectionNodeSerializer.cs
+++ b/mRemoteV1/Config/Serializers/XmlConnectionNodeSerializer.cs
@@ -68,6 +68,7 @@ namespace mRemoteNG.Config.Serializers
             element.Add(new XAttribute("ICAEncryptionStrength", connectionInfo.ICAEncryptionStrength));
             element.Add(new XAttribute("RDPAuthenticationLevel", connectionInfo.RDPAuthenticationLevel));
             element.Add(new XAttribute("RDPMinutesToIdleTimeout", connectionInfo.RDPMinutesToIdleTimeout));
+            element.Add(new XAttribute("RDPAlertIdleTimeout", connectionInfo.RDPAlertIdleTimeout));
             element.Add(new XAttribute("LoadBalanceInfo", connectionInfo.LoadBalanceInfo));
             element.Add(new XAttribute("Colors", connectionInfo.Colors));
             element.Add(new XAttribute("Resolution", connectionInfo.Resolution));
@@ -161,6 +162,7 @@ namespace mRemoteNG.Config.Serializers
                 element.Add(new XAttribute("InheritICAEncryptionStrength", connectionInfo.Inheritance.ICAEncryptionStrength.ToString()));
                 element.Add(new XAttribute("InheritRDPAuthenticationLevel", connectionInfo.Inheritance.RDPAuthenticationLevel.ToString()));
                 element.Add(new XAttribute("InheritRDPMinutesToIdleTimeout", connectionInfo.Inheritance.RDPMinutesToIdleTimeout.ToString()));
+                element.Add(new XAttribute("InheritRDPAlertIdleTimeout", connectionInfo.Inheritance.RDPAlertIdleTimeout.ToString()));
                 element.Add(new XAttribute("InheritLoadBalanceInfo", connectionInfo.Inheritance.LoadBalanceInfo.ToString()));
                 element.Add(new XAttribute("InheritPreExtApp", connectionInfo.Inheritance.PreExtApp.ToString()));
                 element.Add(new XAttribute("InheritPostExtApp", connectionInfo.Inheritance.PostExtApp.ToString()));
@@ -217,6 +219,7 @@ namespace mRemoteNG.Config.Serializers
                 element.Add(new XAttribute("InheritICAEncryptionStrength", false.ToString()));
                 element.Add(new XAttribute("InheritRDPAuthenticationLevel", false.ToString()));
                 element.Add(new XAttribute("InheritRDPMinutesToIdleTimeout", false.ToString()));
+                element.Add(new XAttribute("InheritRDPAlertIdleTimeout", false.ToString()));
                 element.Add(new XAttribute("InheritLoadBalanceInfo", false.ToString()));
                 element.Add(new XAttribute("InheritPreExtApp", false.ToString()));
                 element.Add(new XAttribute("InheritPostExtApp", false.ToString()));

--- a/mRemoteV1/Config/Serializers/XmlConnectionsDeserializer.cs
+++ b/mRemoteV1/Config/Serializers/XmlConnectionsDeserializer.cs
@@ -489,6 +489,8 @@ namespace mRemoteNG.Config.Serializers
                     connectionInfo.Inheritance.SoundQuality = bool.Parse(xmlnode.Attributes["InheritSoundQuality"].Value);
                     connectionInfo.RDPMinutesToIdleTimeout = Convert.ToInt32(xmlnode.Attributes["RDPMinutesToIdleTimeout"]?.Value ?? "0");
                     connectionInfo.Inheritance.RDPMinutesToIdleTimeout = bool.Parse(xmlnode.Attributes["InheritRDPMinutesToIdleTimeout"]?.Value ?? "False");
+                    connectionInfo.RDPAlertIdleTimeout = bool.Parse(xmlnode.Attributes["RDPAlertIdleTimeout"]?.Value ?? "False");
+                    connectionInfo.Inheritance.RDPAlertIdleTimeout = bool.Parse(xmlnode.Attributes["InheritRDPAlertIdleTimeout"]?.Value ?? "False");
                 }
             }
             catch (Exception ex)

--- a/mRemoteV1/Connection/AbstractConnectionInfoData.cs
+++ b/mRemoteV1/Connection/AbstractConnectionInfoData.cs
@@ -31,6 +31,7 @@ namespace mRemoteNG.Connection
         private bool _useConsoleSession;
         private ProtocolRDP.AuthenticationLevel _rdpAuthenticationLevel;
         private int _rdpMinutesToIdleTimeout;
+        private bool _rdpAlertIdleTimeout;
         private string _loadBalanceInfo;
         private HTTPBase.RenderingEngine _renderingEngine;
         private bool _useCredSsp;
@@ -233,6 +234,14 @@ namespace mRemoteNG.Connection
         {
             get { return GetPropertyValue("RDPMinutesToIdleTimeout", _rdpMinutesToIdleTimeout); }
             set { SetField(ref _rdpMinutesToIdleTimeout, value, "RDPMinutesToIdleTimeout"); }
+        }
+        [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 3),
+            LocalizedAttributes.LocalizedDisplayName("strPropertyNameRDPAlertIdleTimeout"),
+            LocalizedAttributes.LocalizedDescription("strPropertyDescriptionRDPAlertIdleTimeout")]
+        public bool RDPAlertIdleTimeout
+        {
+            get { return GetPropertyValue("RDPAlertIdleTimeout", _rdpAlertIdleTimeout); }
+            set { SetField(ref _rdpAlertIdleTimeout, value, "RDPAlertIdleTimeout"); }
         }
 
         [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 3),

--- a/mRemoteV1/Connection/AbstractConnectionInfoData.cs
+++ b/mRemoteV1/Connection/AbstractConnectionInfoData.cs
@@ -233,7 +233,14 @@ namespace mRemoteNG.Connection
         public virtual int RDPMinutesToIdleTimeout
         {
             get { return GetPropertyValue("RDPMinutesToIdleTimeout", _rdpMinutesToIdleTimeout); }
-            set { SetField(ref _rdpMinutesToIdleTimeout, value, "RDPMinutesToIdleTimeout"); }
+            set {
+                if(value < 0) {
+                    value = 0;
+                } else if(value > 240) {
+                    value = 240;
+                }
+                SetField(ref _rdpMinutesToIdleTimeout, value, "RDPMinutesToIdleTimeout");
+            }
         }
         [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 3),
             LocalizedAttributes.LocalizedDisplayName("strPropertyNameRDPAlertIdleTimeout"),

--- a/mRemoteV1/Connection/ConnectionInfo.cs
+++ b/mRemoteV1/Connection/ConnectionInfo.cs
@@ -249,6 +249,7 @@ namespace mRemoteNG.Connection
             UseConsoleSession = Settings.Default.ConDefaultUseConsoleSession;
             RDPAuthenticationLevel = (ProtocolRDP.AuthenticationLevel) Enum.Parse(typeof(ProtocolRDP.AuthenticationLevel), Settings.Default.ConDefaultRDPAuthenticationLevel);
             RDPMinutesToIdleTimeout = Settings.Default.ConDefaultRDPMinutesToIdleTimeout;
+            RDPAlertIdleTimeout = Settings.Default.ConDefaultRDPAlertIdleTimeout;
             LoadBalanceInfo = Settings.Default.ConDefaultLoadBalanceInfo;
             RenderingEngine = (HTTPBase.RenderingEngine) Enum.Parse(typeof(HTTPBase.RenderingEngine), Settings.Default.ConDefaultRenderingEngine);
             UseCredSsp = Settings.Default.ConDefaultUseCredSsp;

--- a/mRemoteV1/Connection/ConnectionInfoInheritance.cs
+++ b/mRemoteV1/Connection/ConnectionInfoInheritance.cs
@@ -90,6 +90,11 @@ namespace mRemoteNG.Connection
         LocalizedAttributes.LocalizedDescriptionInheritAttribute("strPropertyDescriptionRDPMinutesToIdleTimeout"),
         TypeConverter(typeof(MiscTools.YesNoTypeConverter))]public bool RDPMinutesToIdleTimeout { get; set; }
 
+        [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 4),
+        LocalizedAttributes.LocalizedDisplayNameInheritAttribute("strPropertyNameRDPAlertIdleTimeout"),
+        LocalizedAttributes.LocalizedDescriptionInheritAttribute("strPropertyDescriptionRDPAlertIdleTimeout"),
+        TypeConverter(typeof(MiscTools.YesNoTypeConverter))] public bool RDPAlertIdleTimeout { get; set; }
+
         [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 4), 
 		LocalizedAttributes.LocalizedDisplayNameInheritAttribute("strPropertyNameLoadBalanceInfo"), 
 		LocalizedAttributes.LocalizedDescriptionInheritAttribute("strPropertyDescriptionLoadBalanceInfo"), 

--- a/mRemoteV1/Connection/Protocol/RDP/Connection.Protocol.RDP.cs
+++ b/mRemoteV1/Connection/Protocol/RDP/Connection.Protocol.RDP.cs
@@ -132,20 +132,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
                 _rdpClient.FullScreenTitle = _connectionInfo.Name;
 
                 _alertOnIdleDisconnect = _connectionInfo.RDPAlertIdleTimeout;
-                
-                // Set the timeout to the default (zero) if it is out of bounds.
-                if (_connectionInfo.RDPMinutesToIdleTimeout < 0)
-                {
-                    _rdpClient.AdvancedSettings2.MinutesToIdleTimeout = Settings.Default.ConDefaultRDPMinutesToIdleTimeout;
-                } // Set the timeout to the max (240) if it is out of bounds.
-                else if (_connectionInfo.RDPMinutesToIdleTimeout > 240)
-                {
-                    _rdpClient.AdvancedSettings2.MinutesToIdleTimeout = 240;
-                }
-                else
-                {
-                    _rdpClient.AdvancedSettings2.MinutesToIdleTimeout = _connectionInfo.RDPMinutesToIdleTimeout;
-                }
+                _rdpClient.AdvancedSettings2.MinutesToIdleTimeout = _connectionInfo.RDPMinutesToIdleTimeout;
 
                 //not user changeable
                 _rdpClient.AdvancedSettings2.GrabFocusOnConnect = true;

--- a/mRemoteV1/Properties/Settings.Designer.cs
+++ b/mRemoteV1/Properties/Settings.Designer.cs
@@ -2374,5 +2374,29 @@ namespace mRemoteNG {
                 this["InhDefaultRDPMinutesToIdleTimeout"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ConDefaultRDPAlertIdleTimeout {
+            get {
+                return ((bool)(this["ConDefaultRDPAlertIdleTimeout"]));
+            }
+            set {
+                this["ConDefaultRDPAlertIdleTimeout"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool InhDefaultRDPAlertIdleTimeout {
+            get {
+                return ((bool)(this["InhDefaultRDPAlertIdleTimeout"]));
+            }
+            set {
+                this["InhDefaultRDPAlertIdleTimeout"] = value;
+            }
+        }
     }
 }

--- a/mRemoteV1/Properties/Settings.settings
+++ b/mRemoteV1/Properties/Settings.settings
@@ -590,5 +590,11 @@
     <Setting Name="InhDefaultRDPMinutesToIdleTimeout" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ConDefaultRDPAlertIdleTimeout" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="InhDefaultRDPAlertIdleTimeout" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/mRemoteV1/Resources/Language/Language.Designer.cs
+++ b/mRemoteV1/Resources/Language/Language.Designer.cs
@@ -4118,6 +4118,15 @@ namespace mRemoteNG {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Select whether to receive an alert after the RDP session disconnects due to inactivity.
+        /// </summary>
+        internal static string strPropertyDescriptionRDPAlertIdleTimeout {
+            get {
+                return ResourceManager.GetString("strPropertyDescriptionRDPAlertIdleTimeout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The number of minutes for the RDP session to sit idle before automatically disconnecting (for no limit use 0).
         /// </summary>
         internal static string strPropertyDescriptionRDPMinutesToIdleTimeout {
@@ -4609,6 +4618,15 @@ namespace mRemoteNG {
         internal static string strPropertyNameRDGatewayUsername {
             get {
                 return ResourceManager.GetString("strPropertyNameRDGatewayUsername", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Alert on Idle Disconnect.
+        /// </summary>
+        internal static string strPropertyNameRDPAlertIdleTimeout {
+            get {
+                return ResourceManager.GetString("strPropertyNameRDPAlertIdleTimeout", resourceCulture);
             }
         }
         

--- a/mRemoteV1/Resources/Language/Language.resx
+++ b/mRemoteV1/Resources/Language/Language.resx
@@ -2427,4 +2427,10 @@ mRemoteNG will now quit and begin with the installation.</value>
   <data name="strPropertyNameRDPMinutesToIdleTimeout" xml:space="preserve">
     <value>Minutes to Idle</value>
   </data>
+  <data name="strPropertyDescriptionRDPAlertIdleTimeout" xml:space="preserve">
+    <value>Select whether to receive an alert after the RDP session disconnects due to inactivity</value>
+  </data>
+  <data name="strPropertyNameRDPAlertIdleTimeout" xml:space="preserve">
+    <value>Alert on Idle Disconnect</value>
+  </data>
 </root>

--- a/mRemoteV1/Schemas/mremoteng_confcons_v2_6.xsd
+++ b/mRemoteV1/Schemas/mremoteng_confcons_v2_6.xsd
@@ -47,6 +47,7 @@
     <xs:attribute name="ICAEncryptionStrength" type="xs:string" use="required" />
     <xs:attribute name="RDPAuthenticationLevel" type="xs:string" use="required" />
     <xs:attribute name="RDPMinutesToIdleTimeout" type="xs:int" use="required" />
+    <xs:attribute name="RDPAlertIdleTimeout" type="xs:boolean" use="required" />
     <xs:attribute name="LoadBalanceInfo" type="xs:string" use="required" />
     <xs:attribute name="Colors" type="xs:string" use="required" />
     <xs:attribute name="Resolution" type="xs:string" use="required" />
@@ -116,6 +117,7 @@
     <xs:attribute name="InheritICAEncryptionStrength" type="xs:boolean" use="optional" />
     <xs:attribute name="InheritRDPAuthenticationLevel" type="xs:boolean" use="optional" />
     <xs:attribute name="InheritRDPMinutesToIdleTimeout" type="xs:boolean" use="optional" />
+    <xs:attribute name="InheritRDPAlertIdleTimeout" type="xs:boolean" use="optional" />
     <xs:attribute name="InheritLoadBalanceInfo" type="xs:boolean" use="optional" />
     <xs:attribute name="InheritPreExtApp" type="xs:boolean" use="optional" />
     <xs:attribute name="InheritPostExtApp" type="xs:boolean" use="optional" />

--- a/mRemoteV1/UI/Window/ConfigWindow.cs
+++ b/mRemoteV1/UI/Window/ConfigWindow.cs
@@ -813,6 +813,7 @@ namespace mRemoteNG.UI.Window
                     strHide.Add("RDGatewayUsername");
                     strHide.Add("RDPAuthenticationLevel");
                     strHide.Add("RDPMinutesToIdleTimeout");
+                    strHide.Add("RDPAlertIdleTimeout");
                     strHide.Add("LoadBalanceInfo");
                     strHide.Add("RedirectDiskDrives");
                     strHide.Add("RedirectKeys");
@@ -871,6 +872,10 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("VNCProxyUsername");
 							strHide.Add("VNCSmartSizeMode");
 							strHide.Add("VNCViewOnly");
+                            if (conI.RDPMinutesToIdleTimeout <= 0)
+                            {
+                                strHide.Add("RDPAlertIdleTimeout");
+                            }
 							if (conI.RDGatewayUsageMethod == ProtocolRDP.RDGatewayUsageMethod.Never)
 							{
 								strHide.Add("RDGatewayDomain");
@@ -912,6 +917,7 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
                             strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("RDPAlertIdleTimeout");
                             strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
@@ -956,6 +962,7 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
                             strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("RDPAlertIdleTimeout");
                             strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
@@ -999,6 +1006,7 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
                             strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("RDPAlertIdleTimeout");
                             strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
@@ -1043,6 +1051,7 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
                             strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("RDPAlertIdleTimeout");
                             strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
@@ -1088,6 +1097,7 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
                             strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("RDPAlertIdleTimeout");
                             strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
@@ -1133,6 +1143,7 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
                             strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("RDPAlertIdleTimeout");
                             strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
@@ -1178,6 +1189,7 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
                             strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("RDPAlertIdleTimeout");
                             strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
@@ -1221,6 +1233,7 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
                             strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("RDPAlertIdleTimeout");
                             strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
@@ -1260,6 +1273,7 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
                             strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("RDPAlertIdleTimeout");
                             strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
@@ -1302,6 +1316,7 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RDGatewayUsername");
 							strHide.Add("RDPAuthenticationLevel");
                             strHide.Add("RDPMinutesToIdleTimeout");
+                            strHide.Add("RDPAlertIdleTimeout");
                             strHide.Add("LoadBalanceInfo");
 							strHide.Add("RedirectDiskDrives");
 							strHide.Add("RedirectKeys");
@@ -1385,6 +1400,8 @@ namespace mRemoteNG.UI.Window
                             strHide.Add("RDPAuthenticationLevel");
                         if (conI.Inheritance.RDPMinutesToIdleTimeout)
                             strHide.Add("RDPMinutesToIdleTimeout");
+                        if (conI.Inheritance.RDPAlertIdleTimeout)
+                            strHide.Add("RDPAlertIdleTimeout");
                         if (conI.Inheritance.LoadBalanceInfo)
                             strHide.Add("LoadBalanceInfo");
                         if (conI.Inheritance.Username)

--- a/mRemoteV1/app.config
+++ b/mRemoteV1/app.config
@@ -415,6 +415,18 @@
       <setting name="InhDefaultRDPAuthenticationLevel" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="ConDefaultRDPMinutesToIdleTimeout" serializeAs="String">
+        <value>0</value>
+      </setting>
+      <setting name="InhDefaultRDPMinutesToIdleTimeout" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="ConDefaultRDPAlertIdleTimeout" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="InhDefaultRDPAlertIdleTimeout" serializeAs="String">
+        <value>False</value>
+      </setting>
       <setting name="UVNCSCPort" serializeAs="String">
         <value>5500</value>
       </setting>
@@ -608,6 +620,12 @@
         <value>0</value>
       </setting>
       <setting name="InhDefaultRDPMinutesToIdleTimeout" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="ConDefaultRDPAlertIdleTimeout" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="InhDefaultRDPAlertIdleTimeout" serializeAs="String">
         <value>False</value>
       </setting>
     </mRemoteNG.Settings>


### PR DESCRIPTION
Added an option to alert the user if they were disconnected due to inactivity. Additionally, if the user specifies a number of minutes to idle that is above the maximum, it will set the number of minutes to idle at the max (used to be that it would set the minutes to idle to zero or never idle out).
_This is continued off of PR #342 and ticket #221_ 