### PR TITLE
Allow insecure certs for Gecko

### DIFF
--- a/mRemoteV1/Config/Serializers/CsvConnectionsSerializerMremotengFormat.cs
+++ b/mRemoteV1/Config/Serializers/CsvConnectionsSerializerMremotengFormat.cs
@@ -55,7 +55,7 @@ namespace mRemoteNG.Config.Serializers
                 csvHeader += "Domain;";
             csvHeader += "Hostname;Protocol;PuttySession;Port;ConnectToConsole;UseCredSsp;RenderingEngine;ICAEncryptionStrength;RDPAuthenticationLevel;LoadBalanceInfo;Colors;Resolution;AutomaticResize;DisplayWallpaper;DisplayThemes;EnableFontSmoothing;EnableDesktopComposition;CacheBitmaps;RedirectDiskDrives;RedirectPorts;RedirectPrinters;RedirectSmartCards;RedirectSound;RedirectKeys;PreExtApp;PostExtApp;MacAddress;UserField;ExtApp;VNCCompression;VNCEncoding;VNCAuthMode;VNCProxyType;VNCProxyIP;VNCProxyPort;VNCProxyUsername;VNCProxyPassword;VNCColors;VNCSmartSizeMode;VNCViewOnly;RDGatewayUsageMethod;RDGatewayHostname;RDGatewayUseConnectionCredentials;RDGatewayUsername;RDGatewayPassword;RDGatewayDomain;";
             if (_saveFilter.SaveInheritance)
-                csvHeader += "InheritCacheBitmaps;InheritColors;InheritDescription;InheritDisplayThemes;InheritDisplayWallpaper;InheritEnableFontSmoothing;InheritEnableDesktopComposition;InheritDomain;InheritIcon;InheritPanel;InheritPassword;InheritPort;InheritProtocol;InheritPuttySession;InheritRedirectDiskDrives;InheritRedirectKeys;InheritRedirectPorts;InheritRedirectPrinters;InheritRedirectSmartCards;InheritRedirectSound;InheritResolution;InheritAutomaticResize;InheritUseConsoleSession;InheritUseCredSsp;InheritRenderingEngine;InheritUsername;InheritICAEncryptionStrength;InheritRDPAuthenticationLevel;InheritLoadBalanceInfo;InheritPreExtApp;InheritPostExtApp;InheritMacAddress;InheritUserField;InheritExtApp;InheritVNCCompression;InheritVNCEncoding;InheritVNCAuthMode;InheritVNCProxyType;InheritVNCProxyIP;InheritVNCProxyPort;InheritVNCProxyUsername;InheritVNCProxyPassword;InheritVNCColors;InheritVNCSmartSizeMode;InheritVNCViewOnly;InheritRDGatewayUsageMethod;InheritRDGatewayHostname;InheritRDGatewayUseConnectionCredentials;InheritRDGatewayUsername;InheritRDGatewayPassword;InheritRDGatewayDomain";
+                csvHeader += "InheritCacheBitmaps;InheritColors;InheritDescription;InheritDisplayThemes;InheritDisplayWallpaper;InheritEnableFontSmoothing;InheritEnableDesktopComposition;InheritDomain;InheritIcon;InheritPanel;InheritPassword;InheritPort;InheritProtocol;InheritPuttySession;InheritRedirectDiskDrives;InheritRedirectKeys;InheritRedirectPorts;InheritRedirectPrinters;InheritRedirectSmartCards;InheritRedirectSound;InheritResolution;InheritAutomaticResize;InheritUseConsoleSession;InheritUseCredSsp;InheritRenderingEngine;InheritHttpsTrustInsecureCerts;InheritUsername;InheritICAEncryptionStrength;InheritRDPAuthenticationLevel;InheritLoadBalanceInfo;InheritPreExtApp;InheritPostExtApp;InheritMacAddress;InheritUserField;InheritExtApp;InheritVNCCompression;InheritVNCEncoding;InheritVNCAuthMode;InheritVNCProxyType;InheritVNCProxyIP;InheritVNCProxyPort;InheritVNCProxyUsername;InheritVNCProxyPassword;InheritVNCColors;InheritVNCSmartSizeMode;InheritVNCViewOnly;InheritRDGatewayUsageMethod;InheritRDGatewayHostname;InheritRDGatewayUseConnectionCredentials;InheritRDGatewayUsername;InheritRDGatewayPassword;InheritRDGatewayDomain";
             _csv += csvHeader;
         }
 
@@ -99,6 +99,7 @@ namespace mRemoteNG.Config.Serializers
                         Convert.ToString(con.UseConsoleSession) + ";" + 
                         Convert.ToString(con.UseCredSsp) + ";" + 
                         con.RenderingEngine + ";" + 
+                        con.HttpsTrustInsecureCerts + ";" +
                         con.ICAEncryptionStrength + ";" + 
                         con.RDPAuthenticationLevel + ";" + 
                         con.LoadBalanceInfo + ";" + 
@@ -167,6 +168,7 @@ namespace mRemoteNG.Config.Serializers
                     con.Inheritance.UseConsoleSession + ";" +
                     con.Inheritance.UseCredSsp + ";" +
                     con.Inheritance.RenderingEngine + ";" +
+                    con.Inheritance.HttpsTrustInsecureCerts + ";" +
                     con.Inheritance.Username + ";" +
                     con.Inheritance.ICAEncryptionStrength + ";" +
                     con.Inheritance.RDPAuthenticationLevel + ";" +

--- a/mRemoteV1/Config/Serializers/DataTableDeserializer.cs
+++ b/mRemoteV1/Config/Serializers/DataTableDeserializer.cs
@@ -82,6 +82,7 @@ namespace mRemoteNG.Config.Serializers
             connectionInfo.UseConsoleSession = (bool)dataRow["ConnectToConsole"];
             connectionInfo.UseCredSsp = (bool)dataRow["UseCredSsp"];
             connectionInfo.RenderingEngine = (HTTPBase.RenderingEngine)Enum.Parse(typeof(HTTPBase.RenderingEngine), (string)dataRow["RenderingEngine"]);
