### PR TITLE
Added a BeginEdit() at the end of the AddNode function.

### DIFF
--- a/mRemoteV1/UI/Controls/ConnectionTree/ConnectionTree.cs
+++ b/mRemoteV1/UI/Controls/ConnectionTree/ConnectionTree.cs
@@ -210,6 +210,7 @@ namespace mRemoteNG.UI.Controls
             Expand(parent);
             SelectObject(newNode, true);
             EnsureModelVisible(newNode);
+            this.SelectedItem.BeginEdit();
         }
 
         public void DuplicateSelectedNode()


### PR DESCRIPTION
Resolves issue #479.  When right clicking Connections => New Node or New Folder the new item should start in editing mode so that it can be named immediately without additional clicks. 