### PR TITLE
Default connection password must be decrypted before first use

### DIFF
--- a/mRemoteV1/App/Startup.cs
+++ b/mRemoteV1/App/Startup.cs
@@ -42,8 +42,6 @@ namespace mRemoteNG.App
             ParseCommandLineArgs();
             IeBrowserEmulation.Register();
             GetConnectionIcons();
-            DefaultConnectionInfo.Instance.LoadFrom(Settings.Default, a=>"ConDefault"+a);
-            DefaultConnectionInheritance.Instance.LoadFrom(Settings.Default, a=>"InhDefault"+a);
         }
 
         private static void GetConnectionIcons()

--- a/mRemoteV1/UI/Forms/frmMain.cs
+++ b/mRemoteV1/UI/Forms/frmMain.cs
@@ -187,8 +187,9 @@ namespace mRemoteNG.UI.Forms
             // Create gui config load and save objects
             var settingsLoader = new SettingsLoader(this);
 			settingsLoader.LoadSettings();
-			
-			ApplyLanguage();
+		    LoadDefaultConnectionInfo();
+
+            ApplyLanguage();
 			PopulateQuickConnectProtocolMenu();
 			ThemeManager.ThemeChanged += ApplyThemes;
 			ApplyThemes();
@@ -219,6 +220,12 @@ namespace mRemoteNG.UI.Forms
             Opacity = 1;
 
             ConnectionTreeWindow = Windows.TreeForm;
+        }
+
+        private void LoadDefaultConnectionInfo()
+        {
+            DefaultConnectionInfo.Instance.LoadFrom(Settings.Default, a => "ConDefault" + a);
+            DefaultConnectionInheritance.Instance.LoadFrom(Settings.Default, a => "InhDefault" + a);
         }
 
         private void ApplyLanguage()


### PR DESCRIPTION
Potential resolution to one of the problems brought up in #482 

Rearranged some program initialization code to ensure the ConDefaultPassword property in the Settings class is decrypted before it is assigned to the singleton DefaultConnectionInfo which is used through the app.