### PR TITLE
First startup ignores cons param

### DIFF
--- a/mRemoteV1/App/Startup.cs
+++ b/mRemoteV1/App/Startup.cs
@@ -218,6 +218,30 @@ namespace mRemoteNG.App
             }
         }
 
+        /// <summary>
+        /// Returns a path to a file connections XML file for a given absolute or relative path
+        /// </summary>
+        /// <param name="ConsParam">The absolute or relative path to the connection XML file</param>
+        /// <returns>string or null</returns>
+        private static string GetCustomConsPath(string ConsParam)
+        {
+            // early exit condition
+            if (string.IsNullOrEmpty(ConsParam))
+                return null;
+
+            // fallback paths
+            if (File.Exists(ConsParam))
+                return ConsParam;
+
+            if (File.Exists(GeneralAppInfo.HomePath + Path.DirectorySeparatorChar + ConsParam))
+                return GeneralAppInfo.HomePath + Path.DirectorySeparatorChar + ConsParam;
+
+            if (File.Exists(ConnectionsFileInfo.DefaultConnectionsPath + Path.DirectorySeparatorChar + ConsParam))
+                return ConnectionsFileInfo.DefaultConnectionsPath + Path.DirectorySeparatorChar + ConsParam;
+
+            // default case
+            return null;
+        }
 
         private static void ParseCommandLineArgs()
         {
@@ -282,29 +306,13 @@ namespace mRemoteNG.App
                     NoReconnectParam = "norc";
                 }
 
-                if (!string.IsNullOrEmpty(ConsParam))
+                // Handle custom connection file location
+                Settings.Default.CustomConsPath = GetCustomConsPath(ConsParam);
+                if (Settings.Default.CustomConsPath != null)
                 {
-                    if (File.Exists(cmd[ConsParam]))
-                    {
-                        Settings.Default.LoadConsFromCustomLocation = true;
-                        Settings.Default.CustomConsPath = cmd[ConsParam];
-                        return;
-                    }
-                    else
-                    {
-                        if (File.Exists(GeneralAppInfo.HomePath + "\\" + cmd[ConsParam]))
-                        {
-                            Settings.Default.LoadConsFromCustomLocation = true;
-                            Settings.Default.CustomConsPath = GeneralAppInfo.HomePath + "\\" + cmd[ConsParam];
-                            return;
-                        }
-                        if (File.Exists(ConnectionsFileInfo.DefaultConnectionsPath + "\\" + cmd[ConsParam]))
-                        {
-                            Settings.Default.LoadConsFromCustomLocation = true;
-                            Settings.Default.CustomConsPath = ConnectionsFileInfo.DefaultConnectionsPath + "\\" + cmd[ConsParam];
-                            return;
-                        }
-                    }
+                    Settings.Default.LoadConsFromCustomLocation = true;
+                    Settings.Default.Save();
+                    return;
                 }
 
                 if (!string.IsNullOrEmpty(ResetPosParam))

--- a/mRemoteV1/App/Startup.cs
+++ b/mRemoteV1/App/Startup.cs
@@ -229,14 +229,17 @@ namespace mRemoteNG.App
             if (string.IsNullOrEmpty(ConsParam))
                 return null;
 
+            // trim invalid characters for the Combine method (see: https://msdn.microsoft.com/en-us/library/fyy7a5kt.aspx#Anchor_2)
+            ConsParam = ConsParam.Trim().TrimStart('\\').Trim();
+
             // fallback paths
             if (File.Exists(ConsParam))
                 return ConsParam;
 
-            if (File.Exists(GeneralAppInfo.HomePath + Path.DirectorySeparatorChar + ConsParam))
+            if (File.Exists(Path.Combine(GeneralAppInfo.HomePath, ConsParam)))
                 return GeneralAppInfo.HomePath + Path.DirectorySeparatorChar + ConsParam;
 
-            if (File.Exists(ConnectionsFileInfo.DefaultConnectionsPath + Path.DirectorySeparatorChar + ConsParam))
+            if (File.Exists(Path.Combine(ConnectionsFileInfo.DefaultConnectionsPath, ConsParam)))
                 return ConnectionsFileInfo.DefaultConnectionsPath + Path.DirectorySeparatorChar + ConsParam;
 
             // default case

--- a/mRemoteV1/App/Startup.cs
+++ b/mRemoteV1/App/Startup.cs
@@ -284,7 +284,13 @@ namespace mRemoteNG.App
 
                 if (!string.IsNullOrEmpty(ConsParam))
                 {
-                    if (File.Exists(cmd[ConsParam]) == false)
+                    if (File.Exists(cmd[ConsParam]))
+                    {
+                        Settings.Default.LoadConsFromCustomLocation = true;
+                        Settings.Default.CustomConsPath = cmd[ConsParam];
+                        return;
+                    }
+                    else
                     {
                         if (File.Exists(GeneralAppInfo.HomePath + "\\" + cmd[ConsParam]))
                         {
@@ -298,12 +304,6 @@ namespace mRemoteNG.App
                             Settings.Default.CustomConsPath = ConnectionsFileInfo.DefaultConnectionsPath + "\\" + cmd[ConsParam];
                             return;
                         }
-                    }
-                    else
-                    {
-                        Settings.Default.LoadConsFromCustomLocation = true;
-                        Settings.Default.CustomConsPath = cmd[ConsParam];
-                        return;
                     }
                 }
 

--- a/mRemoteV1/App/Startup.cs
+++ b/mRemoteV1/App/Startup.cs
@@ -312,11 +312,7 @@ namespace mRemoteNG.App
                 // Handle custom connection file location
                 Settings.Default.CustomConsPath = GetCustomConsPath(ConsParam);
                 if (Settings.Default.CustomConsPath != null)
-                {
                     Settings.Default.LoadConsFromCustomLocation = true;
-                    Settings.Default.Save();
-                    return;
-                }
 
                 if (!string.IsNullOrEmpty(ResetPosParam))
                 {
@@ -340,6 +336,8 @@ namespace mRemoteNG.App
                 {
                     Settings.Default.ResetToolbars = true;
                 }
+
+                Settings.Default.Save();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
When launching the application for the first time, the settings actually assume the configured default values, which in turn overrides any setting we set before `Application.Run()`; unless we [force save](https://github.com/mRemoteNG/mRemoteNG/compare/Patch9...pedro2555:676?expand=1#diff-14048bc5d1a12b28dc053ffa640f3f19R314)

Fixes #676