### PR TITLE
MR-747 putty sessions.watcher.start watching failed. not found

### DIFF
--- a/mRemoteV1/Config/Putty/PuttySessionsXmingProvider.cs
+++ b/mRemoteV1/Config/Putty/PuttySessionsXmingProvider.cs
@@ -135,15 +135,19 @@ namespace mRemoteNG.Config.Putty
 				
 			try
 			{
-			    _eventWatcher = new FileSystemWatcher(GetSessionsFolderPath())
-			    {
-			        NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite
-			    };
-			    _eventWatcher.Changed += OnFileSystemEventArrived;
-				_eventWatcher.Created += OnFileSystemEventArrived;
-				_eventWatcher.Deleted += OnFileSystemEventArrived;
-				_eventWatcher.Renamed += OnFileSystemEventArrived;
-				_eventWatcher.EnableRaisingEvents = true;
+                var sessionsFolderPath = GetSessionsFolderPath();
+                if (Directory.Exists(sessionsFolderPath))
+                {
+                    _eventWatcher = new FileSystemWatcher(sessionsFolderPath)
+                    {
+                        NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite
+                    };
+                    _eventWatcher.Changed += OnFileSystemEventArrived;
+                    _eventWatcher.Created += OnFileSystemEventArrived;
+                    _eventWatcher.Deleted += OnFileSystemEventArrived;
+                    _eventWatcher.Renamed += OnFileSystemEventArrived;
+                    _eventWatcher.EnableRaisingEvents = true;
+                }
 			}
 			catch (Exception ex)
 			{

--- a/mRemoteV1/Config/Putty/PuttySessionsXmingProvider.cs
+++ b/mRemoteV1/Config/Putty/PuttySessionsXmingProvider.cs
@@ -169,7 +169,7 @@ namespace mRemoteNG.Config.Putty
 		private static string GetPuttyConfPath()
 		{
 		    var puttyPath = mRemoteNG.Settings.Default.UseCustomPuttyPath ? mRemoteNG.Settings.Default.CustomPuttyPath : App.Info.GeneralAppInfo.PuttyPath;
-		    return Path.Combine(puttyPath, "putty.conf");
+		    return Path.Combine(Path.GetDirectoryName(puttyPath), "putty.conf");
 		}
 			
 		private static string GetSessionsFolderPath()


### PR DESCRIPTION
The issue was that the FileSystemWatcher for the Putty Sessions (non-portable) was being initiated on a path that didn't exist, so an exception was being thrown.  I added a check to determine if the path exists before the FileSystemWatcher is initiated.

The other issue is that the full path of putty.exe was being combined with the Putty.conf and created an incorrect path.  (var puttyConfPath = "path_to_exe\PuTTYNG.exe\putty.conf").   I modified the statement to only combine the folder of the exe to the conf file.