### PR TITLE
[RFC] Added support for custom working directory in External Tool

### DIFF
--- a/mRemoteV1/Config/Settings/ExternalAppsLoader.cs
+++ b/mRemoteV1/Config/Settings/ExternalAppsLoader.cs
@@ -59,6 +59,10 @@ namespace mRemoteNG.Config.Settings
                     Arguments = xEl.Attributes["Arguments"].Value
                 };
 
+                // check before, since old save files won't have this set
+                if (xEl.HasAttribute("WorkingDir"))
+                    extA.WorkingDir = xEl.Attributes["WorkingDir"].Value;
+
                 if (xEl.HasAttribute("WaitForExit"))
                 {
                     extA.WaitForExit = bool.Parse(xEl.Attributes["WaitForExit"].Value);

--- a/mRemoteV1/Config/Settings/ExternalAppsLoader.cs
+++ b/mRemoteV1/Config/Settings/ExternalAppsLoader.cs
@@ -62,6 +62,8 @@ namespace mRemoteNG.Config.Settings
                 // check before, since old save files won't have this set
                 if (xEl.HasAttribute("WorkingDir"))
                     extA.WorkingDir = xEl.Attributes["WorkingDir"].Value;
+                if (xEl.HasAttribute("RunElevated"))
+                    extA.RunElevated = bool.Parse(xEl.Attributes["RunElevated"].Value);
 
                 if (xEl.HasAttribute("WaitForExit"))
                 {

--- a/mRemoteV1/Config/Settings/SettingsSaver.cs
+++ b/mRemoteV1/Config/Settings/SettingsSaver.cs
@@ -122,6 +122,7 @@ namespace mRemoteNG.Config.Settings
                     xmlTextWriter.WriteAttributeString("WorkingDir", "", extA.WorkingDir);
                     xmlTextWriter.WriteAttributeString("WaitForExit", "", Convert.ToString(extA.WaitForExit));
                     xmlTextWriter.WriteAttributeString("TryToIntegrate", "", Convert.ToString(extA.TryIntegrate));
+                    xmlTextWriter.WriteAttributeString("RunElevated", "", Convert.ToString(extA.RunElevated));
                     xmlTextWriter.WriteEndElement();
                 }
 

--- a/mRemoteV1/Config/Settings/SettingsSaver.cs
+++ b/mRemoteV1/Config/Settings/SettingsSaver.cs
@@ -119,6 +119,7 @@ namespace mRemoteNG.Config.Settings
                     xmlTextWriter.WriteAttributeString("DisplayName", "", extA.DisplayName);
                     xmlTextWriter.WriteAttributeString("FileName", "", extA.FileName);
                     xmlTextWriter.WriteAttributeString("Arguments", "", extA.Arguments);
+                    xmlTextWriter.WriteAttributeString("WorkingDir", "", extA.WorkingDir);
                     xmlTextWriter.WriteAttributeString("WaitForExit", "", Convert.ToString(extA.WaitForExit));
                     xmlTextWriter.WriteAttributeString("TryToIntegrate", "", Convert.ToString(extA.TryIntegrate));
                     xmlTextWriter.WriteEndElement();

--- a/mRemoteV1/Tools/ExternalTool.cs
+++ b/mRemoteV1/Tools/ExternalTool.cs
@@ -19,6 +19,7 @@ namespace mRemoteNG.Tools
 		public string Arguments { get; set; }
         public string WorkingDir { get; set; }
 		public bool TryIntegrate { get; set; }
+        public bool RunElevated { get; set; }
         public ConnectionInfo ConnectionInfo { get; set; }
 		
         public Icon Icon => File.Exists(FileName) ? MiscTools.GetIconFromFile(FileName) : Resources.mRemote_Icon;
@@ -27,12 +28,13 @@ namespace mRemoteNG.Tools
 
 	    #endregion
 		
-		public ExternalTool(string displayName = "", string fileName = "", string arguments = "", string workingDir = "")
+		public ExternalTool(string displayName = "", string fileName = "", string arguments = "", string workingDir = "", bool runElevated = false)
 		{
 			DisplayName = displayName;
 			FileName = fileName;
 			Arguments = arguments;
             WorkingDir = workingDir;
+            RunElevated = runElevated;
 		}
 
         public void Start(ConnectionInfo startConnectionInfo = null)
@@ -77,6 +79,7 @@ namespace mRemoteNG.Tools
             process.StartInfo.FileName = argParser.ParseArguments(FileName);
             process.StartInfo.Arguments = argParser.ParseArguments(Arguments);
             if (WorkingDir != "") process.StartInfo.WorkingDirectory = argParser.ParseArguments(WorkingDir);
+            if (RunElevated) process.StartInfo.Verb = "runas";
         }
 
         private void StartIntegrated()

--- a/mRemoteV1/Tools/ExternalTool.cs
+++ b/mRemoteV1/Tools/ExternalTool.cs
@@ -17,6 +17,7 @@ namespace mRemoteNG.Tools
 		public string FileName { get; set; }
 		public bool WaitForExit { get; set; }
 		public string Arguments { get; set; }
+        public string WorkingDir { get; set; }
 		public bool TryIntegrate { get; set; }
         public ConnectionInfo ConnectionInfo { get; set; }
 		
@@ -26,11 +27,12 @@ namespace mRemoteNG.Tools
 
 	    #endregion
 		
-		public ExternalTool(string displayName = "", string fileName = "", string arguments = "")
+		public ExternalTool(string displayName = "", string fileName = "", string arguments = "", string workingDir = "")
 		{
 			DisplayName = displayName;
 			FileName = fileName;
 			Arguments = arguments;
+            WorkingDir = workingDir;
 		}
 
         public void Start(ConnectionInfo startConnectionInfo = null)
@@ -74,6 +76,7 @@ namespace mRemoteNG.Tools
             process.StartInfo.UseShellExecute = true;
             process.StartInfo.FileName = argParser.ParseArguments(FileName);
             process.StartInfo.Arguments = argParser.ParseArguments(Arguments);
+            if (WorkingDir != "") process.StartInfo.WorkingDirectory = argParser.ParseArguments(WorkingDir);
         }
 
         private void StartIntegrated()

--- a/mRemoteV1/UI/Window/ExternalToolsWindow.Designer.cs
+++ b/mRemoteV1/UI/Window/ExternalToolsWindow.Designer.cs
@@ -44,6 +44,7 @@ namespace mRemoteNG.UI.Window
             this.ToolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.LaunchToolMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.PropertiesGroupBox = new System.Windows.Forms.GroupBox();
+            this.BrowseWorkingDir = new System.Windows.Forms.Button();
             this.WorkingDirLabel = new System.Windows.Forms.Label();
             this.WorkingDirTextBox = new System.Windows.Forms.TextBox();
             this.TryToIntegrateCheckBox = new System.Windows.Forms.CheckBox();
@@ -173,6 +174,7 @@ namespace mRemoteNG.UI.Window
             // 
             this.PropertiesGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.PropertiesGroupBox.Controls.Add(this.BrowseWorkingDir);
             this.PropertiesGroupBox.Controls.Add(this.WorkingDirLabel);
             this.PropertiesGroupBox.Controls.Add(this.WorkingDirTextBox);
             this.PropertiesGroupBox.Controls.Add(this.TryToIntegrateCheckBox);
@@ -193,6 +195,17 @@ namespace mRemoteNG.UI.Window
             this.PropertiesGroupBox.TabStop = false;
             this.PropertiesGroupBox.Text = "External Tool Properties";
             // 
+            // BrowseWorkingDir
+            // 
+            this.BrowseWorkingDir.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.BrowseWorkingDir.Location = new System.Drawing.Point(574, 103);
+            this.BrowseWorkingDir.Name = "BrowseWorkingDir";
+            this.BrowseWorkingDir.Size = new System.Drawing.Size(95, 23);
+            this.BrowseWorkingDir.TabIndex = 12;
+            this.BrowseWorkingDir.Text = "Browse...";
+            this.BrowseWorkingDir.UseVisualStyleBackColor = true;
+            this.BrowseWorkingDir.Click += new System.EventHandler(this.BrowseWorkingDir_Click);
+            // 
             // WorkingDirLabel
             // 
             this.WorkingDirLabel.AutoSize = true;
