### PR TITLE
Quick fix for #369 (Reset Layout Ignores Notification Pane)

### DIFF
--- a/mRemoteV1/UI/Forms/frmMain.cs
+++ b/mRemoteV1/UI/Forms/frmMain.cs
@@ -1233,7 +1233,9 @@ namespace mRemoteNG.UI.Forms
             Windows.TreePanel.Show(Default.pnlDock, DockState.DockLeft);
             Windows.ConfigPanel.Show(Default.pnlDock);
             Windows.ConfigPanel.DockTo(Windows.TreePanel.Pane, DockStyle.Bottom, -1);
+            Windows.ErrorsPanel.Show(Default.pnlDock, DockState.Document);
 
+            Windows.ErrorsForm.Hide();
             Windows.ScreenshotForm.Hide();
 
             Default.pnlDock.Visible = true;


### PR DESCRIPTION
Fix for #369 

Reset Layout will now hide the notification pane (if it's opened) and dock it to it's default place (if it's been moved). I've tested this by floating the notification pane, and then resetting the layout. It seems to match its default behavior on initial launch with no preexisting pnlLayout.xml config.