+            connectionInfo.HttpsTrustInsecureCerts = (bool)dataRow["HttpsTrustInsecureCerts"];
             connectionInfo.ICAEncryptionStrength = (ProtocolICA.EncryptionStrength)Enum.Parse(typeof(ProtocolICA.EncryptionStrength), (string)dataRow["ICAEncryptionStrength"]);
             connectionInfo.RDPAuthenticationLevel = (ProtocolRDP.AuthenticationLevel)Enum.Parse(typeof(ProtocolRDP.AuthenticationLevel), (string)dataRow["RDPAuthenticationLevel"]);
             connectionInfo.RDPMinutesToIdleTimeout = (int)dataRow["RDPMinutesToIdleTimeout"];
@@ -152,6 +153,7 @@ namespace mRemoteNG.Config.Serializers
             connectionInfo.Inheritance.UseConsoleSession = (bool)dataRow["InheritUseConsoleSession"];
             connectionInfo.Inheritance.UseCredSsp = (bool)dataRow["InheritUseCredSsp"];
             connectionInfo.Inheritance.RenderingEngine = (bool)dataRow["InheritRenderingEngine"];
+            connectionInfo.Inheritance.RenderingEngine = (bool)dataRow["InheritHttpsTrustInsecureCerts"];
             connectionInfo.Inheritance.Username = (bool)dataRow["InheritUsername"];
             connectionInfo.Inheritance.ICAEncryptionStrength = (bool)dataRow["InheritICAEncryptionStrength"];
             connectionInfo.Inheritance.RDPAuthenticationLevel = (bool)dataRow["InheritRDPAuthenticationLevel"];

--- a/mRemoteV1/Config/Serializers/DataTableSerializer.cs
+++ b/mRemoteV1/Config/Serializers/DataTableSerializer.cs
@@ -202,6 +202,7 @@ namespace mRemoteNG.Config.Serializers
             dataRow["ConnectToConsole"] = connectionInfo.UseConsoleSession;
             dataRow["UseCredSsp"] = connectionInfo.UseCredSsp;
             dataRow["RenderingEngine"] = connectionInfo.RenderingEngine;
+            dataRow["HttpsTrustInsecureCerts"] = connectionInfo.HttpsTrustInsecureCerts;
             dataRow["ICAEncryptionStrength"] = connectionInfo.ICAEncryptionStrength;
             dataRow["RDPAuthenticationLevel"] = connectionInfo.RDPAuthenticationLevel;
             //dataRow["RDPMinutesToIdleTimeout"] = connectionInfo.RDPMinutesToIdleTimeout;
@@ -273,6 +274,7 @@ namespace mRemoteNG.Config.Serializers
                 dataRow["InheritUseConsoleSession"] = connectionInfo.Inheritance.UseConsoleSession;
                 dataRow["InheritUseCredSsp"] = connectionInfo.Inheritance.UseCredSsp;
                 dataRow["InheritRenderingEngine"] = connectionInfo.Inheritance.RenderingEngine;
+                dataRow["InheritHttpsTrustInsecureCerts"] = connectionInfo.Inheritance.HttpsTrustInsecureCerts;
                 dataRow["InheritUsername"] = connectionInfo.Inheritance.Username;
                 dataRow["InheritICAEncryptionStrength"] = connectionInfo.Inheritance.ICAEncryptionStrength;
                 dataRow["InheritRDPAuthenticationLevel"] = connectionInfo.Inheritance.RDPAuthenticationLevel;

--- a/mRemoteV1/Config/Serializers/DataTableSerializer.cs
+++ b/mRemoteV1/Config/Serializers/DataTableSerializer.cs
@@ -63,6 +63,7 @@ namespace mRemoteNG.Config.Serializers
             _dataTable.Columns.Add("ConnectToConsole", typeof(bool));
             _dataTable.Columns.Add("UseCredSsp", typeof(bool));
             _dataTable.Columns.Add("RenderingEngine", typeof(string));
+            _dataTable.Columns.Add("HttpsTrustInsecureCerts", typeof(bool));
             _dataTable.Columns.Add("ICAEncryptionStrength", typeof(string));
             _dataTable.Columns.Add("RDPAuthenticationLevel", typeof(string));
             _dataTable.Columns.Add("RDPMinutesToIdleTimeout", typeof(int));
@@ -128,6 +129,7 @@ namespace mRemoteNG.Config.Serializers
             _dataTable.Columns.Add("InheritUseConsoleSession", typeof(bool));
             _dataTable.Columns.Add("InheritUseCredSsp", typeof(bool));
             _dataTable.Columns.Add("InheritRenderingEngine", typeof(bool));
+            _dataTable.Columns.Add("InheritHttpsTrustInsecureCerts", typeof(bool));
             _dataTable.Columns.Add("InheritICAEncryptionStrength", typeof(bool));
             _dataTable.Columns.Add("InheritRDPAuthenticationLevel", typeof(bool));
             _dataTable.Columns.Add("InheritRDPMinutesToIdleTimeout", typeof(bool));

