### PR TITLE
Fix proposal for issue 'Can not add new connection or new folder'

### DIFF
--- a/mRemoteV1/UI/Controls/ConnectionTree/ConnectionTree.cs
+++ b/mRemoteV1/UI/Controls/ConnectionTree/ConnectionTree.cs
@@ -204,11 +204,12 @@ namespace mRemoteNG.UI.Controls
 
         private void AddNode(ConnectionInfo newNode)
         {
-            if (SelectedNode == null) return;
+            // use root node if no node is selected
+            ConnectionInfo parentNode = (SelectedNode == null) ? Roots.Cast<ConnectionInfo>().First(item => item is RootNodeInfo) : SelectedNode;
             DefaultConnectionInfo.Instance.SaveTo(newNode);
             DefaultConnectionInheritance.Instance.SaveTo(newNode.Inheritance);
-            var selectedContainer = SelectedNode as ContainerInfo;
-            var parent = selectedContainer ?? SelectedNode?.Parent;
+            var selectedContainer = parentNode as ContainerInfo;
+            var parent = selectedContainer ?? parentNode?.Parent;
             newNode.SetParent(parent);
             Expand(parent);
             SelectObject(newNode, true);


### PR DESCRIPTION
This is reported in [issue#665](https://github.com/mRemoteNG/mRemoteNG/issues/665) and is actually weird just returning, and leaving the user to guess what happened.

My proposal is just to create on the root node if no node was selected; KeePass does the same, I don't find very friendly, but my is its better than doing literally nothing.

There you go, if anyone has a more user friendly solution I'll go for it.