@@ -209,7 +222,7 @@ namespace mRemoteNG.UI.Window
             | System.Windows.Forms.AnchorStyles.Right)));
             this.WorkingDirTextBox.Location = new System.Drawing.Point(126, 104);
             this.WorkingDirTextBox.Name = "WorkingDirTextBox";
-            this.WorkingDirTextBox.Size = new System.Drawing.Size(543, 22);
+            this.WorkingDirTextBox.Size = new System.Drawing.Size(442, 22);
             this.WorkingDirTextBox.TabIndex = 10;
             this.WorkingDirTextBox.Leave += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
             // 
@@ -420,5 +433,6 @@ namespace mRemoteNG.UI.Window
         internal System.Windows.Forms.ColumnHeader WorkingDirColumnHeader;
         internal System.Windows.Forms.Label WorkingDirLabel;
         internal System.Windows.Forms.TextBox WorkingDirTextBox;
+        internal System.Windows.Forms.Button BrowseWorkingDir;
     }
 }

--- a/mRemoteV1/UI/Window/ExternalToolsWindow.Designer.cs
+++ b/mRemoteV1/UI/Window/ExternalToolsWindow.Designer.cs
@@ -63,6 +63,8 @@ namespace mRemoteNG.UI.Window
             this.DeleteToolToolstripButton = new System.Windows.Forms.ToolStripButton();
             this.ToolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.LaunchToolToolstripButton = new System.Windows.Forms.ToolStripButton();
+            this.RunElevatedCheckBox = new System.Windows.Forms.CheckBox();
+            this.RunElevateHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ToolsContextMenuStrip.SuspendLayout();
             this.PropertiesGroupBox.SuspendLayout();
             this.ToolStripContainer.ContentPanel.SuspendLayout();
@@ -83,7 +85,8 @@ namespace mRemoteNG.UI.Window
             this.ArgumentsColumnHeader,
             this.WorkingDirColumnHeader,
             this.WaitForExitColumnHeader,
-            this.TryToIntegrateColumnHeader});
+            this.TryToIntegrateColumnHeader,
+            this.RunElevateHeader});
             this.ToolsListView.ContextMenuStrip = this.ToolsContextMenuStrip;
             this.ToolsListView.FullRowSelect = true;
             this.ToolsListView.GridLines = true;
@@ -174,6 +177,7 @@ namespace mRemoteNG.UI.Window
             // 
             this.PropertiesGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.PropertiesGroupBox.Controls.Add(this.RunElevatedCheckBox);
             this.PropertiesGroupBox.Controls.Add(this.BrowseWorkingDir);
             this.PropertiesGroupBox.Controls.Add(this.WorkingDirLabel);
             this.PropertiesGroupBox.Controls.Add(this.WorkingDirTextBox);
@@ -397,6 +401,21 @@ namespace mRemoteNG.UI.Window
             this.LaunchToolToolstripButton.Text = "Launch";
             this.LaunchToolToolstripButton.Click += new System.EventHandler(this.LaunchTool_Click);
             // 
+            // RunElevatedCheckBox
+            // 
+            this.RunElevatedCheckBox.AutoSize = true;
+            this.RunElevatedCheckBox.Location = new System.Drawing.Point(330, 135);
+            this.RunElevatedCheckBox.Name = "RunElevatedCheckBox";
+            this.RunElevatedCheckBox.Size = new System.Drawing.Size(93, 17);
+            this.RunElevatedCheckBox.TabIndex = 13;
+            this.RunElevatedCheckBox.Text = "Run Elevated";
+            this.RunElevatedCheckBox.UseVisualStyleBackColor = true;
+            this.RunElevatedCheckBox.Click += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
+            // 
+            // RunElevateHeader
+            // 
+            this.RunElevateHeader.Text = "Run Elevated";
+            // 
             // ExternalToolsWindow
             // 
             this.ClientSize = new System.Drawing.Size(684, 323);
@@ -434,5 +453,7 @@ namespace mRemoteNG.UI.Window
         internal System.Windows.Forms.Label WorkingDirLabel;
         internal System.Windows.Forms.TextBox WorkingDirTextBox;
         internal System.Windows.Forms.Button BrowseWorkingDir;
+        internal System.Windows.Forms.CheckBox RunElevatedCheckBox;
+        private System.Windows.Forms.ColumnHeader RunElevateHeader;
     }
 }

--- a/mRemoteV1/UI/Window/ExternalToolsWindow.Designer.cs
+++ b/mRemoteV1/UI/Window/ExternalToolsWindow.Designer.cs
@@ -211,6 +211,7 @@ namespace mRemoteNG.UI.Window
             this.WorkingDirTextBox.Name = "WorkingDirTextBox";
             this.WorkingDirTextBox.Size = new System.Drawing.Size(543, 22);
             this.WorkingDirTextBox.TabIndex = 10;
+            this.WorkingDirTextBox.Leave += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
             // 
             // TryToIntegrateCheckBox
             // 

--- a/mRemoteV1/UI/Window/ExternalToolsWindow.Designer.cs
+++ b/mRemoteV1/UI/Window/ExternalToolsWindow.Designer.cs
@@ -16,7 +16,6 @@ namespace mRemoteNG.UI.Window
 		internal System.Windows.Forms.Button BrowseButton;
 		internal System.Windows.Forms.ColumnHeader DisplayNameColumnHeader;
 		internal System.Windows.Forms.ContextMenuStrip ToolsContextMenuStrip;
-		private System.ComponentModel.Container components = null;
 		internal System.Windows.Forms.ToolStripMenuItem NewToolMenuItem;
 		internal System.Windows.Forms.ToolStripMenuItem DeleteToolMenuItem;
 		internal System.Windows.Forms.ToolStripSeparator ToolStripSeparator1;