--- a/mRemoteV1/Config/Serializers/XmlConnectionNodeSerializer28.cs
+++ b/mRemoteV1/Config/Serializers/XmlConnectionNodeSerializer28.cs
@@ -1,0 +1,231 @@
+﻿using System.Security;
+using System.Xml.Linq;
+using mRemoteNG.Connection;
+using mRemoteNG.Container;
+using mRemoteNG.Security;
+
+
+namespace mRemoteNG.Config.Serializers
+{
+    public class XmlConnectionNodeSerializer28 : IConnectionSerializer<XElement>
+    {
+        private readonly ICryptographyProvider _cryptographyProvider;
+        private readonly SecureString _encryptionKey;
+        private readonly SaveFilter _saveFilter;
+
+
+        public XmlConnectionNodeSerializer28(ICryptographyProvider cryptographyProvider, SecureString encryptionKey, SaveFilter saveFilter)
+        {
+            _cryptographyProvider = cryptographyProvider;
+            _encryptionKey = encryptionKey;
+            _saveFilter = saveFilter;
+        }
+
+        public XElement Serialize(ConnectionInfo connectionInfo)
+        {
+            var element = new XElement(XName.Get("Node", ""));
+            SetElementAttributes(element, connectionInfo);
+            SetInheritanceAttributes(element, connectionInfo);
+            return element;
+        }
+
+        private void SetElementAttributes(XContainer element, ConnectionInfo connectionInfo)
+        {
+            var nodeAsContainer = connectionInfo as ContainerInfo;
+            element.Add(new XAttribute("Name", connectionInfo.Name));
+            element.Add(new XAttribute("Type", connectionInfo.GetTreeNodeType().ToString()));
+            if (nodeAsContainer != null)
+                element.Add(new XAttribute("Expanded", nodeAsContainer.IsExpanded.ToString()));
+            element.Add(new XAttribute("Descr", connectionInfo.Description));
+            element.Add(new XAttribute("Icon", connectionInfo.Icon));
+            element.Add(new XAttribute("Panel", connectionInfo.Panel));
+            element.Add(new XAttribute("Id", connectionInfo.ConstantID));
+
+            element.Add(_saveFilter.SaveCredentialId
+                ? new XAttribute("CredentialId", connectionInfo.CredentialRecord?.Id.ToString() ?? "")
+                : new XAttribute("CredentialId", ""));
+
+            element.Add(new XAttribute("Hostname", connectionInfo.Hostname));
+            element.Add(new XAttribute("Protocol", connectionInfo.Protocol));
+            element.Add(new XAttribute("PuttySession", connectionInfo.PuttySession));
+            element.Add(new XAttribute("Port", connectionInfo.Port));
+            element.Add(new XAttribute("ConnectToConsole", connectionInfo.UseConsoleSession.ToString()));
+            element.Add(new XAttribute("UseCredSsp", connectionInfo.UseCredSsp.ToString()));
+            element.Add(new XAttribute("RenderingEngine", connectionInfo.RenderingEngine));
+            element.Add(new XAttribute("HttpsTrustInsecureCerts", connectionInfo.RenderingEngine));
+            element.Add(new XAttribute("ICAEncryptionStrength", connectionInfo.ICAEncryptionStrength));
+            element.Add(new XAttribute("RDPAuthenticationLevel", connectionInfo.RDPAuthenticationLevel));
+            element.Add(new XAttribute("RDPMinutesToIdleTimeout", connectionInfo.RDPMinutesToIdleTimeout));
+            element.Add(new XAttribute("LoadBalanceInfo", connectionInfo.LoadBalanceInfo));
+            element.Add(new XAttribute("Colors", connectionInfo.Colors));
+            element.Add(new XAttribute("Resolution", connectionInfo.Resolution));
+            element.Add(new XAttribute("AutomaticResize", connectionInfo.AutomaticResize.ToString()));
+            element.Add(new XAttribute("DisplayWallpaper", connectionInfo.DisplayWallpaper.ToString()));
+            element.Add(new XAttribute("DisplayThemes", connectionInfo.DisplayThemes.ToString()));
+            element.Add(new XAttribute("EnableFontSmoothing", connectionInfo.EnableFontSmoothing.ToString()));
+            element.Add(new XAttribute("EnableDesktopComposition", connectionInfo.EnableDesktopComposition.ToString()));
+            element.Add(new XAttribute("CacheBitmaps", connectionInfo.CacheBitmaps.ToString()));
+            element.Add(new XAttribute("RedirectDiskDrives", connectionInfo.RedirectDiskDrives.ToString()));
+            element.Add(new XAttribute("RedirectPorts", connectionInfo.RedirectPorts.ToString()));
+            element.Add(new XAttribute("RedirectPrinters", connectionInfo.RedirectPrinters.ToString()));
+            element.Add(new XAttribute("RedirectSmartCards", connectionInfo.RedirectSmartCards.ToString()));
+            element.Add(new XAttribute("RedirectSound", connectionInfo.RedirectSound.ToString()));
+            element.Add(new XAttribute("SoundQuality", connectionInfo.SoundQuality.ToString()));
+            element.Add(new XAttribute("RedirectKeys", connectionInfo.RedirectKeys.ToString()));
+            element.Add(new XAttribute("Connected", (connectionInfo.OpenConnections.Count > 0).ToString()));
+            element.Add(new XAttribute("PreExtApp", connectionInfo.PreExtApp));
+            element.Add(new XAttribute("PostExtApp", connectionInfo.PostExtApp));
+            element.Add(new XAttribute("MacAddress", connectionInfo.MacAddress));
+            element.Add(new XAttribute("UserField", connectionInfo.UserField));
+            element.Add(new XAttribute("ExtApp", connectionInfo.ExtApp));
+            element.Add(new XAttribute("VNCCompression", connectionInfo.VNCCompression));
+            element.Add(new XAttribute("VNCEncoding", connectionInfo.VNCEncoding));
+            element.Add(new XAttribute("VNCAuthMode", connectionInfo.VNCAuthMode));
+            element.Add(new XAttribute("VNCProxyType", connectionInfo.VNCProxyType));
+            element.Add(new XAttribute("VNCProxyIP", connectionInfo.VNCProxyIP));
+            element.Add(new XAttribute("VNCProxyPort", connectionInfo.VNCProxyPort));
+
+            element.Add(_saveFilter.SaveUsername
+                ? new XAttribute("VNCProxyUsername", connectionInfo.VNCProxyUsername)
+                : new XAttribute("VNCProxyUsername", ""));
+
+            element.Add(_saveFilter.SavePassword
+                ? new XAttribute("VNCProxyPassword",
+                    _cryptographyProvider.Encrypt(connectionInfo.VNCProxyPassword, _encryptionKey))
+                : new XAttribute("VNCProxyPassword", ""));
+
+            element.Add(new XAttribute("VNCColors", connectionInfo.VNCColors));
+            element.Add(new XAttribute("VNCSmartSizeMode", connectionInfo.VNCSmartSizeMode));
+            element.Add(new XAttribute("VNCViewOnly", connectionInfo.VNCViewOnly.ToString()));
+            element.Add(new XAttribute("RDGatewayUsageMethod", connectionInfo.RDGatewayUsageMethod));
+            element.Add(new XAttribute("RDGatewayHostname", connectionInfo.RDGatewayHostname));
+            element.Add(new XAttribute("RDGatewayUseConnectionCredentials", connectionInfo.RDGatewayUseConnectionCredentials));
+
+            element.Add(_saveFilter.SaveUsername
+                ? new XAttribute("RDGatewayUsername", connectionInfo.RDGatewayUsername)
+                : new XAttribute("RDGatewayUsername", ""));
+
+            element.Add(_saveFilter.SavePassword
+                ? new XAttribute("RDGatewayPassword",
+                    _cryptographyProvider.Encrypt(connectionInfo.RDGatewayPassword, _encryptionKey))
+                : new XAttribute("RDGatewayPassword", ""));
+
+            element.Add(_saveFilter.SaveDomain
+                ? new XAttribute("RDGatewayDomain", connectionInfo.RDGatewayDomain)
+                : new XAttribute("RDGatewayDomain", ""));
+        }
+
+        private void SetInheritanceAttributes(XContainer element, IInheritable connectionInfo)
+        {
+            if (_saveFilter.SaveInheritance)
+            {
+                element.Add(new XAttribute("InheritCredentialRecord", connectionInfo.Inheritance.CredentialRecord));
+                element.Add(new XAttribute("InheritCacheBitmaps", connectionInfo.Inheritance.CacheBitmaps.ToString()));
+                element.Add(new XAttribute("InheritColors", connectionInfo.Inheritance.Colors.ToString()));
+                element.Add(new XAttribute("InheritDescription", connectionInfo.Inheritance.Description.ToString()));
+                element.Add(new XAttribute("InheritDisplayThemes", connectionInfo.Inheritance.DisplayThemes.ToString()));
+                element.Add(new XAttribute("InheritDisplayWallpaper", connectionInfo.Inheritance.DisplayWallpaper.ToString()));
+                element.Add(new XAttribute("InheritEnableFontSmoothing", connectionInfo.Inheritance.EnableFontSmoothing.ToString()));
+                element.Add(new XAttribute("InheritEnableDesktopComposition", connectionInfo.Inheritance.EnableDesktopComposition.ToString()));
+                element.Add(new XAttribute("InheritIcon", connectionInfo.Inheritance.Icon.ToString()));
+                element.Add(new XAttribute("InheritPanel", connectionInfo.Inheritance.Panel.ToString()));
+                element.Add(new XAttribute("InheritPort", connectionInfo.Inheritance.Port.ToString()));
+                element.Add(new XAttribute("InheritProtocol", connectionInfo.Inheritance.Protocol.ToString()));
+                element.Add(new XAttribute("InheritPuttySession", connectionInfo.Inheritance.PuttySession.ToString()));
+                element.Add(new XAttribute("InheritRedirectDiskDrives", connectionInfo.Inheritance.RedirectDiskDrives.ToString()));
+                element.Add(new XAttribute("InheritRedirectKeys", connectionInfo.Inheritance.RedirectKeys.ToString()));
+                element.Add(new XAttribute("InheritRedirectPorts", connectionInfo.Inheritance.RedirectPorts.ToString()));
+                element.Add(new XAttribute("InheritRedirectPrinters", connectionInfo.Inheritance.RedirectPrinters.ToString()));
+                element.Add(new XAttribute("InheritRedirectSmartCards", connectionInfo.Inheritance.RedirectSmartCards.ToString()));
+                element.Add(new XAttribute("InheritRedirectSound", connectionInfo.Inheritance.RedirectSound.ToString()));
+                element.Add(new XAttribute("InheritSoundQuality", connectionInfo.Inheritance.SoundQuality.ToString()));
+                element.Add(new XAttribute("InheritResolution", connectionInfo.Inheritance.Resolution.ToString()));
+                element.Add(new XAttribute("InheritAutomaticResize", connectionInfo.Inheritance.AutomaticResize.ToString()));
+                element.Add(new XAttribute("InheritUseConsoleSession", connectionInfo.Inheritance.UseConsoleSession.ToString()));
+                element.Add(new XAttribute("InheritUseCredSsp", connectionInfo.Inheritance.UseCredSsp.ToString()));
+                element.Add(new XAttribute("InheritRenderingEngine", connectionInfo.Inheritance.RenderingEngine.ToString()));
+                element.Add(new XAttribute("InheritHttpsTrustInsecureCerts", connectionInfo.Inheritance.HttpsTrustInsecureCerts.ToString()));
+                element.Add(new XAttribute("InheritICAEncryptionStrength", connectionInfo.Inheritance.ICAEncryptionStrength.ToString()));
+                element.Add(new XAttribute("InheritRDPAuthenticationLevel", connectionInfo.Inheritance.RDPAuthenticationLevel.ToString()));
+                element.Add(new XAttribute("InheritRDPMinutesToIdleTimeout", connectionInfo.Inheritance.RDPMinutesToIdleTimeout.ToString()));
+                element.Add(new XAttribute("InheritLoadBalanceInfo", connectionInfo.Inheritance.LoadBalanceInfo.ToString()));
+                element.Add(new XAttribute("InheritPreExtApp", connectionInfo.Inheritance.PreExtApp.ToString()));
+                element.Add(new XAttribute("InheritPostExtApp", connectionInfo.Inheritance.PostExtApp.ToString()));
+                element.Add(new XAttribute("InheritMacAddress", connectionInfo.Inheritance.MacAddress.ToString()));
+                element.Add(new XAttribute("InheritUserField", connectionInfo.Inheritance.UserField.ToString()));
+                element.Add(new XAttribute("InheritExtApp", connectionInfo.Inheritance.ExtApp.ToString()));
+                element.Add(new XAttribute("InheritVNCCompression", connectionInfo.Inheritance.VNCCompression.ToString()));
+                element.Add(new XAttribute("InheritVNCEncoding", connectionInfo.Inheritance.VNCEncoding.ToString()));
+                element.Add(new XAttribute("InheritVNCAuthMode", connectionInfo.Inheritance.VNCAuthMode.ToString()));
+                element.Add(new XAttribute("InheritVNCProxyType", connectionInfo.Inheritance.VNCProxyType.ToString()));
+                element.Add(new XAttribute("InheritVNCProxyIP", connectionInfo.Inheritance.VNCProxyIP.ToString()));
+                element.Add(new XAttribute("InheritVNCProxyPort", connectionInfo.Inheritance.VNCProxyPort.ToString()));
+                element.Add(new XAttribute("InheritVNCProxyUsername", connectionInfo.Inheritance.VNCProxyUsername.ToString()));
+                element.Add(new XAttribute("InheritVNCProxyPassword", connectionInfo.Inheritance.VNCProxyPassword.ToString()));
+                element.Add(new XAttribute("InheritVNCColors", connectionInfo.Inheritance.VNCColors.ToString()));
+                element.Add(new XAttribute("InheritVNCSmartSizeMode", connectionInfo.Inheritance.VNCSmartSizeMode.ToString()));
+                element.Add(new XAttribute("InheritVNCViewOnly", connectionInfo.Inheritance.VNCViewOnly.ToString()));
+                element.Add(new XAttribute("InheritRDGatewayUsageMethod", connectionInfo.Inheritance.RDGatewayUsageMethod.ToString()));
+                element.Add(new XAttribute("InheritRDGatewayHostname", connectionInfo.Inheritance.RDGatewayHostname.ToString()));
+                element.Add(new XAttribute("InheritRDGatewayUseConnectionCredentials", connectionInfo.Inheritance.RDGatewayUseConnectionCredentials.ToString()));
+                element.Add(new XAttribute("InheritRDGatewayUsername", connectionInfo.Inheritance.RDGatewayUsername.ToString()));
+                element.Add(new XAttribute("InheritRDGatewayPassword", connectionInfo.Inheritance.RDGatewayPassword.ToString()));
+                element.Add(new XAttribute("InheritRDGatewayDomain", connectionInfo.Inheritance.RDGatewayDomain.ToString()));
+            }
+            else
+            {
+                element.Add(new XAttribute("InheritCredentialRecord", false.ToString()));
+                element.Add(new XAttribute("InheritCacheBitmaps", false.ToString()));
+                element.Add(new XAttribute("InheritColors", false.ToString()));
+                element.Add(new XAttribute("InheritDescription", false.ToString()));
+                element.Add(new XAttribute("InheritDisplayThemes", false.ToString()));
+                element.Add(new XAttribute("InheritDisplayWallpaper", false.ToString()));
+                element.Add(new XAttribute("InheritEnableFontSmoothing", false.ToString()));
+                element.Add(new XAttribute("InheritEnableDesktopComposition", false.ToString()));
+                element.Add(new XAttribute("InheritIcon", false.ToString()));
+                element.Add(new XAttribute("InheritPanel", false.ToString()));
+                element.Add(new XAttribute("InheritPort", false.ToString()));
+                element.Add(new XAttribute("InheritProtocol", false.ToString()));
+                element.Add(new XAttribute("InheritPuttySession", false.ToString()));
+                element.Add(new XAttribute("InheritRedirectDiskDrives", false.ToString()));
+                element.Add(new XAttribute("InheritRedirectKeys", false.ToString()));
+                element.Add(new XAttribute("InheritRedirectPorts", false.ToString()));
+                element.Add(new XAttribute("InheritRedirectPrinters", false.ToString()));
+                element.Add(new XAttribute("InheritRedirectSmartCards", false.ToString()));
+                element.Add(new XAttribute("InheritRedirectSound", false.ToString()));
+                element.Add(new XAttribute("InheritSoundQuality", false.ToString()));
+                element.Add(new XAttribute("InheritResolution", false.ToString()));
+                element.Add(new XAttribute("InheritAutomaticResize", false.ToString()));
+                element.Add(new XAttribute("InheritUseConsoleSession", false.ToString()));
+                element.Add(new XAttribute("InheritUseCredSsp", false.ToString()));
+                element.Add(new XAttribute("InheritRenderingEngine", false.ToString()));
+                element.Add(new XAttribute("InheritICAEncryptionStrength", false.ToString()));
+                element.Add(new XAttribute("InheritRDPAuthenticationLevel", false.ToString()));
+                element.Add(new XAttribute("InheritRDPMinutesToIdleTimeout", false.ToString()));
+                element.Add(new XAttribute("InheritLoadBalanceInfo", false.ToString()));
+                element.Add(new XAttribute("InheritPreExtApp", false.ToString()));
+                element.Add(new XAttribute("InheritPostExtApp", false.ToString()));
+                element.Add(new XAttribute("InheritMacAddress", false.ToString()));
+                element.Add(new XAttribute("InheritUserField", false.ToString()));
+                element.Add(new XAttribute("InheritExtApp", false.ToString()));
+                element.Add(new XAttribute("InheritVNCCompression", false.ToString()));
+                element.Add(new XAttribute("InheritVNCEncoding", false.ToString()));
+                element.Add(new XAttribute("InheritVNCAuthMode", false.ToString()));
+                element.Add(new XAttribute("InheritVNCProxyType", false.ToString()));
+                element.Add(new XAttribute("InheritVNCProxyIP", false.ToString()));
+                element.Add(new XAttribute("InheritVNCProxyPort", false.ToString()));
+                element.Add(new XAttribute("InheritVNCProxyUsername", false.ToString()));
+                element.Add(new XAttribute("InheritVNCProxyPassword", false.ToString()));
+                element.Add(new XAttribute("InheritVNCColors", false.ToString()));
+                element.Add(new XAttribute("InheritVNCSmartSizeMode", false.ToString()));
+                element.Add(new XAttribute("InheritVNCViewOnly", false.ToString()));
+                element.Add(new XAttribute("InheritRDGatewayUsageMethod", false.ToString()));
+                element.Add(new XAttribute("InheritRDGatewayHostname", false.ToString()));
+                element.Add(new XAttribute("InheritRDGatewayUseConnectionCredentials", false.ToString()));
+                element.Add(new XAttribute("InheritRDGatewayUsername", false.ToString()));
+                element.Add(new XAttribute("InheritRDGatewayPassword", false.ToString()));
+                element.Add(new XAttribute("InheritRDGatewayDomain", false.ToString()));
+            }
+        }
+    }
+}

