### PR TITLE
Serialize connectioninfo ID

### DIFF
--- a/mRemoteV1/Config/Serializers/XmlConnectionNodeSerializer.cs
+++ b/mRemoteV1/Config/Serializers/XmlConnectionNodeSerializer.cs
@@ -44,6 +44,7 @@ namespace mRemoteNG.Config.Serializers
             element.Add(new XAttribute("Descr", connectionInfo.Description));
             element.Add(new XAttribute("Icon", connectionInfo.Icon));
             element.Add(new XAttribute("Panel", connectionInfo.Panel));
+            element.Add(new XAttribute("Id", connectionInfo.ConstantID));
 
             element.Add(_saveFilter.SaveUsername
                 ? new XAttribute("Username", connectionInfo.Username)

--- a/mRemoteV1/Config/Serializers/XmlConnectionsDeserializer.cs
+++ b/mRemoteV1/Config/Serializers/XmlConnectionsDeserializer.cs
@@ -485,6 +485,7 @@ namespace mRemoteNG.Config.Serializers
 
                 if (_confVersion >= 2.6)
                 {
+                    connectionInfo.ConstantID = xmlnode.Attributes["Id"]?.Value ?? connectionInfo.ConstantID;
                     connectionInfo.SoundQuality = (ProtocolRDP.RDPSoundQuality)Tools.MiscTools.StringToEnum(typeof(ProtocolRDP.RDPSoundQuality), Convert.ToString(xmlnode.Attributes["SoundQuality"].Value));
                     connectionInfo.Inheritance.SoundQuality = bool.Parse(xmlnode.Attributes["InheritSoundQuality"].Value);
                     connectionInfo.RDPMinutesToIdleTimeout = Convert.ToInt32(xmlnode.Attributes["RDPMinutesToIdleTimeout"]?.Value ?? "0");

--- a/mRemoteV1/Schemas/mremoteng_confcons_v2_6.xsd
+++ b/mRemoteV1/Schemas/mremoteng_confcons_v2_6.xsd
@@ -34,6 +34,7 @@
     <xs:attribute name="Descr" type="xs:string" use="required" />
     <xs:attribute name="Icon" type="xs:string" use="required" />
     <xs:attribute name="Panel" type="xs:string" use="required" />
+    <xs:attribute name="Id" type="xs:string" use="required" />
     <xs:attribute name="Username" type="xs:string" use="required" />
     <xs:attribute name="Domain" type="xs:string" use="required" />
     <xs:attribute name="Password" type="xs:string" use="required" />


### PR DESCRIPTION
The unique connectioninfo id is now being serialized to the confCons file. This enables us to tie serialized objects to their inflated instances in memory.

This change was made to support the credential manager feature being developed for v1.76.