@@ -30,340 +29,353 @@ namespace mRemoteNG.UI.Window
 				
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			this.Load += new System.EventHandler(ExternalTools_Load);
-			base.FormClosed += new System.Windows.Forms.FormClosedEventHandler(ExternalTools_FormClosed);
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ExternalToolsWindow));
-			this.ToolsListView = new System.Windows.Forms.ListView();
-			this.ToolsListView.SelectedIndexChanged += new System.EventHandler(this.ToolsListView_SelectedIndexChanged);
-			this.ToolsListView.DoubleClick += new System.EventHandler(this.ToolsListView_DoubleClick);
-			this.DisplayNameColumnHeader = (System.Windows.Forms.ColumnHeader) (new System.Windows.Forms.ColumnHeader());
-			this.FilenameColumnHeader = (System.Windows.Forms.ColumnHeader) (new System.Windows.Forms.ColumnHeader());
-			this.ArgumentsColumnHeader = (System.Windows.Forms.ColumnHeader) (new System.Windows.Forms.ColumnHeader());
-			this.WaitForExitColumnHeader = (System.Windows.Forms.ColumnHeader) (new System.Windows.Forms.ColumnHeader());
-			this.TryToIntegrateColumnHeader = (System.Windows.Forms.ColumnHeader) (new System.Windows.Forms.ColumnHeader());
-			this.ToolsContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
-			this.NewToolMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.NewToolMenuItem.Click += new System.EventHandler(this.NewTool_Click);
-			this.DeleteToolMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.DeleteToolMenuItem.Click += new System.EventHandler(this.DeleteTool_Click);
-			this.ToolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.LaunchToolMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.LaunchToolMenuItem.Click += new System.EventHandler(this.LaunchTool_Click);
-			this.PropertiesGroupBox = new System.Windows.Forms.GroupBox();
-			this.TryToIntegrateCheckBox = new System.Windows.Forms.CheckBox();
-			this.TryToIntegrateCheckBox.Click += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
-			this.TryToIntegrateCheckBox.CheckedChanged += new System.EventHandler(this.TryToIntegrateCheckBox_CheckedChanged);
-			this.OptionsLabel = new System.Windows.Forms.Label();
-			this.WaitForExitCheckBox = new System.Windows.Forms.CheckBox();
-			this.WaitForExitCheckBox.LostFocus += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
-			this.WaitForExitCheckBox.Click += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
-			this.BrowseButton = new System.Windows.Forms.Button();
-			this.BrowseButton.LostFocus += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
-			this.BrowseButton.Click += new System.EventHandler(this.BrowseButton_Click);
-			this.ArgumentsCheckBox = new System.Windows.Forms.TextBox();
-			this.ArgumentsCheckBox.LostFocus += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
-			this.FilenameTextBox = new System.Windows.Forms.TextBox();
-			this.FilenameTextBox.LostFocus += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
-			this.DisplayNameTextBox = new System.Windows.Forms.TextBox();
-			this.DisplayNameTextBox.LostFocus += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
-			this.ArgumentsLabel = new System.Windows.Forms.Label();
-			this.FilenameLabel = new System.Windows.Forms.Label();
-			this.DisplayNameLabel = new System.Windows.Forms.Label();
-			this.ToolStripContainer = new System.Windows.Forms.ToolStripContainer();
-			this.ToolStrip = new System.Windows.Forms.ToolStrip();
-			this.NewToolToolstripButton = new System.Windows.Forms.ToolStripButton();
-			this.NewToolToolstripButton.Click += new System.EventHandler(this.NewTool_Click);
-			this.DeleteToolToolstripButton = new System.Windows.Forms.ToolStripButton();
-			this.DeleteToolToolstripButton.Click += new System.EventHandler(this.DeleteTool_Click);
-			this.ToolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-			this.LaunchToolToolstripButton = new System.Windows.Forms.ToolStripButton();
-			this.LaunchToolToolstripButton.Click += new System.EventHandler(this.LaunchTool_Click);
-			this.ToolsContextMenuStrip.SuspendLayout();
-			this.PropertiesGroupBox.SuspendLayout();
-			this.ToolStripContainer.ContentPanel.SuspendLayout();
-			this.ToolStripContainer.TopToolStripPanel.SuspendLayout();
-			this.ToolStripContainer.SuspendLayout();
-			this.ToolStrip.SuspendLayout();
-			this.SuspendLayout();
-			//
-			//ToolsListView
-			//
-			this.ToolsListView.Anchor = (System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-				| System.Windows.Forms.AnchorStyles.Left) 
-				| System.Windows.Forms.AnchorStyles.Right);
-			this.ToolsListView.BorderStyle = System.Windows.Forms.BorderStyle.None;
-			this.ToolsListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {this.DisplayNameColumnHeader, this.FilenameColumnHeader, this.ArgumentsColumnHeader, this.WaitForExitColumnHeader, this.TryToIntegrateColumnHeader});
-			this.ToolsListView.ContextMenuStrip = this.ToolsContextMenuStrip;
-			this.ToolsListView.FullRowSelect = true;
-			this.ToolsListView.GridLines = true;
-			this.ToolsListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
-			this.ToolsListView.HideSelection = false;
-			this.ToolsListView.Location = new System.Drawing.Point(0, 0);
-			this.ToolsListView.Name = "ToolsListView";
-			this.ToolsListView.Size = new System.Drawing.Size(684, 157);
-			this.ToolsListView.Sorting = System.Windows.Forms.SortOrder.Ascending;
-			this.ToolsListView.TabIndex = 0;
-			this.ToolsListView.UseCompatibleStateImageBehavior = false;
-			this.ToolsListView.View = System.Windows.Forms.View.Details;
-			//
-			//DisplayNameColumnHeader
-			//
-			this.DisplayNameColumnHeader.Text = "Display Name";
-			this.DisplayNameColumnHeader.Width = 130;
-			//
-			//FilenameColumnHeader
-			//
-			this.FilenameColumnHeader.Text = "Filename";
-			this.FilenameColumnHeader.Width = 200;
-			//
-			//ArgumentsColumnHeader
-			//
-			this.ArgumentsColumnHeader.Text = "Arguments";
-			this.ArgumentsColumnHeader.Width = 160;
-			//
-			//WaitForExitColumnHeader
-			//
-			this.WaitForExitColumnHeader.Text = "Wait for exit";
-			this.WaitForExitColumnHeader.Width = 75;
-			//
-			//TryToIntegrateColumnHeader
-			//
-			this.TryToIntegrateColumnHeader.Text = "Try To Integrate";
-			this.TryToIntegrateColumnHeader.Width = 95;
-			//
-			//ToolsContextMenuStrip
-			//
-			this.ToolsContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {this.NewToolMenuItem, this.DeleteToolMenuItem, this.ToolStripSeparator1, this.LaunchToolMenuItem});
-			this.ToolsContextMenuStrip.Name = "cMenApps";
-			this.ToolsContextMenuStrip.Size = new System.Drawing.Size(221, 76);
-			//
-			//NewToolMenuItem
-			//
-			this.NewToolMenuItem.Image = Resources.ExtApp_Add;
-			this.NewToolMenuItem.Name = "NewToolMenuItem";
-			this.NewToolMenuItem.ShortcutKeys = (System.Windows.Forms.Keys) (System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F4);
-			this.NewToolMenuItem.Size = new System.Drawing.Size(220, 22);
-			this.NewToolMenuItem.Text = "New External Tool";
-			//
-			//DeleteToolMenuItem
-			//
-			this.DeleteToolMenuItem.Image = Resources.ExtApp_Delete;
-			this.DeleteToolMenuItem.Name = "DeleteToolMenuItem";
-			this.DeleteToolMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Delete;
-			this.DeleteToolMenuItem.Size = new System.Drawing.Size(220, 22);
-			this.DeleteToolMenuItem.Text = "Delete External Tool...";
-			//
-			//ToolStripSeparator1
-			//
-			this.ToolStripSeparator1.Name = "ToolStripSeparator1";
-			this.ToolStripSeparator1.Size = new System.Drawing.Size(217, 6);
-			//
-			//LaunchToolMenuItem
-			//
-			this.LaunchToolMenuItem.Image = Resources.ExtApp_Start;
-			this.LaunchToolMenuItem.Name = "LaunchToolMenuItem";
-			this.LaunchToolMenuItem.Size = new System.Drawing.Size(220, 22);
-			this.LaunchToolMenuItem.Text = "Launch External Tool";
-			//
-			//PropertiesGroupBox
-			//
-			this.PropertiesGroupBox.Anchor = (System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
-				| System.Windows.Forms.AnchorStyles.Right);
-			this.PropertiesGroupBox.Controls.Add(this.TryToIntegrateCheckBox);
-			this.PropertiesGroupBox.Controls.Add(this.OptionsLabel);
-			this.PropertiesGroupBox.Controls.Add(this.WaitForExitCheckBox);
-			this.PropertiesGroupBox.Controls.Add(this.BrowseButton);
-			this.PropertiesGroupBox.Controls.Add(this.ArgumentsCheckBox);
-			this.PropertiesGroupBox.Controls.Add(this.FilenameTextBox);
-			this.PropertiesGroupBox.Controls.Add(this.DisplayNameTextBox);
-			this.PropertiesGroupBox.Controls.Add(this.ArgumentsLabel);
-			this.PropertiesGroupBox.Controls.Add(this.FilenameLabel);
-			this.PropertiesGroupBox.Controls.Add(this.DisplayNameLabel);
-			this.PropertiesGroupBox.Enabled = false;
-			this.PropertiesGroupBox.Location = new System.Drawing.Point(3, 163);
-			this.PropertiesGroupBox.Name = "PropertiesGroupBox";
-			this.PropertiesGroupBox.Size = new System.Drawing.Size(678, 132);
-			this.PropertiesGroupBox.TabIndex = 1;
-			this.PropertiesGroupBox.TabStop = false;
-			this.PropertiesGroupBox.Text = "External Tool Properties";
-			//
-			//TryToIntegrateCheckBox
-			//
-			this.TryToIntegrateCheckBox.AutoSize = true;
-			this.TryToIntegrateCheckBox.Location = new System.Drawing.Point(280, 106);
-			this.TryToIntegrateCheckBox.Name = "TryToIntegrateCheckBox";
-			this.TryToIntegrateCheckBox.Size = new System.Drawing.Size(97, 17);
-			this.TryToIntegrateCheckBox.TabIndex = 9;
-			this.TryToIntegrateCheckBox.Text = "Try to integrate";
-			this.TryToIntegrateCheckBox.UseVisualStyleBackColor = true;
-			//
-			//OptionsLabel
-			//
-			this.OptionsLabel.AutoSize = true;
-			this.OptionsLabel.Location = new System.Drawing.Point(58, 107);
-			this.OptionsLabel.Name = "OptionsLabel";
-			this.OptionsLabel.Size = new System.Drawing.Size(46, 13);
-			this.OptionsLabel.TabIndex = 7;
-			this.OptionsLabel.Text = "Options:";
-			this.OptionsLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			//
-			//WaitForExitCheckBox
-			//
-			this.WaitForExitCheckBox.AutoSize = true;
-			this.WaitForExitCheckBox.Location = new System.Drawing.Point(110, 106);
-			this.WaitForExitCheckBox.Name = "WaitForExitCheckBox";
-			this.WaitForExitCheckBox.Size = new System.Drawing.Size(82, 17);
-			this.WaitForExitCheckBox.TabIndex = 8;
-			this.WaitForExitCheckBox.Text = "Wait for exit";
-			this.WaitForExitCheckBox.UseVisualStyleBackColor = true;
-			//
-			//BrowseButton
-			//
-			this.BrowseButton.Anchor = (System.Windows.Forms.AnchorStyles) (System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right);
-			this.BrowseButton.Location = new System.Drawing.Point(574, 45);
-			this.BrowseButton.Name = "BrowseButton";
-			this.BrowseButton.Size = new System.Drawing.Size(95, 23);
-			this.BrowseButton.TabIndex = 4;
-			this.BrowseButton.Text = "Browse...";
-			this.BrowseButton.UseVisualStyleBackColor = true;
-			//
-			//ArgumentsCheckBox
-			//
-			this.ArgumentsCheckBox.Anchor = (System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-				| System.Windows.Forms.AnchorStyles.Right);
-			this.ArgumentsCheckBox.Location = new System.Drawing.Point(110, 76);
-			this.ArgumentsCheckBox.Name = "ArgumentsCheckBox";
-			this.ArgumentsCheckBox.Size = new System.Drawing.Size(559, 20);
-			this.ArgumentsCheckBox.TabIndex = 6;
-			//
-			//FilenameTextBox
-			//
-			this.FilenameTextBox.Anchor = (System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-				| System.Windows.Forms.AnchorStyles.Right);
-			this.FilenameTextBox.Location = new System.Drawing.Point(110, 47);
-			this.FilenameTextBox.Name = "FilenameTextBox";
-			this.FilenameTextBox.Size = new System.Drawing.Size(458, 20);
-			this.FilenameTextBox.TabIndex = 3;
-			//
-			//DisplayNameTextBox
-			//
-			this.DisplayNameTextBox.Anchor = (System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-				| System.Windows.Forms.AnchorStyles.Right);
-			this.DisplayNameTextBox.Location = new System.Drawing.Point(110, 19);
-			this.DisplayNameTextBox.Name = "DisplayNameTextBox";
-			this.DisplayNameTextBox.Size = new System.Drawing.Size(559, 20);
-			this.DisplayNameTextBox.TabIndex = 1;
-			//
-			//ArgumentsLabel
-			//
-			this.ArgumentsLabel.AutoSize = true;
-			this.ArgumentsLabel.Location = new System.Drawing.Point(44, 79);
-			this.ArgumentsLabel.Name = "ArgumentsLabel";
-			this.ArgumentsLabel.Size = new System.Drawing.Size(60, 13);
-			this.ArgumentsLabel.TabIndex = 5;
-			this.ArgumentsLabel.Text = "Arguments:";
-			this.ArgumentsLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			//
-			//FilenameLabel
-			//
-			this.FilenameLabel.AutoSize = true;
-			this.FilenameLabel.Location = new System.Drawing.Point(52, 50);
-			this.FilenameLabel.Name = "FilenameLabel";
-			this.FilenameLabel.Size = new System.Drawing.Size(52, 13);
-			this.FilenameLabel.TabIndex = 2;
-			this.FilenameLabel.Text = "Filename:";
-			this.FilenameLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			//
-			//DisplayNameLabel
-			//
-			this.DisplayNameLabel.AutoSize = true;
-			this.DisplayNameLabel.Location = new System.Drawing.Point(29, 22);
-			this.DisplayNameLabel.Name = "DisplayNameLabel";
-			this.DisplayNameLabel.Size = new System.Drawing.Size(75, 13);
-			this.DisplayNameLabel.TabIndex = 0;
-			this.DisplayNameLabel.Text = "Display Name:";
-			this.DisplayNameLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			//
-			//ToolStripContainer
-			//
-			//
-			//ToolStripContainer.ContentPanel
-			//
-			this.ToolStripContainer.ContentPanel.Controls.Add(this.PropertiesGroupBox);
-			this.ToolStripContainer.ContentPanel.Controls.Add(this.ToolsListView);
-			this.ToolStripContainer.ContentPanel.Size = new System.Drawing.Size(684, 298);
-			this.ToolStripContainer.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.ToolStripContainer.Location = new System.Drawing.Point(0, 0);
-			this.ToolStripContainer.Name = "ToolStripContainer";
-			this.ToolStripContainer.Size = new System.Drawing.Size(684, 323);
-			this.ToolStripContainer.TabIndex = 0;
-			this.ToolStripContainer.Text = "ToolStripContainer";
-			//
-			//ToolStripContainer.TopToolStripPanel
-			//
-			this.ToolStripContainer.TopToolStripPanel.Controls.Add(this.ToolStrip);
-			//
-			//ToolStrip
-			//
-			this.ToolStrip.Dock = System.Windows.Forms.DockStyle.None;
-			this.ToolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-			this.ToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {this.NewToolToolstripButton, this.DeleteToolToolstripButton, this.ToolStripSeparator2, this.LaunchToolToolstripButton});
-			this.ToolStrip.Location = new System.Drawing.Point(3, 0);
-			this.ToolStrip.Name = "ToolStrip";
-			this.ToolStrip.Size = new System.Drawing.Size(186, 25);
-			this.ToolStrip.TabIndex = 0;
-			//
-			//NewToolToolstripButton
-			//
-			this.NewToolToolstripButton.Image = Resources.ExtApp_Add;
-			this.NewToolToolstripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.NewToolToolstripButton.Name = "NewToolToolstripButton";
-			this.NewToolToolstripButton.Size = new System.Drawing.Size(51, 22);
-			this.NewToolToolstripButton.Text = "New";
-			//
-			//DeleteToolToolstripButton
-			//
-			this.DeleteToolToolstripButton.Image = Resources.ExtApp_Delete;
-			this.DeleteToolToolstripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.DeleteToolToolstripButton.Name = "DeleteToolToolstripButton";
-			this.DeleteToolToolstripButton.Size = new System.Drawing.Size(60, 22);
-			this.DeleteToolToolstripButton.Text = "Delete";
-			//
-			//ToolStripSeparator2
-			//
-			this.ToolStripSeparator2.Name = "ToolStripSeparator2";
-			this.ToolStripSeparator2.Size = new System.Drawing.Size(6, 25);
-			//
-			//LaunchToolToolstripButton
-			//
-			this.LaunchToolToolstripButton.Image = Resources.ExtApp_Start;
-			this.LaunchToolToolstripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
-			this.LaunchToolToolstripButton.Name = "LaunchToolToolstripButton";
-			this.LaunchToolToolstripButton.Size = new System.Drawing.Size(66, 22);
-			this.LaunchToolToolstripButton.Text = "Launch";
-			//
-			//ExternalTools
-			//
-			this.ClientSize = new System.Drawing.Size(684, 323);
-			this.Controls.Add(this.ToolStripContainer);
-			this.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, System.Convert.ToByte(0));
-			this.Icon = (System.Drawing.Icon) (resources.GetObject("$this.Icon"));
-			this.Name = "ExternalTools";
-			this.TabText = "External Applications";
-			this.Text = "External Tools";
-			this.ToolsContextMenuStrip.ResumeLayout(false);
-			this.PropertiesGroupBox.ResumeLayout(false);
-			this.PropertiesGroupBox.PerformLayout();
-			this.ToolStripContainer.ContentPanel.ResumeLayout(false);
-			this.ToolStripContainer.TopToolStripPanel.ResumeLayout(false);
-			this.ToolStripContainer.TopToolStripPanel.PerformLayout();
-			this.ToolStripContainer.ResumeLayout(false);
-			this.ToolStripContainer.PerformLayout();
-			this.ToolStrip.ResumeLayout(false);
-			this.ToolStrip.PerformLayout();
-			this.ResumeLayout(false);
-					
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ExternalToolsWindow));
+            this.ToolsListView = new System.Windows.Forms.ListView();
+            this.DisplayNameColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.FilenameColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.ArgumentsColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.WaitForExitColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.TryToIntegrateColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.ToolsContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.NewToolMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.DeleteToolMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.ToolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.LaunchToolMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.PropertiesGroupBox = new System.Windows.Forms.GroupBox();
+            this.TryToIntegrateCheckBox = new System.Windows.Forms.CheckBox();
+            this.OptionsLabel = new System.Windows.Forms.Label();
+            this.WaitForExitCheckBox = new System.Windows.Forms.CheckBox();
+            this.BrowseButton = new System.Windows.Forms.Button();
+            this.ArgumentsCheckBox = new System.Windows.Forms.TextBox();
+            this.FilenameTextBox = new System.Windows.Forms.TextBox();
+            this.DisplayNameTextBox = new System.Windows.Forms.TextBox();
+            this.ArgumentsLabel = new System.Windows.Forms.Label();
+            this.FilenameLabel = new System.Windows.Forms.Label();
+            this.DisplayNameLabel = new System.Windows.Forms.Label();
+            this.ToolStripContainer = new System.Windows.Forms.ToolStripContainer();
+            this.ToolStrip = new System.Windows.Forms.ToolStrip();
+            this.NewToolToolstripButton = new System.Windows.Forms.ToolStripButton();
+            this.DeleteToolToolstripButton = new System.Windows.Forms.ToolStripButton();
+            this.ToolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            this.LaunchToolToolstripButton = new System.Windows.Forms.ToolStripButton();
+            this.ToolsContextMenuStrip.SuspendLayout();
+            this.PropertiesGroupBox.SuspendLayout();
+            this.ToolStripContainer.ContentPanel.SuspendLayout();
+            this.ToolStripContainer.TopToolStripPanel.SuspendLayout();
+            this.ToolStripContainer.SuspendLayout();
+            this.ToolStrip.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // ToolsListView
+            // 
+            this.ToolsListView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.ToolsListView.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.ToolsListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.DisplayNameColumnHeader,
+            this.FilenameColumnHeader,
+            this.ArgumentsColumnHeader,
+            this.WaitForExitColumnHeader,
+            this.TryToIntegrateColumnHeader});
+            this.ToolsListView.ContextMenuStrip = this.ToolsContextMenuStrip;
+            this.ToolsListView.FullRowSelect = true;
+            this.ToolsListView.GridLines = true;
+            this.ToolsListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            this.ToolsListView.HideSelection = false;
+            this.ToolsListView.Location = new System.Drawing.Point(0, 0);
+            this.ToolsListView.Name = "ToolsListView";
+            this.ToolsListView.Size = new System.Drawing.Size(684, 157);
+            this.ToolsListView.Sorting = System.Windows.Forms.SortOrder.Ascending;
+            this.ToolsListView.TabIndex = 0;
+            this.ToolsListView.UseCompatibleStateImageBehavior = false;
+            this.ToolsListView.View = System.Windows.Forms.View.Details;
+            this.ToolsListView.SelectedIndexChanged += new System.EventHandler(this.ToolsListView_SelectedIndexChanged);
+            this.ToolsListView.DoubleClick += new System.EventHandler(this.ToolsListView_DoubleClick);
+            // 
+            // DisplayNameColumnHeader
+            // 
+            this.DisplayNameColumnHeader.Text = "Display Name";
+            this.DisplayNameColumnHeader.Width = 130;
+            // 
+            // FilenameColumnHeader
+            // 
+            this.FilenameColumnHeader.Text = "Filename";
+            this.FilenameColumnHeader.Width = 200;
+            // 
+            // ArgumentsColumnHeader
+            // 
+            this.ArgumentsColumnHeader.Text = "Arguments";
+            this.ArgumentsColumnHeader.Width = 160;
+            // 
+            // WaitForExitColumnHeader
+            // 
+            this.WaitForExitColumnHeader.Text = "Wait for exit";
+            this.WaitForExitColumnHeader.Width = 75;
+            // 
+            // TryToIntegrateColumnHeader
+            // 
+            this.TryToIntegrateColumnHeader.Text = "Try To Integrate";
+            this.TryToIntegrateColumnHeader.Width = 95;
+            // 
+            // ToolsContextMenuStrip
+            // 
+            this.ToolsContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.NewToolMenuItem,
+            this.DeleteToolMenuItem,
+            this.ToolStripSeparator1,
+            this.LaunchToolMenuItem});
+            this.ToolsContextMenuStrip.Name = "cMenApps";
+            this.ToolsContextMenuStrip.Size = new System.Drawing.Size(220, 76);
+            // 
+            // NewToolMenuItem
+            // 
+            this.NewToolMenuItem.Image = global::mRemoteNG.Resources.ExtApp_Add;
+            this.NewToolMenuItem.Name = "NewToolMenuItem";
+            this.NewToolMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.F4)));
+            this.NewToolMenuItem.Size = new System.Drawing.Size(219, 22);
+            this.NewToolMenuItem.Text = "New External Tool";
+            this.NewToolMenuItem.Click += new System.EventHandler(this.NewTool_Click);
+            // 
+            // DeleteToolMenuItem
+            // 
+            this.DeleteToolMenuItem.Image = global::mRemoteNG.Resources.ExtApp_Delete;
+            this.DeleteToolMenuItem.Name = "DeleteToolMenuItem";
+            this.DeleteToolMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Delete;
+            this.DeleteToolMenuItem.Size = new System.Drawing.Size(219, 22);
+            this.DeleteToolMenuItem.Text = "Delete External Tool...";
+            this.DeleteToolMenuItem.Click += new System.EventHandler(this.DeleteTool_Click);
+            // 
+            // ToolStripSeparator1
+            // 
+            this.ToolStripSeparator1.Name = "ToolStripSeparator1";
+            this.ToolStripSeparator1.Size = new System.Drawing.Size(216, 6);
+            // 
+            // LaunchToolMenuItem
+            // 
+            this.LaunchToolMenuItem.Image = global::mRemoteNG.Resources.ExtApp_Start;
+            this.LaunchToolMenuItem.Name = "LaunchToolMenuItem";
+            this.LaunchToolMenuItem.Size = new System.Drawing.Size(219, 22);
+            this.LaunchToolMenuItem.Text = "Launch External Tool";
+            this.LaunchToolMenuItem.Click += new System.EventHandler(this.LaunchTool_Click);
+            // 
+            // PropertiesGroupBox
+            // 
+            this.PropertiesGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.PropertiesGroupBox.Controls.Add(this.TryToIntegrateCheckBox);
+            this.PropertiesGroupBox.Controls.Add(this.OptionsLabel);
+            this.PropertiesGroupBox.Controls.Add(this.WaitForExitCheckBox);
+            this.PropertiesGroupBox.Controls.Add(this.BrowseButton);
+            this.PropertiesGroupBox.Controls.Add(this.ArgumentsCheckBox);
+            this.PropertiesGroupBox.Controls.Add(this.FilenameTextBox);
+            this.PropertiesGroupBox.Controls.Add(this.DisplayNameTextBox);
+            this.PropertiesGroupBox.Controls.Add(this.ArgumentsLabel);
+            this.PropertiesGroupBox.Controls.Add(this.FilenameLabel);
+            this.PropertiesGroupBox.Controls.Add(this.DisplayNameLabel);
+            this.PropertiesGroupBox.Enabled = false;
+            this.PropertiesGroupBox.Location = new System.Drawing.Point(3, 163);
+            this.PropertiesGroupBox.Name = "PropertiesGroupBox";
+            this.PropertiesGroupBox.Size = new System.Drawing.Size(678, 132);
+            this.PropertiesGroupBox.TabIndex = 1;
+            this.PropertiesGroupBox.TabStop = false;
+            this.PropertiesGroupBox.Text = "External Tool Properties";
+            // 
+            // TryToIntegrateCheckBox
+            // 
+            this.TryToIntegrateCheckBox.AutoSize = true;
+            this.TryToIntegrateCheckBox.Location = new System.Drawing.Point(221, 107);
+            this.TryToIntegrateCheckBox.Name = "TryToIntegrateCheckBox";
+            this.TryToIntegrateCheckBox.Size = new System.Drawing.Size(103, 17);
+            this.TryToIntegrateCheckBox.TabIndex = 9;
+            this.TryToIntegrateCheckBox.Text = "Try to integrate";
+            this.TryToIntegrateCheckBox.UseVisualStyleBackColor = true;
+            this.TryToIntegrateCheckBox.CheckedChanged += new System.EventHandler(this.TryToIntegrateCheckBox_CheckedChanged);
+            this.TryToIntegrateCheckBox.Click += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
+            // 
+            // OptionsLabel
+            // 
+            this.OptionsLabel.AutoSize = true;
+            this.OptionsLabel.Location = new System.Drawing.Point(68, 108);
+            this.OptionsLabel.Name = "OptionsLabel";
+            this.OptionsLabel.Size = new System.Drawing.Size(52, 13);
+            this.OptionsLabel.TabIndex = 7;
+            this.OptionsLabel.Text = "Options:";
+            this.OptionsLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // WaitForExitCheckBox
+            // 
+            this.WaitForExitCheckBox.AutoSize = true;
+            this.WaitForExitCheckBox.Location = new System.Drawing.Point(126, 107);
+            this.WaitForExitCheckBox.Name = "WaitForExitCheckBox";
+            this.WaitForExitCheckBox.Size = new System.Drawing.Size(89, 17);
+            this.WaitForExitCheckBox.TabIndex = 8;
+            this.WaitForExitCheckBox.Text = "Wait for exit";
+            this.WaitForExitCheckBox.UseVisualStyleBackColor = true;
+            this.WaitForExitCheckBox.Click += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
+            this.WaitForExitCheckBox.LostFocus += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
+            // 
+            // BrowseButton
+            // 
+            this.BrowseButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.BrowseButton.Location = new System.Drawing.Point(574, 45);
+            this.BrowseButton.Name = "BrowseButton";
+            this.BrowseButton.Size = new System.Drawing.Size(95, 23);
+            this.BrowseButton.TabIndex = 4;
+            this.BrowseButton.Text = "Browse...";
+            this.BrowseButton.UseVisualStyleBackColor = true;
+            this.BrowseButton.Click += new System.EventHandler(this.BrowseButton_Click);
+            this.BrowseButton.LostFocus += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
+            // 
+            // ArgumentsCheckBox
+            // 
+            this.ArgumentsCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.ArgumentsCheckBox.Location = new System.Drawing.Point(126, 76);
+            this.ArgumentsCheckBox.Name = "ArgumentsCheckBox";
+            this.ArgumentsCheckBox.Size = new System.Drawing.Size(543, 22);
+            this.ArgumentsCheckBox.TabIndex = 6;
+            this.ArgumentsCheckBox.LostFocus += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
+            // 
+            // FilenameTextBox
+            // 
+            this.FilenameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.FilenameTextBox.Location = new System.Drawing.Point(126, 47);
+            this.FilenameTextBox.Name = "FilenameTextBox";
+            this.FilenameTextBox.Size = new System.Drawing.Size(442, 22);
+            this.FilenameTextBox.TabIndex = 3;
+            this.FilenameTextBox.LostFocus += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
+            // 
+            // DisplayNameTextBox
+            // 
+            this.DisplayNameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.DisplayNameTextBox.Location = new System.Drawing.Point(126, 19);
+            this.DisplayNameTextBox.Name = "DisplayNameTextBox";
+            this.DisplayNameTextBox.Size = new System.Drawing.Size(543, 22);
+            this.DisplayNameTextBox.TabIndex = 1;
+            this.DisplayNameTextBox.LostFocus += new System.EventHandler(this.PropertyControl_ChangedOrLostFocus);
+            // 
+            // ArgumentsLabel
+            // 
+            this.ArgumentsLabel.AutoSize = true;
+            this.ArgumentsLabel.Location = new System.Drawing.Point(54, 79);
+            this.ArgumentsLabel.Name = "ArgumentsLabel";
+            this.ArgumentsLabel.Size = new System.Drawing.Size(66, 13);
+            this.ArgumentsLabel.TabIndex = 5;
+            this.ArgumentsLabel.Text = "Arguments:";
+            this.ArgumentsLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // FilenameLabel
+            // 
+            this.FilenameLabel.AutoSize = true;
+            this.FilenameLabel.Location = new System.Drawing.Point(64, 50);
+            this.FilenameLabel.Name = "FilenameLabel";
+            this.FilenameLabel.Size = new System.Drawing.Size(56, 13);
+            this.FilenameLabel.TabIndex = 2;
+            this.FilenameLabel.Text = "Filename:";
+            this.FilenameLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // DisplayNameLabel
+            // 
+            this.DisplayNameLabel.AutoSize = true;
+            this.DisplayNameLabel.Location = new System.Drawing.Point(41, 22);
+            this.DisplayNameLabel.Name = "DisplayNameLabel";
+            this.DisplayNameLabel.Size = new System.Drawing.Size(79, 13);
+            this.DisplayNameLabel.TabIndex = 0;
+            this.DisplayNameLabel.Text = "Display Name:";
+            this.DisplayNameLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // ToolStripContainer
+            // 
+            // 
+            // ToolStripContainer.ContentPanel
+            // 
+            this.ToolStripContainer.ContentPanel.Controls.Add(this.PropertiesGroupBox);
+            this.ToolStripContainer.ContentPanel.Controls.Add(this.ToolsListView);
+            this.ToolStripContainer.ContentPanel.Size = new System.Drawing.Size(684, 298);
+            this.ToolStripContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ToolStripContainer.Location = new System.Drawing.Point(0, 0);
+            this.ToolStripContainer.Name = "ToolStripContainer";
+            this.ToolStripContainer.Size = new System.Drawing.Size(684, 323);
+            this.ToolStripContainer.TabIndex = 0;
+            this.ToolStripContainer.Text = "ToolStripContainer";
+            // 
+            // ToolStripContainer.TopToolStripPanel
+            // 
+            this.ToolStripContainer.TopToolStripPanel.Controls.Add(this.ToolStrip);
+            // 
+            // ToolStrip
+            // 
+            this.ToolStrip.Dock = System.Windows.Forms.DockStyle.None;
+            this.ToolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+            this.ToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.NewToolToolstripButton,
+            this.DeleteToolToolstripButton,
+            this.ToolStripSeparator2,
+            this.LaunchToolToolstripButton});
+            this.ToolStrip.Location = new System.Drawing.Point(3, 0);
+            this.ToolStrip.Name = "ToolStrip";
+            this.ToolStrip.Size = new System.Drawing.Size(186, 25);
+            this.ToolStrip.TabIndex = 0;
+            // 
+            // NewToolToolstripButton
+            // 
+            this.NewToolToolstripButton.Image = global::mRemoteNG.Resources.ExtApp_Add;
+            this.NewToolToolstripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.NewToolToolstripButton.Name = "NewToolToolstripButton";
+            this.NewToolToolstripButton.Size = new System.Drawing.Size(51, 22);
+            this.NewToolToolstripButton.Text = "New";
+            this.NewToolToolstripButton.Click += new System.EventHandler(this.NewTool_Click);
+            // 
+            // DeleteToolToolstripButton
+            // 
+            this.DeleteToolToolstripButton.Image = global::mRemoteNG.Resources.ExtApp_Delete;
+            this.DeleteToolToolstripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.DeleteToolToolstripButton.Name = "DeleteToolToolstripButton";
+            this.DeleteToolToolstripButton.Size = new System.Drawing.Size(60, 22);
+            this.DeleteToolToolstripButton.Text = "Delete";
+            this.DeleteToolToolstripButton.Click += new System.EventHandler(this.DeleteTool_Click);
+            // 
+            // ToolStripSeparator2
+            // 
+            this.ToolStripSeparator2.Name = "ToolStripSeparator2";
+            this.ToolStripSeparator2.Size = new System.Drawing.Size(6, 25);
+            // 
+            // LaunchToolToolstripButton
+            // 
+            this.LaunchToolToolstripButton.Image = global::mRemoteNG.Resources.ExtApp_Start;
+            this.LaunchToolToolstripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.LaunchToolToolstripButton.Name = "LaunchToolToolstripButton";
+            this.LaunchToolToolstripButton.Size = new System.Drawing.Size(66, 22);
+            this.LaunchToolToolstripButton.Text = "Launch";
+            this.LaunchToolToolstripButton.Click += new System.EventHandler(this.LaunchTool_Click);
+            // 
+            // ExternalToolsWindow
+            // 
+            this.ClientSize = new System.Drawing.Size(684, 323);
+            this.Controls.Add(this.ToolStripContainer);
+            this.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Name = "ExternalToolsWindow";
+            this.TabText = "External Applications";
+            this.Text = "External Tools";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.ExternalTools_FormClosed);
+            this.Load += new System.EventHandler(this.ExternalTools_Load);
+            this.ToolsContextMenuStrip.ResumeLayout(false);
+            this.PropertiesGroupBox.ResumeLayout(false);
+            this.PropertiesGroupBox.PerformLayout();
+            this.ToolStripContainer.ContentPanel.ResumeLayout(false);
+            this.ToolStripContainer.TopToolStripPanel.ResumeLayout(false);
+            this.ToolStripContainer.TopToolStripPanel.PerformLayout();
+            this.ToolStripContainer.ResumeLayout(false);
+            this.ToolStripContainer.PerformLayout();
+            this.ToolStrip.ResumeLayout(false);
+            this.ToolStrip.PerformLayout();
+            this.ResumeLayout(false);
+
 		}
 		internal System.Windows.Forms.ToolStripContainer ToolStripContainer;
 		internal System.Windows.Forms.ToolStrip ToolStrip;