--- a/mRemoteV1/Config/Serializers/XmlConnectionsDeserializer.cs
+++ b/mRemoteV1/Config/Serializers/XmlConnectionsDeserializer.cs
@@ -516,6 +516,12 @@ namespace mRemoteNG.Config.Serializers
                             Runtime.MessageCollector?.AddMessage(MessageClass.InformationMsg, string.Format(Language.strFindMatchingCredentialFailed, requestedCredentialId, connectionInfo.Name));
                     }
                 }
+
+                if (_confVersion >= 2.8)
+                {
+                    connectionInfo.HttpsTrustInsecureCerts = bool.Parse(xmlnode.Attributes["HttpsTrustInsecureCerts"]?.Value ?? "False");
+                    connectionInfo.Inheritance.HttpsTrustInsecureCerts = bool.Parse(xmlnode.Attributes["HttpsTrustInsecureCerts"].Value);
+                }
             }
             catch (Exception ex)
             {

--- a/mRemoteV1/Connection/AbstractConnectionRecord.cs
+++ b/mRemoteV1/Connection/AbstractConnectionRecord.cs
@@ -36,6 +36,7 @@ namespace mRemoteNG.Connection
         private bool _rdpAlertIdleTimeout;
         private string _loadBalanceInfo = "";
         private HTTPBase.RenderingEngine _renderingEngine;
+        private bool _trustInsecureCerts;
         private bool _useCredSsp;
 
         private ProtocolRDP.RDGatewayUsageMethod _rdGatewayUsageMethod;
@@ -266,6 +267,16 @@ namespace mRemoteNG.Connection
         {
             get { return GetPropertyValue("RenderingEngine", _renderingEngine); }
             set { SetField(ref _renderingEngine, value, "RenderingEngine"); }
+        }
+
+        [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 3),
+            LocalizedAttributes.LocalizedDisplayName("strPropertyNameHttpsTrustInsecureCerts"),
+            LocalizedAttributes.LocalizedDescription("strPropertyDescriptionHttpsTrustInsecureCerts"),
+            TypeConverter(typeof(MiscTools.YesNoTypeConverter))]
+        public bool HttpsTrustInsecureCerts
+        {
+            get { return GetPropertyValue("HttpsTrustInsecureCerts", _trustInsecureCerts); }
+            set { SetField(ref _trustInsecureCerts, value, "HttpsTrustInsecureCerts"); }
         }
 
         [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 3),
