### PR TITLE
Added extra logic to search the hostname and description fields of the connection instead of just the name.

### DIFF
--- a/mRemoteNGTests/Tree/NodeSearcherTests.cs
+++ b/mRemoteNGTests/Tree/NodeSearcherTests.cs
@@ -48,7 +48,7 @@ namespace mRemoteNGTests.Tree
         }
 
         [Test]
-        public void SearchByHostnameReturnsAllExpectedMatches()
+        public void SearchByHostname1ReturnsAllExpectedMatches()
         {
             var matches = _nodeSearcher.SearchByName("hostname1");
             Assert.That(matches.ToList(), Is.EquivalentTo(new[] { _folder1 }));

--- a/mRemoteNGTests/Tree/NodeSearcherTests.cs
+++ b/mRemoteNGTests/Tree/NodeSearcherTests.cs
@@ -34,6 +34,27 @@ namespace mRemoteNGTests.Tree
         }
 
         [Test]
+        public void SearchByDescriptionReturnsAllExpectedMatches()
+        {
+            var matches = _nodeSearcher.SearchByName("description");
+            Assert.That(matches.ToList(), Is.EquivalentTo(new[] { _folder1, _folder2, _con1, _con2, _con3, _con4, _con5 }));
+        }
+
+        [Test]
+        public void SearchByDescription1ReturnsAllExpectedMatches()
+        {
+            var matches = _nodeSearcher.SearchByName("description1");
+            Assert.That(matches.ToList(), Is.EquivalentTo(new[] { _folder1 }));
+        }
+
+        [Test]
+        public void SearchByHostnameReturnsAllExpectedMatches()
+        {
+            var matches = _nodeSearcher.SearchByName("hostname1");
+            Assert.That(matches.ToList(), Is.EquivalentTo(new[] { _folder1 }));
+        }
+
+        [Test]
         public void NextMatchAdvancesTheIterator()
         {
             _nodeSearcher.SearchByName("folder");
@@ -64,24 +85,24 @@ namespace mRemoteNGTests.Tree
             /*
              * Tree:
              * Root
-             * |--- folder1
-             * |    |--- con1
-             * |    L--- con2
-             * |--- folder2
-             * |    |--- con3
-             * |    L--- con4
-             * L--- con5
+             * |--- folder1 (description1, hostname1)
+             * |    |--- con1 (description2, hostname2)
+             * |    L--- con2 (description3, hostname3)
+             * |--- folder2 (description4, hostname4)
+             * |    |--- con3 (description5, hostname5)
+             * |    L--- con4 (description6, hostname6)
+             * L--- con5 (description7, hostname7)
              * 
              */
             var connectionTreeModel = new ConnectionTreeModel();
             var root = new RootNodeInfo(RootNodeType.Connection);
-            _folder1 = new ContainerInfo { Name = "folder1"};
-            _con1 = new ConnectionInfo { Name = "con1"};
-            _con2 = new ConnectionInfo { Name = "con2"};
-            _folder2 = new ContainerInfo { Name = "folder2" };
-            _con3 = new ConnectionInfo { Name = "con3" };
-            _con4 = new ConnectionInfo { Name = "con4" };
-            _con5 = new ConnectionInfo { Name = "con5" };
+            _folder1 = new ContainerInfo { Name = "folder1", Description = "description1", Hostname = "hostname1" };
+            _con1 = new ConnectionInfo { Name = "con1", Description="description2", Hostname="hostname2" };
+            _con2 = new ConnectionInfo { Name = "con2", Description="description3", Hostname="hostname3" };
+            _folder2 = new ContainerInfo { Name = "folder2", Description="description4", Hostname="hostname4" };
+            _con3 = new ConnectionInfo { Name = "con3", Description="description5", Hostname="hostname5" };
+            _con4 = new ConnectionInfo { Name = "con4", Description="description6", Hostname="hostname6" };
+            _con5 = new ConnectionInfo { Name = "con5", Description="description7", Hostname="hostname7" };
 
             connectionTreeModel.AddRootNode(root);
             root.AddChildRange(new [] { _folder1, _folder2, _con5 });

--- a/mRemoteV1/Tree/NodeSearcher.cs
+++ b/mRemoteV1/Tree/NodeSearcher.cs
@@ -23,11 +23,12 @@ namespace mRemoteNG.Tree
             ResetMatches();
             if (searchText == "") return Matches;
             var nodes = (List<ConnectionInfo>)_connectionTreeModel.GetRecursiveChildList();
+            var searchTextLower = searchText.ToLowerInvariant();
             foreach (var node in nodes)
             {
-                if (node.Name.ToLowerInvariant().Contains(searchText.ToLowerInvariant()) ||
-                    node.Description.ToLowerInvariant().Contains(searchText.ToLowerInvariant()) ||
-                    node.Hostname.ToLowerInvariant().Contains(searchText.ToLowerInvariant()))
+                if (node.Name.ToLowerInvariant().Contains(searchTextLower) ||
+                    node.Description.ToLowerInvariant().Contains(searchTextLower) ||
+                    node.Hostname.ToLowerInvariant().Contains(searchTextLower))
                     Matches.Add(node);
             }
             if (Matches.Count > 0)

--- a/mRemoteV1/Tree/NodeSearcher.cs
+++ b/mRemoteV1/Tree/NodeSearcher.cs
@@ -25,7 +25,9 @@ namespace mRemoteNG.Tree
             var nodes = (List<ConnectionInfo>)_connectionTreeModel.GetRecursiveChildList();
             foreach (var node in nodes)
             {
-                if (node.Name.ToLowerInvariant().Contains(searchText.ToLowerInvariant()))
+                if (node.Name.ToLowerInvariant().Contains(searchText.ToLowerInvariant()) ||
+                    node.Description.ToLowerInvariant().Contains(searchText.ToLowerInvariant()) ||
+                    node.Hostname.ToLowerInvariant().Contains(searchText.ToLowerInvariant()))
                     Matches.Add(node);
             }
             if (Matches.Count > 0)


### PR DESCRIPTION
This pull request is to cover the below feature request:

https://github.com/mRemoteNG/mRemoteNG/issues/184

Minor changes to search the hostname and description field of the connection, instead of just the connection name.

Also added the following three tests:

SearchByDescriptionReturnsAllExpectedMatches
SearchByDescription1ReturnsAllExpectedMatches
SearchByHostnameReturnsAllExpectedMatches

All tests passed after the changes.

Please also note the search performance might be slow due to tree not being indexed but I think it should be sufficient.