@@ -372,5 +384,7 @@ namespace mRemoteNG.UI.Window
 		internal System.Windows.Forms.ToolStripSeparator ToolStripSeparator2;
 		internal System.Windows.Forms.ToolStripButton LaunchToolToolstripButton;
         #endregion
-	}
+
+        private System.ComponentModel.IContainer components;
+    }
 }

--- a/mRemoteV1/UI/Window/ExternalToolsWindow.Designer.cs
+++ b/mRemoteV1/UI/Window/ExternalToolsWindow.Designer.cs
@@ -35,6 +35,7 @@ namespace mRemoteNG.UI.Window
             this.DisplayNameColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.FilenameColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ArgumentsColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.WorkingDirColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.WaitForExitColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.TryToIntegrateColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.ToolsContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -43,6 +44,8 @@ namespace mRemoteNG.UI.Window
             this.ToolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.LaunchToolMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.PropertiesGroupBox = new System.Windows.Forms.GroupBox();
+            this.WorkingDirLabel = new System.Windows.Forms.Label();
+            this.WorkingDirTextBox = new System.Windows.Forms.TextBox();
             this.TryToIntegrateCheckBox = new System.Windows.Forms.CheckBox();
             this.OptionsLabel = new System.Windows.Forms.Label();
             this.WaitForExitCheckBox = new System.Windows.Forms.CheckBox();