@@ -665,7 +676,8 @@ namespace mRemoteNG.Connection
             PropertyChanged?.Invoke(sender, new PropertyChangedEventArgs(args.PropertyName));
         }
 
-        protected bool SetField<T>(ref T field, T value, string propertyName = null)
+        // ReSharper disable once UnusedMethodReturnValue.Local
+        private bool SetField<T>(ref T field, T value, string propertyName = null)
         {
             if (EqualityComparer<T>.Default.Equals(field, value)) return false;
             field = value;

--- a/mRemoteV1/Connection/ConnectionInfo.cs
+++ b/mRemoteV1/Connection/ConnectionInfo.cs
@@ -196,6 +196,7 @@ namespace mRemoteNG.Connection
 		{
 			try
 			{
+			    // ReSharper disable once SwitchStatementMissingSomeCases
                 switch (protocol)
                 {
                     case ProtocolType.RDP:
@@ -256,6 +257,7 @@ namespace mRemoteNG.Connection
             RDPAlertIdleTimeout = Settings.Default.ConDefaultRDPAlertIdleTimeout;
             LoadBalanceInfo = Settings.Default.ConDefaultLoadBalanceInfo;
             RenderingEngine = (HTTPBase.RenderingEngine) Enum.Parse(typeof(HTTPBase.RenderingEngine), Settings.Default.ConDefaultRenderingEngine);
+            HttpsTrustInsecureCerts = false;
             UseCredSsp = Settings.Default.ConDefaultUseCredSsp;
         }
 

--- a/mRemoteV1/Connection/ConnectionInfoInheritance.cs
+++ b/mRemoteV1/Connection/ConnectionInfoInheritance.cs
@@ -116,8 +116,14 @@ namespace mRemoteNG.Connection
 		LocalizedAttributes.LocalizedDisplayNameInheritAttribute("strPropertyNameRenderingEngine"), 
 		LocalizedAttributes.LocalizedDescriptionInheritAttribute("strPropertyDescriptionRenderingEngine"), 
 		TypeConverter(typeof(MiscTools.YesNoTypeConverter))]public bool RenderingEngine {get; set;}
-				
-		[LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 4), 
+
+        [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 4),
+            LocalizedAttributes.LocalizedDisplayName("strPropertyNameHttpsTrustInsecureCerts"),
+            LocalizedAttributes.LocalizedDescription("strPropertyDescriptionHttpsTrustInsecureCerts"),
+            TypeConverter(typeof(MiscTools.YesNoTypeConverter))]
+        public bool HttpsTrustInsecureCerts { get; set; }
+
+        [LocalizedAttributes.LocalizedCategory("strCategoryProtocol", 4), 
 		LocalizedAttributes.LocalizedDisplayNameInheritAttribute("strPropertyNameUseConsoleSession"), 
 		LocalizedAttributes.LocalizedDescriptionInheritAttribute("strPropertyDescriptionUseConsoleSession"), 
 		TypeConverter(typeof(MiscTools.YesNoTypeConverter))]public bool UseConsoleSession {get; set;}

--- a/mRemoteV1/Connection/Protocol/Http/Connection.Protocol.HTTP.cs
+++ b/mRemoteV1/Connection/Protocol/Http/Connection.Protocol.HTTP.cs
@@ -6,8 +6,8 @@ namespace mRemoteNG.Connection.Protocol.Http
 		public ProtocolHTTP(RenderingEngine RenderingEngine) : base(RenderingEngine)
 		{
 		}
-				
-		public override void NewExtended()
+
+	    protected override void NewExtended()
 		{
 			base.NewExtended();
 					

--- a/mRemoteV1/Connection/Protocol/Http/Connection.Protocol.HTTPS.cs
+++ b/mRemoteV1/Connection/Protocol/Http/Connection.Protocol.HTTPS.cs
@@ -6,8 +6,8 @@ namespace mRemoteNG.Connection.Protocol.Http
 		public ProtocolHTTPS(RenderingEngine RenderingEngine) : base(RenderingEngine)
 		{
 		}
-				
-		public override void NewExtended()
+
+	    protected override void NewExtended()
 		{
 			base.NewExtended();
 			httpOrS = "https";

--- a/mRemoteV1/Properties/Settings.Designer.cs
+++ b/mRemoteV1/Properties/Settings.Designer.cs
@@ -2530,5 +2530,17 @@ namespace mRemoteNG {
                 this["LogToApplicationDirectory"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool InhDefaultHttpsTrustInsecureCerts {
+            get {
+                return ((bool)(this["InhDefaultHttpsTrustInsecureCerts"]));
+            }
+            set {
+                this["InhDefaultHttpsTrustInsecureCerts"] = value;
+            }
+        }
     }
 }

--- a/mRemoteV1/Properties/Settings.settings
+++ b/mRemoteV1/Properties/Settings.settings
@@ -629,5 +629,8 @@
     <Setting Name="LogToApplicationDirectory" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="InhDefaultHttpsTrustInsecureCerts" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/mRemoteV1/Resources/Language/Language.Designer.cs
+++ b/mRemoteV1/Resources/Language/Language.Designer.cs
@@ -4199,6 +4199,15 @@ namespace mRemoteNG {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Trust Invalid HTTPS Certificates (Gecko Only).
+        /// </summary>
+        internal static string strPropertyDescriptionHttpsTrustInsecureCerts {
+            get {
+                return ResourceManager.GetString("strPropertyDescriptionHttpsTrustInsecureCerts", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Choose a icon that will be displayed when connected to the host..
         /// </summary>
         internal static string strPropertyDescriptionIcon {
@@ -4690,6 +4699,15 @@ namespace mRemoteNG {
         internal static string strPropertyNameExternalToolBefore {
             get {
                 return ResourceManager.GetString("strPropertyNameExternalToolBefore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Trust Invalid HTTPS Certificates (Gecko Only).
+        /// </summary>
+        internal static string strPropertyNameHttpsTrustInsecureCerts {
+            get {
+                return ResourceManager.GetString("strPropertyNameHttpsTrustInsecureCerts", resourceCulture);
             }
         }
         

--- a/mRemoteV1/Resources/Language/Language.resx
+++ b/mRemoteV1/Resources/Language/Language.resx
@@ -2508,4 +2508,10 @@ mRemoteNG will now quit and begin with the installation.</value>
   <data name="strAssignedCredential" xml:space="preserve">
     <value>Assigned Credential</value>
   </data>
+  <data name="strPropertyDescriptionHttpsTrustInsecureCerts" xml:space="preserve">
+    <value>Trust Invalid HTTPS Certificates (Gecko Only)</value>
+  </data>
+  <data name="strPropertyNameHttpsTrustInsecureCerts" xml:space="preserve">
+    <value>Trust Invalid HTTPS Certificates (Gecko Only)</value>
+  </data>
 </root>

--- a/mRemoteV1/UI/Window/ConfigWindow.cs
+++ b/mRemoteV1/UI/Window/ConfigWindow.cs
@@ -15,6 +15,7 @@ using System.Net.NetworkInformation;
 using System.Threading;
 using System.Windows.Forms;
 using mRemoteNG.Connection.Protocol;
+using mRemoteNG.Connection.Protocol.Http;
 using mRemoteNG.Container;
 using mRemoteNG.Security;
 using mRemoteNG.Themes;
@@ -204,7 +205,8 @@ namespace mRemoteNG.UI.Window
 		}
 		
         #region Public Properties
-        public bool PropertiesVisible
+
+	    private bool PropertiesVisible
 		{
 			get
 			{
@@ -219,8 +221,8 @@ namespace mRemoteNG.UI.Window
 			    _btnShowDefaultProperties.Checked = false;
 			}
 		}
-		
-        public bool InheritanceVisible
+
+	    private bool InheritanceVisible
 		{
 			get
 			{
@@ -235,8 +237,8 @@ namespace mRemoteNG.UI.Window
 			    _btnShowDefaultProperties.Checked = false;
 			}
 		}
-		
-        public bool DefaultPropertiesVisible
+
+	    private bool DefaultPropertiesVisible
 		{
 			get
 			{
@@ -251,8 +253,8 @@ namespace mRemoteNG.UI.Window
 			    _btnShowInheritance.Checked = false;
 			}
 		}
-		
-        public bool DefaultInheritanceVisible
+
+	    private bool DefaultInheritanceVisible
 		{
 			get { return _btnShowDefaultInheritance.Checked; }
 			set
@@ -813,6 +815,7 @@ namespace mRemoteNG.UI.Window
                     strHide.Add("RedirectSmartCards");
                     strHide.Add("RedirectSound");
                     strHide.Add("RenderingEngine");
+                    strHide.Add("HttpsTrustInsecureCerts");
                     strHide.Add("Resolution");
                     strHide.Add("AutomaticResize");
                     strHide.Add("UseConsoleSession");
@@ -854,7 +857,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("ICAEncryptionStrength");
 							strHide.Add("PuttySession");
 							strHide.Add("RenderingEngine");
-							strHide.Add("VNCAuthMode");
+                            strHide.Add("HttpsTrustInsecureCerts");
+                            strHide.Add("VNCAuthMode");
 							strHide.Add("VNCColors");
 							strHide.Add("VNCCompression");
 							strHide.Add("VNCEncoding");
@@ -919,7 +923,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
-							strHide.Add("Resolution");
+                            strHide.Add("HttpsTrustInsecureCerts");
+                            strHide.Add("Resolution");
 							strHide.Add("AutomaticResize");
 							strHide.Add("UseConsoleSession");
 							strHide.Add("UseCredSsp");
@@ -964,7 +969,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
-							strHide.Add("Resolution");
+                            strHide.Add("HttpsTrustInsecureCerts");
+                            strHide.Add("Resolution");
 							strHide.Add("AutomaticResize");
 							strHide.Add("UseConsoleSession");
 							strHide.Add("UseCredSsp");
@@ -1008,7 +1014,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
-							strHide.Add("Resolution");
+                            strHide.Add("HttpsTrustInsecureCerts");
+                            strHide.Add("Resolution");
 							strHide.Add("AutomaticResize");
 							strHide.Add("UseConsoleSession");
 							strHide.Add("UseCredSsp");
@@ -1053,7 +1060,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
-							strHide.Add("Resolution");
+                            strHide.Add("HttpsTrustInsecureCerts");
+                            strHide.Add("Resolution");
 							strHide.Add("AutomaticResize");
 							strHide.Add("UseConsoleSession");
 							strHide.Add("UseCredSsp");
@@ -1099,7 +1107,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
-							strHide.Add("Resolution");
+                            strHide.Add("HttpsTrustInsecureCerts");
+                            strHide.Add("Resolution");
 							strHide.Add("AutomaticResize");
 							strHide.Add("UseConsoleSession");
 							strHide.Add("UseCredSsp");
@@ -1145,7 +1154,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
-							strHide.Add("Resolution");
+                            strHide.Add("HttpsTrustInsecureCerts");
+                            strHide.Add("Resolution");
 							strHide.Add("AutomaticResize");
 							strHide.Add("UseConsoleSession");
 							strHide.Add("UseCredSsp");
@@ -1249,6 +1259,10 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("VNCSmartSizeMode");
 							strHide.Add("VNCViewOnly");
                             strHide.Add("SoundQuality");
+
+                            if(conI.RenderingEngine == HTTPBase.RenderingEngine.IE)
+                                strHide.Add("HttpsTrustInsecureCerts");
+
                             break;
 						case ProtocolType.ICA:
 							strHide.Add("DisplayThemes");
@@ -1275,7 +1289,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
-							strHide.Add("AutomaticResize");
+                            strHide.Add("HttpsTrustInsecureCerts");
+                            strHide.Add("AutomaticResize");
 							strHide.Add("UseConsoleSession");
 							strHide.Add("UseCredSsp");
 							strHide.Add("VNCAuthMode");
@@ -1318,7 +1333,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
-							strHide.Add("Resolution");
+                            strHide.Add("HttpsTrustInsecureCerts");
+                            strHide.Add("Resolution");
 							strHide.Add("AutomaticResize");
 							strHide.Add("UseConsoleSession");
 							strHide.Add("UseCredSsp");
@@ -1387,6 +1403,8 @@ namespace mRemoteNG.UI.Window
                             strHide.Add("UseCredSsp");
                         if (conI.Inheritance.RenderingEngine)
                             strHide.Add("RenderingEngine");
+                        if (conI.Inheritance.HttpsTrustInsecureCerts)
+                            strHide.Add("HttpsTrustInsecureCerts");
                         if (conI.Inheritance.ICAEncryptionStrength)
                             strHide.Add("ICAEncryptionStrength");
                         if (conI.Inheritance.RDPAuthenticationLevel)

--- a/mRemoteV1/app.config
+++ b/mRemoteV1/app.config
@@ -649,6 +649,9 @@
       <setting name="LogToApplicationDirectory" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="InhDefaultHttpsTrustInsecureCerts" serializeAs="String">
+        <value>False</value>
+      </setting>
     </mRemoteNG.Settings>
   </userSettings>
   <applicationSettings>

--- a/mRemoteV1/mRemoteV1.csproj
+++ b/mRemoteV1/mRemoteV1.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Config\Serializers\RemoteDesktopConnectionManagerDeserializer.cs" />
     <Compile Include="Config\DataProviders\FileDataProviderWithBackup.cs" />
     <Compile Include="Config\Serializers\XmlConnectionNodeSerializer26.cs" />
+    <Compile Include="Config\Serializers\XmlConnectionNodeSerializer28.cs" />
     <Compile Include="Config\Serializers\XmlConnectionsDecryptor.cs" />
     <Compile Include="Config\Connections\ConnectionsLoader.cs" />
     <Compile Include="Config\Connections\ConnectionsSaver.cs" />


### PR DESCRIPTION
Possible fix for #195. At least initial fix. This does work and is straightforward. 

I could potentially put a prompt in the event handler in Connection.Protocol.HTTPBase.cs... But I think that would be massively annoying. 

Check this out to make sure that I didn't mess up any of the config related stuff...