### PR TITLE
Credential manager upgrade crash

### DIFF
--- a/mRemoteV1/Config/Serializers/Versioning/XmlCredentialManagerUpgrader.cs
+++ b/mRemoteV1/Config/Serializers/Versioning/XmlCredentialManagerUpgrader.cs
@@ -11,6 +11,7 @@ using mRemoteNG.Security.Authentication;
 using mRemoteNG.Security.Factories;
 using mRemoteNG.Tools;
 using mRemoteNG.Tree;
+using System.Globalization;
 
 namespace mRemoteNG.Config.Serializers.Versioning
 {
@@ -57,10 +58,20 @@ namespace mRemoteNG.Config.Serializers.Versioning
             return xdoc;
         }
 
+        public static decimal? GetVersionFromConfiguration(XDocument xdoc)
+        {
+            var versionString = xdoc.Root?.Attribute("ConfVersion")?.Value;
+            return versionString != null
+                ? (decimal?)decimal.Parse(versionString, CultureInfo.InvariantCulture)
+                : null;
+        }
+
         public Dictionary<Guid, ICredentialRecord> UpgradeUserFilesForCredentialManager(XDocument xdoc)
         {
-            if (double.Parse(xdoc.Root?.Attribute("ConfVersion")?.Value ?? "0") >= 2.7)
+            if ((GetVersionFromConfiguration(xdoc) ?? 0) >= 2.7m)
+            {
                 return null;
+            }
 
             var cryptoProvider = new CryptoProviderFactoryFromXml(xdoc.Root).Build();
             var encryptedValue = xdoc.Root?.Attribute("Protected")?.Value;

--- a/mRemoteV1/UI/Forms/CredentialManagerUpgradeForm.cs
+++ b/mRemoteV1/UI/Forms/CredentialManagerUpgradeForm.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using System.Windows.Forms;
 using System.Xml.Linq;
 using mRemoteNG.App;
@@ -57,8 +56,7 @@ namespace mRemoteNG.UI.Forms
 
         private bool WeCanUpgradeFromThisVersion(XDocument xdoc)
         {
-            var versionString = xdoc.Root?.Attribute("ConfVersion")?.Value ?? "999";
-            return double.Parse(versionString, CultureInfo.InvariantCulture) < 2.8;
+            return XmlCredentialManagerUpgrader.GetVersionFromConfiguration(xdoc) < 2.8m;
         }
 
         private void ApplyLanguage()

--- a/mRemoteV1/UI/Forms/CredentialManagerUpgradeForm.cs
+++ b/mRemoteV1/UI/Forms/CredentialManagerUpgradeForm.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Windows.Forms;
 using System.Xml.Linq;
 using mRemoteNG.App;
@@ -56,7 +57,8 @@ namespace mRemoteNG.UI.Forms
 
         private bool WeCanUpgradeFromThisVersion(XDocument xdoc)
         {
-            return double.Parse(xdoc.Root?.Attribute("ConfVersion")?.Value ?? "999") < 2.8;
+            var versionString = xdoc.Root?.Attribute("ConfVersion")?.Value ?? "999";
+            return double.Parse(versionString, CultureInfo.InvariantCulture) < 2.8;
         }
 
         private void ApplyLanguage()


### PR DESCRIPTION
The configuration version was parsed in the credential manager upgrade
process using the current user culture and crashed on cultures where '.'
isn't the decimal separator.