@@ -77,6 +80,7 @@ namespace mRemoteNG.UI.Window
             this.DisplayNameColumnHeader,
             this.FilenameColumnHeader,
             this.ArgumentsColumnHeader,
+            this.WorkingDirColumnHeader,
             this.WaitForExitColumnHeader,
             this.TryToIntegrateColumnHeader});
             this.ToolsListView.ContextMenuStrip = this.ToolsContextMenuStrip;
@@ -86,7 +90,7 @@ namespace mRemoteNG.UI.Window
             this.ToolsListView.HideSelection = false;
             this.ToolsListView.Location = new System.Drawing.Point(0, 0);
             this.ToolsListView.Name = "ToolsListView";
-            this.ToolsListView.Size = new System.Drawing.Size(684, 157);
+            this.ToolsListView.Size = new System.Drawing.Size(684, 126);
             this.ToolsListView.Sorting = System.Windows.Forms.SortOrder.Ascending;
             this.ToolsListView.TabIndex = 0;
             this.ToolsListView.UseCompatibleStateImageBehavior = false;
@@ -108,6 +112,11 @@ namespace mRemoteNG.UI.Window
             // 
             this.ArgumentsColumnHeader.Text = "Arguments";
             this.ArgumentsColumnHeader.Width = 160;
+            // 
+            // WorkingDirColumnHeader
+            // 
+            this.WorkingDirColumnHeader.Text = "Working Directory";
+            this.WorkingDirColumnHeader.Width = 160;
             // 
             // WaitForExitColumnHeader
             // 
