### PR TITLE
force call connect on protocol change in quick connect bar

### DIFF
--- a/mRemoteV1/UI/Forms/frmMain.cs
+++ b/mRemoteV1/UI/Forms/frmMain.cs
@@ -946,7 +946,10 @@ namespace mRemoteNG.UI.Forms
         private void btnQuickConnect_DropDownItemClicked(object sender, ToolStripItemClickedEventArgs e)
 		{
 			SetQuickConnectProtocol(e.ClickedItem.Text);
-		}
+
+            btnQuickConnect_ButtonClick(this, e);
+
+        }
 		
 		private void SetQuickConnectProtocol(string protocol)
 		{


### PR DESCRIPTION
This pretty much sums up, entirely, what I was proposing in #197.

Basically, as soon as you change protocol, it connects. If, for any reason the address field is not populated, it is simply focused and no connection is initiated; as is the case when clicking the connect button.