### PR TITLE
Prevented log file creation when writeLogFile option is not set

### DIFF
--- a/mRemoteV1/App/Logger.cs
+++ b/mRemoteV1/App/Logger.cs
@@ -45,6 +45,9 @@ namespace mRemoteNG.App
 
         private static string BuildLogFilePath()
         {
+            if (!Settings.Default.WriteLogFile)
+                return "";
+
 #if !PORTABLE
 			var logFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), Application.ProductName);
 #else


### PR DESCRIPTION
Under Options -> Advanced, the option Write log file (mRemoteNG.log) is simply ignored when attempting to create the file.

Setting the log file path to null seems to work as intended. But it requires a program restart, maybe a warning for that?

Reported in [issue #536](https://github.com/mRemoteNG/mRemoteNG/issues/536).