@@ -164,6 +173,8 @@ namespace mRemoteNG.UI.Window
             // 
             this.PropertiesGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.PropertiesGroupBox.Controls.Add(this.WorkingDirLabel);
+            this.PropertiesGroupBox.Controls.Add(this.WorkingDirTextBox);
             this.PropertiesGroupBox.Controls.Add(this.TryToIntegrateCheckBox);
             this.PropertiesGroupBox.Controls.Add(this.OptionsLabel);
             this.PropertiesGroupBox.Controls.Add(this.WaitForExitCheckBox);
@@ -175,17 +186,36 @@ namespace mRemoteNG.UI.Window
             this.PropertiesGroupBox.Controls.Add(this.FilenameLabel);
             this.PropertiesGroupBox.Controls.Add(this.DisplayNameLabel);
             this.PropertiesGroupBox.Enabled = false;
-            this.PropertiesGroupBox.Location = new System.Drawing.Point(3, 163);
+            this.PropertiesGroupBox.Location = new System.Drawing.Point(3, 132);
             this.PropertiesGroupBox.Name = "PropertiesGroupBox";
-            this.PropertiesGroupBox.Size = new System.Drawing.Size(678, 132);
+            this.PropertiesGroupBox.Size = new System.Drawing.Size(678, 163);
             this.PropertiesGroupBox.TabIndex = 1;
             this.PropertiesGroupBox.TabStop = false;
             this.PropertiesGroupBox.Text = "External Tool Properties";
             // 
