### PR TITLE
Fixed integrated cli apps?

### DIFF
--- a/mRemoteV1/Connection/Protocol/IntegratedProgram.cs
+++ b/mRemoteV1/Connection/Protocol/IntegratedProgram.cs
@@ -63,8 +63,9 @@ namespace mRemoteNG.Connection.Protocol
 			    _process.Exited += ProcessExited;
 						
 				_process.Start();
-						
-				var startTicks = Environment.TickCount;
+                _process.WaitForInputIdle(Settings.Default.MaxPuttyWaitTime * 1000);
+
+                var startTicks = Environment.TickCount;
 				while (_handle.ToInt32() == 0 & Environment.TickCount < startTicks + Settings.Default.MaxPuttyWaitTime * 1000)
 				{
 					_process.Refresh();

--- a/mRemoteV1/Connection/Protocol/IntegratedProgram.cs
+++ b/mRemoteV1/Connection/Protocol/IntegratedProgram.cs
@@ -23,7 +23,7 @@ namespace mRemoteNG.Connection.Protocol
 		{
 		    if (InterfaceControl.Info == null) return base.Initialize();
 
-		    _externalTool = Runtime.GetExtAppByName(InterfaceControl.Info.ExtApp);
+		    _externalTool = Runtime.GetExtAppByName(InterfaceControl.Info.Name);
 		    _externalTool.ConnectionInfo = InterfaceControl.Info;
 
 		    return base.Initialize();
@@ -63,7 +63,6 @@ namespace mRemoteNG.Connection.Protocol
 			    _process.Exited += ProcessExited;
 						
 				_process.Start();
-				_process.WaitForInputIdle(Settings.Default.MaxPuttyWaitTime * 1000);
 						
 				var startTicks = Environment.TickCount;
 				while (_handle.ToInt32() == 0 & Environment.TickCount < startTicks + Settings.Default.MaxPuttyWaitTime * 1000)

--- a/mRemoteV1/Tools/ExternalTool.cs
+++ b/mRemoteV1/Tools/ExternalTool.cs
@@ -105,7 +105,7 @@ namespace mRemoteNG.Tools
 	    private void SetConnectionInfoFields(ConnectionInfo newConnectionInfo)
         {
             newConnectionInfo.Protocol = ProtocolType.IntApp;
-            newConnectionInfo.ExtApp = DisplayName;
+            newConnectionInfo.ExtApp = FileName;
             newConnectionInfo.Name = DisplayName;
             newConnectionInfo.Panel = Language.strMenuExternalTools;
         }


### PR DESCRIPTION
I've noticed #649 myself, when integration cli apps. There was a bunch of swapped names and paths that I fix here.

But, from all I could try [this little change](https://github.com/mRemoteNG/mRemoteNG/compare/Patch9...pedro2555:issue%23649-cannot-integrate-cli-apps?expand=1#diff-c5eb9dabf670787a86a2a706864efecfL66), that seems super dangerous, allows both cli apps to integrate correctly and I could not find an app that could break this.

I've tried blaming that line back in the tree, but got far too deep to continue (6b4f2d3).