+            // WorkingDirLabel
+            // 
+            this.WorkingDirLabel.AutoSize = true;
+            this.WorkingDirLabel.Location = new System.Drawing.Point(16, 107);
+            this.WorkingDirLabel.Name = "WorkingDirLabel";
+            this.WorkingDirLabel.Size = new System.Drawing.Size(104, 13);
+            this.WorkingDirLabel.TabIndex = 11;
+            this.WorkingDirLabel.Text = "Working Directory:";
+            this.WorkingDirLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // WorkingDirTextBox
+            // 
+            this.WorkingDirTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.WorkingDirTextBox.Location = new System.Drawing.Point(126, 104);
+            this.WorkingDirTextBox.Name = "WorkingDirTextBox";
+            this.WorkingDirTextBox.Size = new System.Drawing.Size(543, 22);
+            this.WorkingDirTextBox.TabIndex = 10;
+            // 
             // TryToIntegrateCheckBox
             // 
             this.TryToIntegrateCheckBox.AutoSize = true;
-            this.TryToIntegrateCheckBox.Location = new System.Drawing.Point(221, 107);
+            this.TryToIntegrateCheckBox.Location = new System.Drawing.Point(221, 135);
             this.TryToIntegrateCheckBox.Name = "TryToIntegrateCheckBox";
             this.TryToIntegrateCheckBox.Size = new System.Drawing.Size(103, 17);
             this.TryToIntegrateCheckBox.TabIndex = 9;
@@ -197,7 +227,7 @@ namespace mRemoteNG.UI.Window
             // OptionsLabel
             // 
             this.OptionsLabel.AutoSize = true;
-            this.OptionsLabel.Location = new System.Drawing.Point(68, 108);
+            this.OptionsLabel.Location = new System.Drawing.Point(68, 135);
             this.OptionsLabel.Name = "OptionsLabel";
             this.OptionsLabel.Size = new System.Drawing.Size(52, 13);
             this.OptionsLabel.TabIndex = 7;
@@ -207,7 +237,7 @@ namespace mRemoteNG.UI.Window
             // WaitForExitCheckBox
             // 
             this.WaitForExitCheckBox.AutoSize = true;
-            this.WaitForExitCheckBox.Location = new System.Drawing.Point(126, 107);
+            this.WaitForExitCheckBox.Location = new System.Drawing.Point(126, 134);
             this.WaitForExitCheckBox.Name = "WaitForExitCheckBox";
             this.WaitForExitCheckBox.Size = new System.Drawing.Size(89, 17);
             this.WaitForExitCheckBox.TabIndex = 8;
@@ -362,7 +392,7 @@ namespace mRemoteNG.UI.Window
             this.Name = "ExternalToolsWindow";
             this.TabText = "External Applications";
             this.Text = "External Tools";
-            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.ExternalTools_FormClosed);
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.ExternalToolsWindow_FormClosed);
             this.Load += new System.EventHandler(this.ExternalTools_Load);
             this.ToolsContextMenuStrip.ResumeLayout(false);
             this.PropertiesGroupBox.ResumeLayout(false);
@@ -386,5 +416,8 @@ namespace mRemoteNG.UI.Window
         #endregion
 
         private System.ComponentModel.IContainer components;
+        internal System.Windows.Forms.ColumnHeader WorkingDirColumnHeader;
+        internal System.Windows.Forms.Label WorkingDirLabel;
+        internal System.Windows.Forms.TextBox WorkingDirTextBox;
     }
 }

--- a/mRemoteV1/UI/Window/ExternalToolsWindow.cs
+++ b/mRemoteV1/UI/Window/ExternalToolsWindow.cs
@@ -114,6 +114,7 @@ namespace mRemoteNG.UI.Window
 					DisplayNameTextBox.Text = _selectedTool.DisplayName;
 					FilenameTextBox.Text = _selectedTool.FileName;
 					ArgumentsCheckBox.Text = _selectedTool.Arguments;
+                    WorkingDirTextBox.Text = _selectedTool.WorkingDir;
 					WaitForExitCheckBox.Checked = _selectedTool.WaitForExit;
 					TryToIntegrateCheckBox.Checked = _selectedTool.TryIntegrate;
 				}
@@ -148,6 +149,7 @@ namespace mRemoteNG.UI.Window
 				_selectedTool.DisplayName = DisplayNameTextBox.Text;
 				_selectedTool.FileName = FilenameTextBox.Text;
 				_selectedTool.Arguments = ArgumentsCheckBox.Text;
+                _selectedTool.WorkingDir = WorkingDirTextBox.Text;
 				_selectedTool.WaitForExit = WaitForExitCheckBox.Checked;
 				_selectedTool.TryIntegrate = TryToIntegrateCheckBox.Checked;
 						
@@ -251,7 +253,8 @@ namespace mRemoteNG.UI.Window
 				    var listViewItem = new ListViewItem {Text = externalTool.DisplayName};
 				    listViewItem.SubItems.Add(externalTool.FileName);
 					listViewItem.SubItems.Add(externalTool.Arguments);
-					listViewItem.SubItems.Add(externalTool.WaitForExit.ToString());
+                    listViewItem.SubItems.Add(externalTool.WorkingDir);
+                    listViewItem.SubItems.Add(externalTool.WaitForExit.ToString());
 					listViewItem.SubItems.Add(externalTool.TryIntegrate.ToString());
 					listViewItem.Tag = externalTool;
 							

--- a/mRemoteV1/UI/Window/ExternalToolsWindow.cs
+++ b/mRemoteV1/UI/Window/ExternalToolsWindow.cs
@@ -117,6 +117,7 @@ namespace mRemoteNG.UI.Window
                     WorkingDirTextBox.Text = _selectedTool.WorkingDir;
 					WaitForExitCheckBox.Checked = _selectedTool.WaitForExit;
 					TryToIntegrateCheckBox.Checked = _selectedTool.TryIntegrate;
+                    RunElevatedCheckBox.Checked = _selectedTool.RunElevated;
 				}
 				else
 				{
@@ -152,6 +153,7 @@ namespace mRemoteNG.UI.Window
                 _selectedTool.WorkingDir = WorkingDirTextBox.Text;
 				_selectedTool.WaitForExit = WaitForExitCheckBox.Checked;
 				_selectedTool.TryIntegrate = TryToIntegrateCheckBox.Checked;
+                _selectedTool.RunElevated = RunElevatedCheckBox.Checked;
 						
 				UpdateToolsListView();
 			}
@@ -277,7 +279,8 @@ namespace mRemoteNG.UI.Window
                     listViewItem.SubItems.Add(externalTool.WorkingDir);
                     listViewItem.SubItems.Add(externalTool.WaitForExit.ToString());
 					listViewItem.SubItems.Add(externalTool.TryIntegrate.ToString());
-					listViewItem.Tag = externalTool;
+                    listViewItem.SubItems.Add(externalTool.RunElevated.ToString());
+                    listViewItem.Tag = externalTool;
 							
 					ToolsListView.Items.Add(listViewItem);
 							

--- a/mRemoteV1/UI/Window/ExternalToolsWindow.cs
+++ b/mRemoteV1/UI/Window/ExternalToolsWindow.cs
@@ -171,15 +171,36 @@ namespace mRemoteNG.UI.Window
 					if (browseDialog.ShowDialog() == DialogResult.OK)
 					{
 						FilenameTextBox.Text = browseDialog.FileName;
-					}
+                        PropertyControl_ChangedOrLostFocus(this, e);
+
+                    }
 				}
-						
 			}
 			catch (Exception ex)
 			{
 				Runtime.MessageCollector.AddExceptionMessage(message: "UI.Window.ExternalTools.BrowseButton_Click() failed.", ex: ex, logOnly: true);
 			}
-		}
+        }
+
+        private void BrowseWorkingDir_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                using (var browseDialog = new FolderBrowserDialog())
+                {
+                    if (browseDialog.ShowDialog() == DialogResult.OK)
+                    {
+                        WorkingDirTextBox.Text = browseDialog.SelectedPath;
+                        PropertyControl_ChangedOrLostFocus(this, e);
+                    }
+                }
+
+            }
+            catch (Exception ex)
+            {
+                Runtime.MessageCollector.AddExceptionMessage(message: "UI.Window.ExternalTools.BrowseButton_Click() failed.", ex: ex, logOnly: true);
+            }
+        }
 
         private void TryToIntegrateCheckBox_CheckedChanged(object sender, EventArgs e)
 		{

--- a/mRemoteV1/UI/Window/ExternalToolsWindow.cs
+++ b/mRemoteV1/UI/Window/ExternalToolsWindow.cs
@@ -32,10 +32,10 @@ namespace mRemoteNG.UI.Window
 			UpdateToolsListView();
 		}
 
-        private static void ExternalTools_FormClosed(object sender, FormClosedEventArgs e)
-		{
+        private void ExternalToolsWindow_FormClosed(object sender, FormClosedEventArgs e)
+        {
             Config.Settings.SettingsSaver.SaveExternalAppsToXML();
-		}
+        }
 
         private void NewTool_Click(object sender, EventArgs e)
 		{
@@ -290,5 +290,5 @@ namespace mRemoteNG.UI.Window
 			}
 		}
         #endregion
-	}
+    }
 }

--- a/mRemoteV1/UI/Window/ExternalToolsWindow.resx
+++ b/mRemoteV1/UI/Window/ExternalToolsWindow.resx
@@ -112,21 +112,21 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="ToolsContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="ToolsContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="ToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="ToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>197, 17</value>
   </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>54</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA


### PR DESCRIPTION
I'm closing #207 and as far as code goes, this is pretty much whats missing; can even be merged straight away with no backward compatibility issues.

But I'm unsure about 2 things:

1. What is `argParser.ParseArguments()` supposed to do? (I've peeked at the code, and it's no easy guess)

2. This, of course, would required adding UI elements to expose this, but just stumbled on [this bit of code](https://github.com/mRemoteNG/mRemoteNG/blob/Patch9/mRemoteV1/UI/Window/ExternalToolsWindow.cs#L196). My intention is to add a new input exactly as there is for _Arguments_, does this require any coordination or how does it work with the internationalisation part? (kinda lost here)
![image](https://user-images.githubusercontent.com/1645623/30243733-28ea5e1c-95a8-11e7-9f21-126bd252597e.png)
