### PR TITLE
Rearranged settings elements

### DIFF
--- a/mRemoteV1.sln
+++ b/mRemoteV1.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+VisualStudioVersion = 15.0.27004.2008
 MinimumVisualStudioVersion = 14.0.25420.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mRemoteV1", "mRemoteV1\mRemoteV1.csproj", "{4934A491-40BC-4E5B-9166-EA1169A220F6}"
 EndProject
@@ -46,6 +46,7 @@ Global
 		{4934A491-40BC-4E5B-9166-EA1169A220F6}.Release Portable|x86.ActiveCfg = Release Portable|x86
 		{4934A491-40BC-4E5B-9166-EA1169A220F6}.Release Portable|x86.Build.0 = Release Portable|x86
 		{4934A491-40BC-4E5B-9166-EA1169A220F6}.Release|Any CPU.ActiveCfg = Release|x86
+		{4934A491-40BC-4E5B-9166-EA1169A220F6}.Release|Any CPU.Build.0 = Release|x86
 		{4934A491-40BC-4E5B-9166-EA1169A220F6}.Release|x86.ActiveCfg = Release|x86
 		{4934A491-40BC-4E5B-9166-EA1169A220F6}.Release|x86.Build.0 = Release|x86
 		{1453B37F-8621-499E-B0B2-6091F76DC0BB}.Debug Portable|Any CPU.ActiveCfg = Debug Portable|x86
@@ -62,6 +63,7 @@ Global
 		{1453B37F-8621-499E-B0B2-6091F76DC0BB}.Release Portable|x86.ActiveCfg = Release Portable|x86
 		{1453B37F-8621-499E-B0B2-6091F76DC0BB}.Release Portable|x86.Build.0 = Release Portable|x86
 		{1453B37F-8621-499E-B0B2-6091F76DC0BB}.Release|Any CPU.ActiveCfg = Release|x86
+		{1453B37F-8621-499E-B0B2-6091F76DC0BB}.Release|Any CPU.Build.0 = Release|x86
 		{1453B37F-8621-499E-B0B2-6091F76DC0BB}.Release|x86.ActiveCfg = Release|x86
 		{1453B37F-8621-499E-B0B2-6091F76DC0BB}.Release|x86.Build.0 = Release|x86
 		{5423D985-CB48-4344-B47F-E8C6D60C8B04}.Debug Portable|Any CPU.ActiveCfg = Release|x86
@@ -78,6 +80,7 @@ Global
 		{5423D985-CB48-4344-B47F-E8C6D60C8B04}.Release Portable|Any CPU.Build.0 = Release|x86
 		{5423D985-CB48-4344-B47F-E8C6D60C8B04}.Release Portable|x86.ActiveCfg = Release|x86
 		{5423D985-CB48-4344-B47F-E8C6D60C8B04}.Release|Any CPU.ActiveCfg = Release|x86
+		{5423D985-CB48-4344-B47F-E8C6D60C8B04}.Release|Any CPU.Build.0 = Release|x86
 		{5423D985-CB48-4344-B47F-E8C6D60C8B04}.Release|x86.ActiveCfg = Release|x86
 		{F0168B9F-6815-40DF-BA53-46CEE7683B68}.Debug Portable|Any CPU.ActiveCfg = Debug Portable|x86
 		{F0168B9F-6815-40DF-BA53-46CEE7683B68}.Debug Portable|x86.ActiveCfg = Debug Portable|x86
@@ -118,5 +121,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{5423D985-CB48-4344-B47F-E8C6D60C8B04} = {4FE795BE-646E-4F1B-BAD0-A68EA26394DD}
 		{F0168B9F-6815-40DF-BA53-46CEE7683B68} = {4FE795BE-646E-4F1B-BAD0-A68EA26394DD}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5D390A0C-2FC4-4908-B86E-7E4DEF5916EC}
 	EndGlobalSection
 EndGlobal

--- a/mRemoteV1/UI/Forms/OptionsPages/AppearancePage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/AppearancePage.Designer.cs
@@ -30,99 +30,104 @@ namespace mRemoteNG.UI.Forms.OptionsPages
 		//Do not modify it using the code editor.
 		[System.Diagnostics.DebuggerStepThrough()]private void InitializeComponent()
 		{
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AppearancePage));
-			this.lblLanguageRestartRequired = new Controls.Base.NGLabel();
-			this.cboLanguage = new Controls.Base.NGComboBox();
-			this.lblLanguage = new Controls.Base.NGLabel();
-			this.chkShowFullConnectionsFilePathInTitle = new Controls.Base.NGCheckBox();
-			this.chkShowDescriptionTooltipsInTree = new Controls.Base.NGCheckBox();
-			this.chkShowSystemTrayIcon = new Controls.Base.NGCheckBox();
-			this.chkMinimizeToSystemTray = new Controls.Base.NGCheckBox();
-			this.SuspendLayout();
-			//
-			//lblLanguageRestartRequired
-			//
-			this.lblLanguageRestartRequired.AutoSize = true;
-			this.lblLanguageRestartRequired.Location = new System.Drawing.Point(3, 56);
-			this.lblLanguageRestartRequired.Name = "lblLanguageRestartRequired";
-			this.lblLanguageRestartRequired.Size = new System.Drawing.Size(380, 13);
-			this.lblLanguageRestartRequired.TabIndex = 9;
-			this.lblLanguageRestartRequired.Text = "mRemoteNG must be restarted before changes to the language will take effect.";
-			//
-			//cboLanguage
-			//
-			this.cboLanguage.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cboLanguage.FormattingEnabled = true;
-			this.cboLanguage.Location = new System.Drawing.Point(3, 24);
-			this.cboLanguage.Name = "cboLanguage";
-			this.cboLanguage.Size = new System.Drawing.Size(304, 21);
-			this.cboLanguage.Sorted = true;
-			this.cboLanguage.TabIndex = 8;
-			//
-			//lblLanguage
-			//
-			this.lblLanguage.AutoSize = true;
-			this.lblLanguage.Location = new System.Drawing.Point(3, 0);
-			this.lblLanguage.Name = "lblLanguage";
-			this.lblLanguage.Size = new System.Drawing.Size(55, 13);
-			this.lblLanguage.TabIndex = 7;
-			this.lblLanguage.Text = "Language";
-			//
-			//chkShowFullConnectionsFilePathInTitle
-			//
-			this.chkShowFullConnectionsFilePathInTitle.AutoSize = true;
-			this.chkShowFullConnectionsFilePathInTitle.Location = new System.Drawing.Point(3, 141);
-			this.chkShowFullConnectionsFilePathInTitle.Name = "chkShowFullConnectionsFilePathInTitle";
-			this.chkShowFullConnectionsFilePathInTitle.Size = new System.Drawing.Size(239, 17);
-			this.chkShowFullConnectionsFilePathInTitle.TabIndex = 11;
-			this.chkShowFullConnectionsFilePathInTitle.Text = "Show full connections file path in window title";
-			this.chkShowFullConnectionsFilePathInTitle.UseVisualStyleBackColor = true;
-			//
-			//chkShowDescriptionTooltipsInTree
-			//
-			this.chkShowDescriptionTooltipsInTree.AutoSize = true;
-			this.chkShowDescriptionTooltipsInTree.Location = new System.Drawing.Point(3, 118);
-			this.chkShowDescriptionTooltipsInTree.Name = "chkShowDescriptionTooltipsInTree";
-			this.chkShowDescriptionTooltipsInTree.Size = new System.Drawing.Size(231, 17);
-			this.chkShowDescriptionTooltipsInTree.TabIndex = 10;
-			this.chkShowDescriptionTooltipsInTree.Text = "Show description tooltips in connection tree";
-			this.chkShowDescriptionTooltipsInTree.UseVisualStyleBackColor = true;
-			//
-			//chkShowSystemTrayIcon
-			//
-			this.chkShowSystemTrayIcon.AutoSize = true;
-			this.chkShowSystemTrayIcon.Location = new System.Drawing.Point(3, 187);
-			this.chkShowSystemTrayIcon.Name = "chkShowSystemTrayIcon";
-			this.chkShowSystemTrayIcon.Size = new System.Drawing.Size(172, 17);
-			this.chkShowSystemTrayIcon.TabIndex = 12;
-			this.chkShowSystemTrayIcon.Text = "Always show System Tray Icon";
-			this.chkShowSystemTrayIcon.UseVisualStyleBackColor = true;
-			//
-			//chkMinimizeToSystemTray
-			//
-			this.chkMinimizeToSystemTray.AutoSize = true;
-			this.chkMinimizeToSystemTray.Location = new System.Drawing.Point(3, 210);
-			this.chkMinimizeToSystemTray.Name = "chkMinimizeToSystemTray";
-			this.chkMinimizeToSystemTray.Size = new System.Drawing.Size(139, 17);
-			this.chkMinimizeToSystemTray.TabIndex = 13;
-			this.chkMinimizeToSystemTray.Text = "Minimize to System Tray";
-			this.chkMinimizeToSystemTray.UseVisualStyleBackColor = true;
-			//
-			//AppearancePage
-			//
-			this.Controls.Add(this.lblLanguageRestartRequired);
-			this.Controls.Add(this.cboLanguage);
-			this.Controls.Add(this.lblLanguage);
-			this.Controls.Add(this.chkShowFullConnectionsFilePathInTitle);
-			this.Controls.Add(this.chkShowDescriptionTooltipsInTree);
-			this.Controls.Add(this.chkShowSystemTrayIcon);
-			this.Controls.Add(this.chkMinimizeToSystemTray);
-			this.Name = "AppearancePage";
-			this.PageIcon = (System.Drawing.Icon) (resources.GetObject("$this.PageIcon"));
-			this.Size = new System.Drawing.Size(610, 489);
-			this.ResumeLayout(false);
-			this.PerformLayout();
-				
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AppearancePage));
+            this.lblLanguageRestartRequired = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.cboLanguage = new mRemoteNG.UI.Controls.Base.NGComboBox();
+            this.lblLanguage = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.chkShowFullConnectionsFilePathInTitle = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkShowDescriptionTooltipsInTree = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkShowSystemTrayIcon = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkMinimizeToSystemTray = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.SuspendLayout();
+            // 
+            // lblLanguageRestartRequired
+            // 
+            this.lblLanguageRestartRequired.AutoSize = true;
+            this.lblLanguageRestartRequired.Location = new System.Drawing.Point(3, 56);
+            this.lblLanguageRestartRequired.Name = "lblLanguageRestartRequired";
+            this.lblLanguageRestartRequired.Size = new System.Drawing.Size(380, 13);
+            this.lblLanguageRestartRequired.TabIndex = 9;
+            this.lblLanguageRestartRequired.Text = "mRemoteNG must be restarted before changes to the language will take effect.";
+            // 
+            // cboLanguage
+            // 
+            this.cboLanguage._mice = mRemoteNG.UI.Controls.Base.NGComboBox.MouseState.HOVER;
+            this.cboLanguage.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboLanguage.FormattingEnabled = true;
+            this.cboLanguage.Location = new System.Drawing.Point(3, 24);
+            this.cboLanguage.Name = "cboLanguage";
+            this.cboLanguage.Size = new System.Drawing.Size(304, 21);
+            this.cboLanguage.Sorted = true;
+            this.cboLanguage.TabIndex = 8;
+            // 
+            // lblLanguage
+            // 
+            this.lblLanguage.AutoSize = true;
+            this.lblLanguage.Location = new System.Drawing.Point(3, 3);
+            this.lblLanguage.Name = "lblLanguage";
+            this.lblLanguage.Size = new System.Drawing.Size(55, 13);
+            this.lblLanguage.TabIndex = 7;
+            this.lblLanguage.Text = "Language";
+            // 
+            // chkShowFullConnectionsFilePathInTitle
+            // 
+            this.chkShowFullConnectionsFilePathInTitle._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkShowFullConnectionsFilePathInTitle.AutoSize = true;
+            this.chkShowFullConnectionsFilePathInTitle.Location = new System.Drawing.Point(3, 127);
+            this.chkShowFullConnectionsFilePathInTitle.Name = "chkShowFullConnectionsFilePathInTitle";
+            this.chkShowFullConnectionsFilePathInTitle.Size = new System.Drawing.Size(239, 17);
+            this.chkShowFullConnectionsFilePathInTitle.TabIndex = 11;
+            this.chkShowFullConnectionsFilePathInTitle.Text = "Show full connections file path in window title";
+            this.chkShowFullConnectionsFilePathInTitle.UseVisualStyleBackColor = true;
+            // 
+            // chkShowDescriptionTooltipsInTree
+            // 
+            this.chkShowDescriptionTooltipsInTree._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkShowDescriptionTooltipsInTree.AutoSize = true;
+            this.chkShowDescriptionTooltipsInTree.Location = new System.Drawing.Point(3, 104);
+            this.chkShowDescriptionTooltipsInTree.Name = "chkShowDescriptionTooltipsInTree";
+            this.chkShowDescriptionTooltipsInTree.Size = new System.Drawing.Size(231, 17);
+            this.chkShowDescriptionTooltipsInTree.TabIndex = 10;
+            this.chkShowDescriptionTooltipsInTree.Text = "Show description tooltips in connection tree";
+            this.chkShowDescriptionTooltipsInTree.UseVisualStyleBackColor = true;
+            // 
+            // chkShowSystemTrayIcon
+            // 
+            this.chkShowSystemTrayIcon._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkShowSystemTrayIcon.AutoSize = true;
+            this.chkShowSystemTrayIcon.Location = new System.Drawing.Point(3, 173);
+            this.chkShowSystemTrayIcon.Name = "chkShowSystemTrayIcon";
+            this.chkShowSystemTrayIcon.Size = new System.Drawing.Size(172, 17);
+            this.chkShowSystemTrayIcon.TabIndex = 12;
+            this.chkShowSystemTrayIcon.Text = "Always show System Tray Icon";
+            this.chkShowSystemTrayIcon.UseVisualStyleBackColor = true;
+            // 
+            // chkMinimizeToSystemTray
+            // 
+            this.chkMinimizeToSystemTray._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkMinimizeToSystemTray.AutoSize = true;
+            this.chkMinimizeToSystemTray.Location = new System.Drawing.Point(3, 196);
+            this.chkMinimizeToSystemTray.Name = "chkMinimizeToSystemTray";
+            this.chkMinimizeToSystemTray.Size = new System.Drawing.Size(139, 17);
+            this.chkMinimizeToSystemTray.TabIndex = 13;
+            this.chkMinimizeToSystemTray.Text = "Minimize to System Tray";
+            this.chkMinimizeToSystemTray.UseVisualStyleBackColor = true;
+            // 
+            // AppearancePage
+            // 
+            this.Controls.Add(this.lblLanguageRestartRequired);
+            this.Controls.Add(this.cboLanguage);
+            this.Controls.Add(this.lblLanguage);
+            this.Controls.Add(this.chkShowFullConnectionsFilePathInTitle);
+            this.Controls.Add(this.chkShowDescriptionTooltipsInTree);
+            this.Controls.Add(this.chkShowSystemTrayIcon);
+            this.Controls.Add(this.chkMinimizeToSystemTray);
+            this.Name = "AppearancePage";
+            this.PageIcon = ((System.Drawing.Icon)(resources.GetObject("$this.PageIcon")));
+            this.Size = new System.Drawing.Size(610, 489);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
 		}
 		internal Controls.Base.NGLabel lblLanguageRestartRequired;
 		internal Controls.Base.NGComboBox cboLanguage;

--- a/mRemoteV1/UI/Forms/OptionsPages/AppearancePage.resx
+++ b/mRemoteV1/UI/Forms/OptionsPages/AppearancePage.resx
@@ -112,12 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.PageIcon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAQAEBAQAAEABAAoAQAARgAAABAQAAABAAgAaAUAAG4BAAAQEAAAAQAYAGgDAADWBgAAEBAAAAEA

--- a/mRemoteV1/UI/Forms/OptionsPages/ConnectionsPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/ConnectionsPage.Designer.cs
@@ -31,47 +31,37 @@ namespace mRemoteNG.UI.Forms.OptionsPages
 		[System.Diagnostics.DebuggerStepThrough()]private void InitializeComponent()
 		{
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ConnectionsPage));
-            this.pnlRdpReconnectionCount = new System.Windows.Forms.Panel();
-            this.numRDPConTimeout = new Controls.Base.NGNumericUpDown();
-            this.lblRDPConTimeout = new Controls.Base.NGLabel();
-            this.lblRdpReconnectionCount = new Controls.Base.NGLabel();
-            this.numRdpReconnectionCount = new Controls.Base.NGNumericUpDown();
-            this.chkSingleClickOnConnectionOpensIt = new Controls.Base.NGCheckBox();
-            this.chkHostnameLikeDisplayName = new Controls.Base.NGCheckBox();
-            this.chkSingleClickOnOpenedConnectionSwitchesToIt = new Controls.Base.NGCheckBox();
-            this.pnlAutoSave = new System.Windows.Forms.Panel();
-            this.lblAutoSave1 = new Controls.Base.NGLabel();
-            this.numAutoSave = new Controls.Base.NGNumericUpDown();
-            this.lblAutoSave2 = new Controls.Base.NGLabel();
+            this.numRDPConTimeout = new mRemoteNG.UI.Controls.Base.NGNumericUpDown();
+            this.lblRDPConTimeout = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.lblRdpReconnectionCount = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.numRdpReconnectionCount = new mRemoteNG.UI.Controls.Base.NGNumericUpDown();
+            this.chkSingleClickOnConnectionOpensIt = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkHostnameLikeDisplayName = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkSingleClickOnOpenedConnectionSwitchesToIt = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.lblAutoSave1 = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.numAutoSave = new mRemoteNG.UI.Controls.Base.NGNumericUpDown();
             this.pnlConfirmCloseConnection = new System.Windows.Forms.Panel();
-            this.lblClosingConnections = new Controls.Base.NGLabel();
-            this.radCloseWarnAll = new Controls.Base.NGRadioButton();
-            this.radCloseWarnMultiple = new Controls.Base.NGRadioButton();
-            this.radCloseWarnExit = new Controls.Base.NGRadioButton();
-            this.radCloseWarnNever = new Controls.Base.NGRadioButton();
-            this.pnlRdpReconnectionCount.SuspendLayout();
+            this.lblClosingConnections = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.radCloseWarnAll = new mRemoteNG.UI.Controls.Base.NGRadioButton();
+            this.radCloseWarnMultiple = new mRemoteNG.UI.Controls.Base.NGRadioButton();
+            this.radCloseWarnExit = new mRemoteNG.UI.Controls.Base.NGRadioButton();
+            this.radCloseWarnNever = new mRemoteNG.UI.Controls.Base.NGRadioButton();
+            this.pnlRdpReconnectionCount = new System.Windows.Forms.TableLayoutPanel();
+            this.pnlRdpConnectionTimeout = new System.Windows.Forms.TableLayoutPanel();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             ((System.ComponentModel.ISupportInitialize)(this.numRDPConTimeout)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numRdpReconnectionCount)).BeginInit();
-            this.pnlAutoSave.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numAutoSave)).BeginInit();
             this.pnlConfirmCloseConnection.SuspendLayout();
+            this.pnlRdpReconnectionCount.SuspendLayout();
+            this.pnlRdpConnectionTimeout.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // pnlRdpReconnectionCount
-            // 
-            this.pnlRdpReconnectionCount.Controls.Add(this.numRDPConTimeout);
-            this.pnlRdpReconnectionCount.Controls.Add(this.lblRDPConTimeout);
-            this.pnlRdpReconnectionCount.Controls.Add(this.lblRdpReconnectionCount);
-            this.pnlRdpReconnectionCount.Controls.Add(this.numRdpReconnectionCount);
-            this.pnlRdpReconnectionCount.Location = new System.Drawing.Point(3, 69);
-            this.pnlRdpReconnectionCount.Name = "pnlRdpReconnectionCount";
-            this.pnlRdpReconnectionCount.Size = new System.Drawing.Size(596, 29);
-            this.pnlRdpReconnectionCount.TabIndex = 10;
             // 
             // numRDPConTimeout
             // 
             this.numRDPConTimeout.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.numRDPConTimeout.Location = new System.Drawing.Point(369, 7);
+            this.numRDPConTimeout.Location = new System.Drawing.Point(270, 3);
             this.numRDPConTimeout.Maximum = new decimal(new int[] {
             600,
             0,
@@ -93,26 +83,28 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // lblRDPConTimeout
             // 
-            this.lblRDPConTimeout.Location = new System.Drawing.Point(226, 9);
+            this.lblRDPConTimeout.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblRDPConTimeout.Location = new System.Drawing.Point(3, 6);
             this.lblRDPConTimeout.Name = "lblRDPConTimeout";
             this.lblRDPConTimeout.Size = new System.Drawing.Size(137, 13);
             this.lblRDPConTimeout.TabIndex = 2;
             this.lblRDPConTimeout.Text = "RDP Connection Timeout";
-            this.lblRDPConTimeout.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.lblRDPConTimeout.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // lblRdpReconnectionCount
             // 
-            this.lblRdpReconnectionCount.Location = new System.Drawing.Point(3, 9);
+            this.lblRdpReconnectionCount.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblRdpReconnectionCount.Location = new System.Drawing.Point(3, 6);
             this.lblRdpReconnectionCount.Name = "lblRdpReconnectionCount";
             this.lblRdpReconnectionCount.Size = new System.Drawing.Size(139, 13);
             this.lblRdpReconnectionCount.TabIndex = 0;
             this.lblRdpReconnectionCount.Text = "RDP Reconnection Count";
-            this.lblRdpReconnectionCount.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.lblRdpReconnectionCount.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // numRdpReconnectionCount
             // 
             this.numRdpReconnectionCount.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.numRdpReconnectionCount.Location = new System.Drawing.Point(145, 6);
+            this.numRdpReconnectionCount.Location = new System.Drawing.Point(270, 3);
             this.numRdpReconnectionCount.Maximum = new decimal(new int[] {
             20,
             0,
@@ -129,8 +121,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkSingleClickOnConnectionOpensIt
             // 
+            this.chkSingleClickOnConnectionOpensIt._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkSingleClickOnConnectionOpensIt.AutoSize = true;
-            this.chkSingleClickOnConnectionOpensIt.Location = new System.Drawing.Point(3, 0);
+            this.chkSingleClickOnConnectionOpensIt.Location = new System.Drawing.Point(3, 3);
             this.chkSingleClickOnConnectionOpensIt.Name = "chkSingleClickOnConnectionOpensIt";
             this.chkSingleClickOnConnectionOpensIt.Size = new System.Drawing.Size(191, 17);
             this.chkSingleClickOnConnectionOpensIt.TabIndex = 7;
@@ -139,8 +132,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkHostnameLikeDisplayName
             // 
+            this.chkHostnameLikeDisplayName._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkHostnameLikeDisplayName.AutoSize = true;
-            this.chkHostnameLikeDisplayName.Location = new System.Drawing.Point(3, 46);
+            this.chkHostnameLikeDisplayName.Location = new System.Drawing.Point(3, 49);
             this.chkHostnameLikeDisplayName.Name = "chkHostnameLikeDisplayName";
             this.chkHostnameLikeDisplayName.Size = new System.Drawing.Size(328, 17);
             this.chkHostnameLikeDisplayName.TabIndex = 9;
@@ -149,37 +143,29 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkSingleClickOnOpenedConnectionSwitchesToIt
             // 
+            this.chkSingleClickOnOpenedConnectionSwitchesToIt._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkSingleClickOnOpenedConnectionSwitchesToIt.AutoSize = true;
-            this.chkSingleClickOnOpenedConnectionSwitchesToIt.Location = new System.Drawing.Point(3, 23);
+            this.chkSingleClickOnOpenedConnectionSwitchesToIt.Location = new System.Drawing.Point(3, 26);
             this.chkSingleClickOnOpenedConnectionSwitchesToIt.Name = "chkSingleClickOnOpenedConnectionSwitchesToIt";
             this.chkSingleClickOnOpenedConnectionSwitchesToIt.Size = new System.Drawing.Size(457, 17);
             this.chkSingleClickOnOpenedConnectionSwitchesToIt.TabIndex = 8;
             this.chkSingleClickOnOpenedConnectionSwitchesToIt.Text = global::mRemoteNG.Language.strSingleClickOnOpenConnectionSwitchesToIt;
             this.chkSingleClickOnOpenedConnectionSwitchesToIt.UseVisualStyleBackColor = true;
             // 
-            // pnlAutoSave
-            // 
-            this.pnlAutoSave.Controls.Add(this.lblAutoSave1);
-            this.pnlAutoSave.Controls.Add(this.numAutoSave);
-            this.pnlAutoSave.Controls.Add(this.lblAutoSave2);
-            this.pnlAutoSave.Location = new System.Drawing.Point(3, 104);
-            this.pnlAutoSave.Name = "pnlAutoSave";
-            this.pnlAutoSave.Size = new System.Drawing.Size(596, 29);
-            this.pnlAutoSave.TabIndex = 11;
-            // 
             // lblAutoSave1
             // 
-            this.lblAutoSave1.Location = new System.Drawing.Point(6, 9);
+            this.lblAutoSave1.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblAutoSave1.Location = new System.Drawing.Point(3, 6);
             this.lblAutoSave1.Name = "lblAutoSave1";
-            this.lblAutoSave1.Size = new System.Drawing.Size(288, 13);
+            this.lblAutoSave1.Size = new System.Drawing.Size(261, 13);
             this.lblAutoSave1.TabIndex = 0;
-            this.lblAutoSave1.Text = "Auto Save every:";
-            this.lblAutoSave1.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.lblAutoSave1.Text = "Auto Save  in Minutes (0 means disabled)";
+            this.lblAutoSave1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // numAutoSave
             // 
             this.numAutoSave.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.numAutoSave.Location = new System.Drawing.Point(300, 7);
+            this.numAutoSave.Location = new System.Drawing.Point(270, 3);
             this.numAutoSave.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -189,15 +175,6 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.numAutoSave.Size = new System.Drawing.Size(53, 20);
             this.numAutoSave.TabIndex = 1;
             // 
-            // lblAutoSave2
-            // 
-            this.lblAutoSave2.AutoSize = true;
-            this.lblAutoSave2.Location = new System.Drawing.Point(359, 9);
-            this.lblAutoSave2.Name = "lblAutoSave2";
-            this.lblAutoSave2.Size = new System.Drawing.Size(135, 13);
-            this.lblAutoSave2.TabIndex = 2;
-            this.lblAutoSave2.Text = "Minutes (0 means disabled)";
-            // 
             // pnlConfirmCloseConnection
             // 
             this.pnlConfirmCloseConnection.Controls.Add(this.lblClosingConnections);
@@ -205,15 +182,15 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.pnlConfirmCloseConnection.Controls.Add(this.radCloseWarnMultiple);
             this.pnlConfirmCloseConnection.Controls.Add(this.radCloseWarnExit);
             this.pnlConfirmCloseConnection.Controls.Add(this.radCloseWarnNever);
-            this.pnlConfirmCloseConnection.Location = new System.Drawing.Point(3, 139);
+            this.pnlConfirmCloseConnection.Location = new System.Drawing.Point(3, 171);
             this.pnlConfirmCloseConnection.Name = "pnlConfirmCloseConnection";
-            this.pnlConfirmCloseConnection.Size = new System.Drawing.Size(596, 137);
+            this.pnlConfirmCloseConnection.Size = new System.Drawing.Size(595, 137);
             this.pnlConfirmCloseConnection.TabIndex = 13;
             // 
             // lblClosingConnections
             // 
             this.lblClosingConnections.AutoSize = true;
-            this.lblClosingConnections.Location = new System.Drawing.Point(3, 9);
+            this.lblClosingConnections.Location = new System.Drawing.Point(3, 12);
             this.lblClosingConnections.Name = "lblClosingConnections";
             this.lblClosingConnections.Size = new System.Drawing.Size(136, 13);
             this.lblClosingConnections.TabIndex = 0;
@@ -222,7 +199,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // radCloseWarnAll
             // 
             this.radCloseWarnAll.AutoSize = true;
-            this.radCloseWarnAll.Location = new System.Drawing.Point(16, 31);
+            this.radCloseWarnAll.Location = new System.Drawing.Point(16, 34);
             this.radCloseWarnAll.Name = "radCloseWarnAll";
             this.radCloseWarnAll.Size = new System.Drawing.Size(194, 17);
             this.radCloseWarnAll.TabIndex = 1;
@@ -233,7 +210,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // radCloseWarnMultiple
             // 
             this.radCloseWarnMultiple.AutoSize = true;
-            this.radCloseWarnMultiple.Location = new System.Drawing.Point(16, 54);
+            this.radCloseWarnMultiple.Location = new System.Drawing.Point(16, 57);
             this.radCloseWarnMultiple.Name = "radCloseWarnMultiple";
             this.radCloseWarnMultiple.Size = new System.Drawing.Size(254, 17);
             this.radCloseWarnMultiple.TabIndex = 2;
@@ -244,7 +221,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // radCloseWarnExit
             // 
             this.radCloseWarnExit.AutoSize = true;
-            this.radCloseWarnExit.Location = new System.Drawing.Point(16, 77);
+            this.radCloseWarnExit.Location = new System.Drawing.Point(16, 80);
             this.radCloseWarnExit.Name = "radCloseWarnExit";
             this.radCloseWarnExit.Size = new System.Drawing.Size(216, 17);
             this.radCloseWarnExit.TabIndex = 3;
@@ -255,7 +232,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // radCloseWarnNever
             // 
             this.radCloseWarnNever.AutoSize = true;
-            this.radCloseWarnNever.Location = new System.Drawing.Point(16, 100);
+            this.radCloseWarnNever.Location = new System.Drawing.Point(16, 103);
             this.radCloseWarnNever.Name = "radCloseWarnNever";
             this.radCloseWarnNever.Size = new System.Drawing.Size(226, 17);
             this.radCloseWarnNever.TabIndex = 4;
@@ -263,40 +240,83 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.radCloseWarnNever.Text = "Do not warn me when closing connections";
             this.radCloseWarnNever.UseVisualStyleBackColor = true;
             // 
+            // pnlRdpReconnectionCount
+            // 
+            this.pnlRdpReconnectionCount.ColumnCount = 2;
+            this.pnlRdpReconnectionCount.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 45F));
+            this.pnlRdpReconnectionCount.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 55F));
+            this.pnlRdpReconnectionCount.Controls.Add(this.lblRdpReconnectionCount, 0, 0);
+            this.pnlRdpReconnectionCount.Controls.Add(this.numRdpReconnectionCount, 1, 0);
+            this.pnlRdpReconnectionCount.Location = new System.Drawing.Point(4, 75);
+            this.pnlRdpReconnectionCount.Name = "pnlRdpReconnectionCount";
+            this.pnlRdpReconnectionCount.RowCount = 1;
+            this.pnlRdpReconnectionCount.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.pnlRdpReconnectionCount.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.pnlRdpReconnectionCount.Size = new System.Drawing.Size(595, 26);
+            this.pnlRdpReconnectionCount.TabIndex = 14;
+            // 
+            // pnlRdpConnectionTimeout
+            // 
+            this.pnlRdpConnectionTimeout.ColumnCount = 2;
+            this.pnlRdpConnectionTimeout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 45F));
+            this.pnlRdpConnectionTimeout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 55F));
+            this.pnlRdpConnectionTimeout.Controls.Add(this.numRDPConTimeout, 1, 0);
+            this.pnlRdpConnectionTimeout.Controls.Add(this.lblRDPConTimeout, 0, 0);
+            this.pnlRdpConnectionTimeout.Location = new System.Drawing.Point(4, 107);
+            this.pnlRdpConnectionTimeout.Name = "pnlRdpConnectionTimeout";
+            this.pnlRdpConnectionTimeout.RowCount = 1;
+            this.pnlRdpConnectionTimeout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.pnlRdpConnectionTimeout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.pnlRdpConnectionTimeout.Size = new System.Drawing.Size(595, 26);
+            this.pnlRdpConnectionTimeout.TabIndex = 15;
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 45F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 55F));
+            this.tableLayoutPanel1.Controls.Add(this.numAutoSave, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.lblAutoSave1, 0, 0);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(4, 139);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 1;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(595, 26);
+            this.tableLayoutPanel1.TabIndex = 16;
+            // 
             // ConnectionsPage
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.Controls.Add(this.pnlRdpConnectionTimeout);
             this.Controls.Add(this.pnlRdpReconnectionCount);
             this.Controls.Add(this.chkSingleClickOnConnectionOpensIt);
             this.Controls.Add(this.chkHostnameLikeDisplayName);
             this.Controls.Add(this.chkSingleClickOnOpenedConnectionSwitchesToIt);
-            this.Controls.Add(this.pnlAutoSave);
             this.Controls.Add(this.pnlConfirmCloseConnection);
             this.Name = "ConnectionsPage";
             this.PageIcon = ((System.Drawing.Icon)(resources.GetObject("$this.PageIcon")));
             this.Size = new System.Drawing.Size(610, 489);
-            this.pnlRdpReconnectionCount.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.numRDPConTimeout)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numRdpReconnectionCount)).EndInit();
-            this.pnlAutoSave.ResumeLayout(false);
-            this.pnlAutoSave.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numAutoSave)).EndInit();
             this.pnlConfirmCloseConnection.ResumeLayout(false);
             this.pnlConfirmCloseConnection.PerformLayout();
+            this.pnlRdpReconnectionCount.ResumeLayout(false);
+            this.pnlRdpConnectionTimeout.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
 		}
-		internal System.Windows.Forms.Panel pnlRdpReconnectionCount;
 		internal Controls.Base.NGLabel lblRdpReconnectionCount;
 		internal Controls.Base.NGCheckBox chkSingleClickOnConnectionOpensIt;
 		internal Controls.Base.NGCheckBox chkHostnameLikeDisplayName;
 		internal Controls.Base.NGCheckBox chkSingleClickOnOpenedConnectionSwitchesToIt;
-		internal System.Windows.Forms.Panel pnlAutoSave;
 		internal Controls.Base.NGLabel lblAutoSave1;
 		internal Controls.Base.NGNumericUpDown numAutoSave;
-		internal Controls.Base.NGLabel lblAutoSave2;
 		internal System.Windows.Forms.Panel pnlConfirmCloseConnection;
 		internal Controls.Base.NGLabel lblClosingConnections;
 		internal Controls.Base.NGRadioButton radCloseWarnAll;
@@ -306,5 +326,8 @@ namespace mRemoteNG.UI.Forms.OptionsPages
         internal Controls.Base.NGNumericUpDown numRDPConTimeout;
         internal Controls.Base.NGLabel lblRDPConTimeout;
         internal Controls.Base.NGNumericUpDown numRdpReconnectionCount;
+        private System.Windows.Forms.TableLayoutPanel pnlRdpReconnectionCount;
+        private System.Windows.Forms.TableLayoutPanel pnlRdpConnectionTimeout;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
     }
 }

--- a/mRemoteV1/UI/Forms/OptionsPages/ConnectionsPage.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/ConnectionsPage.cs
@@ -32,7 +32,6 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             lblRDPConTimeout.Text = Language.strRDPOverallConnectionTimeout;
 
             lblAutoSave1.Text = Language.strAutoSaveEvery;
-            lblAutoSave2.Text = Language.strAutoSaveMins;
 
             lblClosingConnections.Text = Language.strLabelClosingConnections;
             radCloseWarnAll.Text = Language.strRadioCloseWarnAll;

--- a/mRemoteV1/UI/Forms/OptionsPages/CredentialsPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/CredentialsPage.Designer.cs
@@ -28,149 +28,149 @@
         /// </summary>
         private void InitializeComponent()
         {
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CredentialsPage));
-			this.pnlDefaultCredentials = new System.Windows.Forms.Panel();
-			this.radCredentialsCustom = new mRemoteNG.UI.Controls.Base.NGRadioButton();
-			this.lblDefaultCredentials = new mRemoteNG.UI.Controls.Base.NGLabel();
-			this.radCredentialsNoInfo = new mRemoteNG.UI.Controls.Base.NGRadioButton();
-			this.radCredentialsWindows = new mRemoteNG.UI.Controls.Base.NGRadioButton();
-			this.txtCredentialsDomain = new mRemoteNG.UI.Controls.Base.NGTextBox();
-			this.lblCredentialsUsername = new mRemoteNG.UI.Controls.Base.NGLabel();
-			this.txtCredentialsPassword = new mRemoteNG.UI.Controls.Base.NGTextBox();
-			this.lblCredentialsPassword = new mRemoteNG.UI.Controls.Base.NGLabel();
-			this.txtCredentialsUsername = new mRemoteNG.UI.Controls.Base.NGTextBox();
-			this.lblCredentialsDomain = new mRemoteNG.UI.Controls.Base.NGLabel();
-			this.pnlDefaultCredentials.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// pnlDefaultCredentials
-			// 
-			this.pnlDefaultCredentials.Controls.Add(this.radCredentialsCustom);
-			this.pnlDefaultCredentials.Controls.Add(this.lblDefaultCredentials);
-			this.pnlDefaultCredentials.Controls.Add(this.radCredentialsNoInfo);
-			this.pnlDefaultCredentials.Controls.Add(this.radCredentialsWindows);
-			this.pnlDefaultCredentials.Controls.Add(this.txtCredentialsDomain);
-			this.pnlDefaultCredentials.Controls.Add(this.lblCredentialsUsername);
-			this.pnlDefaultCredentials.Controls.Add(this.txtCredentialsPassword);
-			this.pnlDefaultCredentials.Controls.Add(this.lblCredentialsPassword);
-			this.pnlDefaultCredentials.Controls.Add(this.txtCredentialsUsername);
-			this.pnlDefaultCredentials.Controls.Add(this.lblCredentialsDomain);
-			this.pnlDefaultCredentials.Location = new System.Drawing.Point(3, 38);
-			this.pnlDefaultCredentials.Name = "pnlDefaultCredentials";
-			this.pnlDefaultCredentials.Size = new System.Drawing.Size(596, 175);
-			this.pnlDefaultCredentials.TabIndex = 13;
-			// 
-			// radCredentialsCustom
-			// 
-			this.radCredentialsCustom.AutoSize = true;
-			this.radCredentialsCustom.Location = new System.Drawing.Point(16, 69);
-			this.radCredentialsCustom.Name = "radCredentialsCustom";
-			this.radCredentialsCustom.Size = new System.Drawing.Size(87, 17);
-			this.radCredentialsCustom.TabIndex = 3;
-			this.radCredentialsCustom.Text = "the following:";
-			this.radCredentialsCustom.UseVisualStyleBackColor = true;
-			this.radCredentialsCustom.CheckedChanged += new System.EventHandler(this.radCredentialsCustom_CheckedChanged);
-			// 
-			// lblDefaultCredentials
-			// 
-			this.lblDefaultCredentials.AutoSize = true;
-			this.lblDefaultCredentials.Location = new System.Drawing.Point(3, 9);
-			this.lblDefaultCredentials.Name = "lblDefaultCredentials";
-			this.lblDefaultCredentials.Size = new System.Drawing.Size(257, 13);
-			this.lblDefaultCredentials.TabIndex = 0;
-			this.lblDefaultCredentials.Text = "For empty Username, Password or Domain fields use:";
-			// 
-			// radCredentialsNoInfo
-			// 
-			this.radCredentialsNoInfo.AutoSize = true;
-			this.radCredentialsNoInfo.Checked = true;
-			this.radCredentialsNoInfo.Location = new System.Drawing.Point(16, 31);
-			this.radCredentialsNoInfo.Name = "radCredentialsNoInfo";
-			this.radCredentialsNoInfo.Size = new System.Drawing.Size(91, 17);
-			this.radCredentialsNoInfo.TabIndex = 1;
-			this.radCredentialsNoInfo.TabStop = true;
-			this.radCredentialsNoInfo.Text = "no information";
-			this.radCredentialsNoInfo.UseVisualStyleBackColor = true;
-			// 
-			// radCredentialsWindows
-			// 
-			this.radCredentialsWindows.AutoSize = true;
-			this.radCredentialsWindows.Location = new System.Drawing.Point(16, 50);
-			this.radCredentialsWindows.Name = "radCredentialsWindows";
-			this.radCredentialsWindows.Size = new System.Drawing.Size(227, 17);
-			this.radCredentialsWindows.TabIndex = 2;
-			this.radCredentialsWindows.Text = "my current credentials (windows logon info)";
-			this.radCredentialsWindows.UseVisualStyleBackColor = true;
-			// 
-			// txtCredentialsDomain
-			// 
-			this.txtCredentialsDomain.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtCredentialsDomain.Enabled = false;
-			this.txtCredentialsDomain.Location = new System.Drawing.Point(140, 147);
-			this.txtCredentialsDomain.Name = "txtCredentialsDomain";
-			this.txtCredentialsDomain.Size = new System.Drawing.Size(150, 20);
-			this.txtCredentialsDomain.TabIndex = 9;
-			// 
-			// lblCredentialsUsername
-			// 
-			this.lblCredentialsUsername.Enabled = false;
-			this.lblCredentialsUsername.Location = new System.Drawing.Point(37, 95);
-			this.lblCredentialsUsername.Name = "lblCredentialsUsername";
-			this.lblCredentialsUsername.Size = new System.Drawing.Size(97, 13);
-			this.lblCredentialsUsername.TabIndex = 4;
-			this.lblCredentialsUsername.Text = "Username:";
-			this.lblCredentialsUsername.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			// 
-			// txtCredentialsPassword
-			// 
-			this.txtCredentialsPassword.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtCredentialsPassword.Enabled = false;
-			this.txtCredentialsPassword.Location = new System.Drawing.Point(140, 120);
-			this.txtCredentialsPassword.Name = "txtCredentialsPassword";
-			this.txtCredentialsPassword.Size = new System.Drawing.Size(150, 20);
-			this.txtCredentialsPassword.TabIndex = 7;
-			this.txtCredentialsPassword.UseSystemPasswordChar = true;
-			// 
-			// lblCredentialsPassword
-			// 
-			this.lblCredentialsPassword.Enabled = false;
-			this.lblCredentialsPassword.Location = new System.Drawing.Point(34, 123);
-			this.lblCredentialsPassword.Name = "lblCredentialsPassword";
-			this.lblCredentialsPassword.Size = new System.Drawing.Size(100, 13);
-			this.lblCredentialsPassword.TabIndex = 6;
-			this.lblCredentialsPassword.Text = "Password:";
-			this.lblCredentialsPassword.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			// 
-			// txtCredentialsUsername
-			// 
-			this.txtCredentialsUsername.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtCredentialsUsername.Enabled = false;
-			this.txtCredentialsUsername.Location = new System.Drawing.Point(140, 93);
-			this.txtCredentialsUsername.Name = "txtCredentialsUsername";
-			this.txtCredentialsUsername.Size = new System.Drawing.Size(150, 20);
-			this.txtCredentialsUsername.TabIndex = 5;
-			// 
-			// lblCredentialsDomain
-			// 
-			this.lblCredentialsDomain.Enabled = false;
-			this.lblCredentialsDomain.Location = new System.Drawing.Point(34, 150);
-			this.lblCredentialsDomain.Name = "lblCredentialsDomain";
-			this.lblCredentialsDomain.Size = new System.Drawing.Size(100, 13);
-			this.lblCredentialsDomain.TabIndex = 8;
-			this.lblCredentialsDomain.Text = "Domain:";
-			this.lblCredentialsDomain.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			// 
-			// CredentialsPage
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this.pnlDefaultCredentials);
-			this.Name = "CredentialsPage";
-			this.PageIcon = ((System.Drawing.Icon)(resources.GetObject("$this.PageIcon")));
-			this.Size = new System.Drawing.Size(610, 489);
-			this.pnlDefaultCredentials.ResumeLayout(false);
-			this.pnlDefaultCredentials.PerformLayout();
-			this.ResumeLayout(false);
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CredentialsPage));
+            this.pnlDefaultCredentials = new System.Windows.Forms.Panel();
+            this.radCredentialsCustom = new mRemoteNG.UI.Controls.Base.NGRadioButton();
+            this.lblDefaultCredentials = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.radCredentialsNoInfo = new mRemoteNG.UI.Controls.Base.NGRadioButton();
+            this.radCredentialsWindows = new mRemoteNG.UI.Controls.Base.NGRadioButton();
+            this.txtCredentialsDomain = new mRemoteNG.UI.Controls.Base.NGTextBox();
+            this.lblCredentialsUsername = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.txtCredentialsPassword = new mRemoteNG.UI.Controls.Base.NGTextBox();
+            this.lblCredentialsPassword = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.txtCredentialsUsername = new mRemoteNG.UI.Controls.Base.NGTextBox();
+            this.lblCredentialsDomain = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.pnlDefaultCredentials.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // pnlDefaultCredentials
+            // 
+            this.pnlDefaultCredentials.Controls.Add(this.radCredentialsCustom);
+            this.pnlDefaultCredentials.Controls.Add(this.lblDefaultCredentials);
+            this.pnlDefaultCredentials.Controls.Add(this.radCredentialsNoInfo);
+            this.pnlDefaultCredentials.Controls.Add(this.radCredentialsWindows);
+            this.pnlDefaultCredentials.Controls.Add(this.txtCredentialsDomain);
+            this.pnlDefaultCredentials.Controls.Add(this.lblCredentialsUsername);
+            this.pnlDefaultCredentials.Controls.Add(this.txtCredentialsPassword);
+            this.pnlDefaultCredentials.Controls.Add(this.lblCredentialsPassword);
+            this.pnlDefaultCredentials.Controls.Add(this.txtCredentialsUsername);
+            this.pnlDefaultCredentials.Controls.Add(this.lblCredentialsDomain);
+            this.pnlDefaultCredentials.Location = new System.Drawing.Point(3, 3);
+            this.pnlDefaultCredentials.Name = "pnlDefaultCredentials";
+            this.pnlDefaultCredentials.Size = new System.Drawing.Size(596, 175);
+            this.pnlDefaultCredentials.TabIndex = 13;
+            // 
+            // radCredentialsCustom
+            // 
+            this.radCredentialsCustom.AutoSize = true;
+            this.radCredentialsCustom.Location = new System.Drawing.Point(16, 69);
+            this.radCredentialsCustom.Name = "radCredentialsCustom";
+            this.radCredentialsCustom.Size = new System.Drawing.Size(87, 17);
+            this.radCredentialsCustom.TabIndex = 3;
+            this.radCredentialsCustom.Text = "the following:";
+            this.radCredentialsCustom.UseVisualStyleBackColor = true;
+            this.radCredentialsCustom.CheckedChanged += new System.EventHandler(this.radCredentialsCustom_CheckedChanged);
+            // 
+            // lblDefaultCredentials
+            // 
+            this.lblDefaultCredentials.AutoSize = true;
+            this.lblDefaultCredentials.Location = new System.Drawing.Point(3, 9);
+            this.lblDefaultCredentials.Name = "lblDefaultCredentials";
+            this.lblDefaultCredentials.Size = new System.Drawing.Size(257, 13);
+            this.lblDefaultCredentials.TabIndex = 0;
+            this.lblDefaultCredentials.Text = "For empty Username, Password or Domain fields use:";
+            // 
+            // radCredentialsNoInfo
+            // 
+            this.radCredentialsNoInfo.AutoSize = true;
+            this.radCredentialsNoInfo.Checked = true;
+            this.radCredentialsNoInfo.Location = new System.Drawing.Point(16, 31);
+            this.radCredentialsNoInfo.Name = "radCredentialsNoInfo";
+            this.radCredentialsNoInfo.Size = new System.Drawing.Size(91, 17);
+            this.radCredentialsNoInfo.TabIndex = 1;
+            this.radCredentialsNoInfo.TabStop = true;
+            this.radCredentialsNoInfo.Text = "no information";
+            this.radCredentialsNoInfo.UseVisualStyleBackColor = true;
+            // 
+            // radCredentialsWindows
+            // 
+            this.radCredentialsWindows.AutoSize = true;
+            this.radCredentialsWindows.Location = new System.Drawing.Point(16, 50);
+            this.radCredentialsWindows.Name = "radCredentialsWindows";
+            this.radCredentialsWindows.Size = new System.Drawing.Size(227, 17);
+            this.radCredentialsWindows.TabIndex = 2;
+            this.radCredentialsWindows.Text = "my current credentials (windows logon info)";
+            this.radCredentialsWindows.UseVisualStyleBackColor = true;
+            // 
+            // txtCredentialsDomain
+            // 
+            this.txtCredentialsDomain.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtCredentialsDomain.Enabled = false;
+            this.txtCredentialsDomain.Location = new System.Drawing.Point(140, 147);
+            this.txtCredentialsDomain.Name = "txtCredentialsDomain";
+            this.txtCredentialsDomain.Size = new System.Drawing.Size(150, 20);
+            this.txtCredentialsDomain.TabIndex = 9;
+            // 
+            // lblCredentialsUsername
+            // 
+            this.lblCredentialsUsername.Enabled = false;
+            this.lblCredentialsUsername.Location = new System.Drawing.Point(37, 95);
+            this.lblCredentialsUsername.Name = "lblCredentialsUsername";
+            this.lblCredentialsUsername.Size = new System.Drawing.Size(97, 13);
+            this.lblCredentialsUsername.TabIndex = 4;
+            this.lblCredentialsUsername.Text = "Username:";
+            this.lblCredentialsUsername.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // txtCredentialsPassword
+            // 
+            this.txtCredentialsPassword.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtCredentialsPassword.Enabled = false;
+            this.txtCredentialsPassword.Location = new System.Drawing.Point(140, 120);
+            this.txtCredentialsPassword.Name = "txtCredentialsPassword";
+            this.txtCredentialsPassword.Size = new System.Drawing.Size(150, 20);
+            this.txtCredentialsPassword.TabIndex = 7;
+            this.txtCredentialsPassword.UseSystemPasswordChar = true;
+            // 
+            // lblCredentialsPassword
+            // 
+            this.lblCredentialsPassword.Enabled = false;
+            this.lblCredentialsPassword.Location = new System.Drawing.Point(34, 123);
+            this.lblCredentialsPassword.Name = "lblCredentialsPassword";
+            this.lblCredentialsPassword.Size = new System.Drawing.Size(100, 13);
+            this.lblCredentialsPassword.TabIndex = 6;
+            this.lblCredentialsPassword.Text = "Password:";
+            this.lblCredentialsPassword.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // txtCredentialsUsername
+            // 
+            this.txtCredentialsUsername.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtCredentialsUsername.Enabled = false;
+            this.txtCredentialsUsername.Location = new System.Drawing.Point(140, 93);
+            this.txtCredentialsUsername.Name = "txtCredentialsUsername";
+            this.txtCredentialsUsername.Size = new System.Drawing.Size(150, 20);
+            this.txtCredentialsUsername.TabIndex = 5;
+            // 
+            // lblCredentialsDomain
+            // 
+            this.lblCredentialsDomain.Enabled = false;
+            this.lblCredentialsDomain.Location = new System.Drawing.Point(34, 150);
+            this.lblCredentialsDomain.Name = "lblCredentialsDomain";
+            this.lblCredentialsDomain.Size = new System.Drawing.Size(100, 13);
+            this.lblCredentialsDomain.TabIndex = 8;
+            this.lblCredentialsDomain.Text = "Domain:";
+            this.lblCredentialsDomain.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // CredentialsPage
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.pnlDefaultCredentials);
+            this.Name = "CredentialsPage";
+            this.PageIcon = ((System.Drawing.Icon)(resources.GetObject("$this.PageIcon")));
+            this.Size = new System.Drawing.Size(610, 489);
+            this.pnlDefaultCredentials.ResumeLayout(false);
+            this.pnlDefaultCredentials.PerformLayout();
+            this.ResumeLayout(false);
 
         }
 

--- a/mRemoteV1/UI/Forms/OptionsPages/NotificationsPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/NotificationsPage.Designer.cs
@@ -31,44 +31,48 @@ namespace mRemoteNG.UI.Forms.OptionsPages
 		[System.Diagnostics.DebuggerStepThrough()]private void InitializeComponent()
 		{
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(NotificationsPage));
-            this.labelSwitchToErrorsAndInfos = new Controls.Base.NGLabel();
-            this.chkSwitchToMCInformation = new Controls.Base.NGCheckBox();
-            this.chkSwitchToMCErrors = new Controls.Base.NGCheckBox();
-            this.chkSwitchToMCWarnings = new Controls.Base.NGCheckBox();
+            this.labelSwitchToErrorsAndInfos = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.chkSwitchToMCInformation = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkSwitchToMCErrors = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkSwitchToMCWarnings = new mRemoteNG.UI.Controls.Base.NGCheckBox();
             this.groupBoxNotifications = new System.Windows.Forms.GroupBox();
-            this.labelNotificationsShowTypes = new Controls.Base.NGLabel();
-            this.chkShowErrorInMC = new Controls.Base.NGCheckBox();
-            this.chkShowWarningInMC = new Controls.Base.NGCheckBox();
-            this.chkShowInfoInMC = new Controls.Base.NGCheckBox();
-            this.chkShowDebugInMC = new Controls.Base.NGCheckBox();
+            this.labelNotificationsShowTypes = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.chkShowErrorInMC = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkShowWarningInMC = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkShowInfoInMC = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkShowDebugInMC = new mRemoteNG.UI.Controls.Base.NGCheckBox();
             this.groupBoxLogging = new System.Windows.Forms.GroupBox();
-            this.chkLogToCurrentDir = new Controls.Base.NGCheckBox();
-            this.buttonRestoreDefaultLogPath = new Controls.Base.NGButton();
-            this.buttonOpenLogFile = new Controls.Base.NGButton();
-            this.buttonSelectLogPath = new Controls.Base.NGButton();
-            this.labelLogTheseMsgTypes = new Controls.Base.NGLabel();
-            this.chkLogErrorMsgs = new Controls.Base.NGCheckBox();
-            this.labelLogFilePath = new Controls.Base.NGLabel();
-            this.chkLogWarningMsgs = new Controls.Base.NGCheckBox();
-            this.textBoxLogPath = new Controls.Base.NGTextBox();
-            this.chkLogInfoMsgs = new Controls.Base.NGCheckBox();
-            this.chkLogDebugMsgs = new Controls.Base.NGCheckBox();
+            this.tblLogging = new System.Windows.Forms.TableLayoutPanel();
+            this.chkLogDebugMsgs = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkLogInfoMsgs = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkLogWarningMsgs = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkLogErrorMsgs = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkLogToCurrentDir = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.buttonRestoreDefaultLogPath = new mRemoteNG.UI.Controls.Base.NGButton();
+            this.buttonOpenLogFile = new mRemoteNG.UI.Controls.Base.NGButton();
+            this.buttonSelectLogPath = new mRemoteNG.UI.Controls.Base.NGButton();
+            this.labelLogTheseMsgTypes = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.labelLogFilePath = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.textBoxLogPath = new mRemoteNG.UI.Controls.Base.NGTextBox();
             this.saveFileDialogLogging = new System.Windows.Forms.SaveFileDialog();
             this.groupBoxPopups = new System.Windows.Forms.GroupBox();
-            this.chkPopupError = new Controls.Base.NGCheckBox();
-            this.labelPopupShowTypes = new Controls.Base.NGLabel();
-            this.chkPopupWarning = new Controls.Base.NGCheckBox();
-            this.chkPopupDebug = new Controls.Base.NGCheckBox();
-            this.chkPopupInfo = new Controls.Base.NGCheckBox();
+            this.tblPopups = new System.Windows.Forms.TableLayoutPanel();
+            this.chkPopupDebug = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkPopupError = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkPopupInfo = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkPopupWarning = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.labelPopupShowTypes = new mRemoteNG.UI.Controls.Base.NGLabel();
             this.groupBoxNotifications.SuspendLayout();
             this.groupBoxLogging.SuspendLayout();
+            this.tblLogging.SuspendLayout();
             this.groupBoxPopups.SuspendLayout();
+            this.tblPopups.SuspendLayout();
             this.SuspendLayout();
             // 
             // labelSwitchToErrorsAndInfos
             // 
             this.labelSwitchToErrorsAndInfos.AutoSize = true;
-            this.labelSwitchToErrorsAndInfos.Location = new System.Drawing.Point(177, 26);
+            this.labelSwitchToErrorsAndInfos.Location = new System.Drawing.Point(177, 25);
             this.labelSwitchToErrorsAndInfos.Name = "labelSwitchToErrorsAndInfos";
             this.labelSwitchToErrorsAndInfos.Size = new System.Drawing.Size(159, 13);
             this.labelSwitchToErrorsAndInfos.TabIndex = 24;
@@ -76,8 +80,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkSwitchToMCInformation
             // 
+            this.chkSwitchToMCInformation._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkSwitchToMCInformation.AutoSize = true;
-            this.chkSwitchToMCInformation.Location = new System.Drawing.Point(195, 68);
+            this.chkSwitchToMCInformation.Location = new System.Drawing.Point(195, 67);
             this.chkSwitchToMCInformation.Name = "chkSwitchToMCInformation";
             this.chkSwitchToMCInformation.Size = new System.Drawing.Size(78, 17);
             this.chkSwitchToMCInformation.TabIndex = 25;
@@ -86,8 +91,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkSwitchToMCErrors
             // 
+            this.chkSwitchToMCErrors._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkSwitchToMCErrors.AutoSize = true;
-            this.chkSwitchToMCErrors.Location = new System.Drawing.Point(195, 114);
+            this.chkSwitchToMCErrors.Location = new System.Drawing.Point(195, 113);
             this.chkSwitchToMCErrors.Name = "chkSwitchToMCErrors";
             this.chkSwitchToMCErrors.Size = new System.Drawing.Size(48, 17);
             this.chkSwitchToMCErrors.TabIndex = 27;
@@ -96,8 +102,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkSwitchToMCWarnings
             // 
+            this.chkSwitchToMCWarnings._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkSwitchToMCWarnings.AutoSize = true;
-            this.chkSwitchToMCWarnings.Location = new System.Drawing.Point(195, 91);
+            this.chkSwitchToMCWarnings.Location = new System.Drawing.Point(195, 90);
             this.chkSwitchToMCWarnings.Name = "chkSwitchToMCWarnings";
             this.chkSwitchToMCWarnings.Size = new System.Drawing.Size(66, 17);
             this.chkSwitchToMCWarnings.TabIndex = 26;
@@ -115,7 +122,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.groupBoxNotifications.Controls.Add(this.chkSwitchToMCWarnings);
             this.groupBoxNotifications.Controls.Add(this.chkShowInfoInMC);
             this.groupBoxNotifications.Controls.Add(this.chkShowDebugInMC);
-            this.groupBoxNotifications.Location = new System.Drawing.Point(6, 3);
+            this.groupBoxNotifications.Location = new System.Drawing.Point(6, 2);
             this.groupBoxNotifications.Name = "groupBoxNotifications";
             this.groupBoxNotifications.Size = new System.Drawing.Size(601, 141);
             this.groupBoxNotifications.TabIndex = 28;
@@ -125,7 +132,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // labelNotificationsShowTypes
             // 
             this.labelNotificationsShowTypes.AutoSize = true;
-            this.labelNotificationsShowTypes.Location = new System.Drawing.Point(6, 26);
+            this.labelNotificationsShowTypes.Location = new System.Drawing.Point(6, 25);
             this.labelNotificationsShowTypes.Name = "labelNotificationsShowTypes";
             this.labelNotificationsShowTypes.Size = new System.Drawing.Size(139, 13);
             this.labelNotificationsShowTypes.TabIndex = 29;
@@ -133,8 +140,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkShowErrorInMC
             // 
+            this.chkShowErrorInMC._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkShowErrorInMC.AutoSize = true;
-            this.chkShowErrorInMC.Location = new System.Drawing.Point(20, 114);
+            this.chkShowErrorInMC.Location = new System.Drawing.Point(20, 113);
             this.chkShowErrorInMC.Name = "chkShowErrorInMC";
             this.chkShowErrorInMC.Size = new System.Drawing.Size(48, 17);
             this.chkShowErrorInMC.TabIndex = 32;
@@ -143,8 +151,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkShowWarningInMC
             // 
+            this.chkShowWarningInMC._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkShowWarningInMC.AutoSize = true;
-            this.chkShowWarningInMC.Location = new System.Drawing.Point(20, 91);
+            this.chkShowWarningInMC.Location = new System.Drawing.Point(20, 90);
             this.chkShowWarningInMC.Name = "chkShowWarningInMC";
             this.chkShowWarningInMC.Size = new System.Drawing.Size(66, 17);
             this.chkShowWarningInMC.TabIndex = 31;
@@ -153,8 +162,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkShowInfoInMC
             // 
+            this.chkShowInfoInMC._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkShowInfoInMC.AutoSize = true;
-            this.chkShowInfoInMC.Location = new System.Drawing.Point(20, 68);
+            this.chkShowInfoInMC.Location = new System.Drawing.Point(20, 67);
             this.chkShowInfoInMC.Name = "chkShowInfoInMC";
             this.chkShowInfoInMC.Size = new System.Drawing.Size(78, 17);
             this.chkShowInfoInMC.TabIndex = 30;
@@ -163,8 +173,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkShowDebugInMC
             // 
+            this.chkShowDebugInMC._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkShowDebugInMC.AutoSize = true;
-            this.chkShowDebugInMC.Location = new System.Drawing.Point(20, 45);
+            this.chkShowDebugInMC.Location = new System.Drawing.Point(20, 44);
             this.chkShowDebugInMC.Name = "chkShowDebugInMC";
             this.chkShowDebugInMC.Size = new System.Drawing.Size(58, 17);
             this.chkShowDebugInMC.TabIndex = 29;
@@ -173,29 +184,89 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // groupBoxLogging
             // 
+            this.groupBoxLogging.Controls.Add(this.tblLogging);
             this.groupBoxLogging.Controls.Add(this.chkLogToCurrentDir);
             this.groupBoxLogging.Controls.Add(this.buttonRestoreDefaultLogPath);
             this.groupBoxLogging.Controls.Add(this.buttonOpenLogFile);
             this.groupBoxLogging.Controls.Add(this.buttonSelectLogPath);
             this.groupBoxLogging.Controls.Add(this.labelLogTheseMsgTypes);
-            this.groupBoxLogging.Controls.Add(this.chkLogErrorMsgs);
             this.groupBoxLogging.Controls.Add(this.labelLogFilePath);
-            this.groupBoxLogging.Controls.Add(this.chkLogWarningMsgs);
             this.groupBoxLogging.Controls.Add(this.textBoxLogPath);
-            this.groupBoxLogging.Controls.Add(this.chkLogInfoMsgs);
-            this.groupBoxLogging.Controls.Add(this.chkLogDebugMsgs);
-            this.groupBoxLogging.Location = new System.Drawing.Point(6, 150);
+            this.groupBoxLogging.Location = new System.Drawing.Point(6, 149);
             this.groupBoxLogging.Name = "groupBoxLogging";
-            this.groupBoxLogging.Size = new System.Drawing.Size(601, 140);
+            this.groupBoxLogging.Size = new System.Drawing.Size(601, 158);
             this.groupBoxLogging.TabIndex = 29;
             this.groupBoxLogging.TabStop = false;
             this.groupBoxLogging.Text = "Logging";
             // 
+            // tblLogging
+            // 
+            this.tblLogging.ColumnCount = 4;
+            this.tblLogging.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tblLogging.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tblLogging.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tblLogging.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tblLogging.Controls.Add(this.chkLogDebugMsgs, 0, 0);
+            this.tblLogging.Controls.Add(this.chkLogInfoMsgs, 1, 0);
+            this.tblLogging.Controls.Add(this.chkLogWarningMsgs, 2, 0);
+            this.tblLogging.Controls.Add(this.chkLogErrorMsgs, 3, 0);
+            this.tblLogging.Location = new System.Drawing.Point(9, 124);
+            this.tblLogging.Name = "tblLogging";
+            this.tblLogging.RowCount = 1;
+            this.tblLogging.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tblLogging.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tblLogging.Size = new System.Drawing.Size(585, 25);
+            this.tblLogging.TabIndex = 31;
+            // 
+            // chkLogDebugMsgs
+            // 
+            this.chkLogDebugMsgs._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkLogDebugMsgs.AutoSize = true;
+            this.chkLogDebugMsgs.Location = new System.Drawing.Point(3, 3);
+            this.chkLogDebugMsgs.Name = "chkLogDebugMsgs";
+            this.chkLogDebugMsgs.Size = new System.Drawing.Size(58, 17);
+            this.chkLogDebugMsgs.TabIndex = 35;
+            this.chkLogDebugMsgs.Text = "Debug";
+            this.chkLogDebugMsgs.UseVisualStyleBackColor = true;
+            // 
+            // chkLogInfoMsgs
+            // 
+            this.chkLogInfoMsgs._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkLogInfoMsgs.AutoSize = true;
+            this.chkLogInfoMsgs.Location = new System.Drawing.Point(149, 3);
+            this.chkLogInfoMsgs.Name = "chkLogInfoMsgs";
+            this.chkLogInfoMsgs.Size = new System.Drawing.Size(78, 17);
+            this.chkLogInfoMsgs.TabIndex = 36;
+            this.chkLogInfoMsgs.Text = "Information";
+            this.chkLogInfoMsgs.UseVisualStyleBackColor = true;
+            // 
+            // chkLogWarningMsgs
+            // 
+            this.chkLogWarningMsgs._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkLogWarningMsgs.AutoSize = true;
+            this.chkLogWarningMsgs.Location = new System.Drawing.Point(295, 3);
+            this.chkLogWarningMsgs.Name = "chkLogWarningMsgs";
+            this.chkLogWarningMsgs.Size = new System.Drawing.Size(66, 17);
+            this.chkLogWarningMsgs.TabIndex = 37;
+            this.chkLogWarningMsgs.Text = "Warning";
+            this.chkLogWarningMsgs.UseVisualStyleBackColor = true;
+            // 
+            // chkLogErrorMsgs
+            // 
+            this.chkLogErrorMsgs._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkLogErrorMsgs.AutoSize = true;
+            this.chkLogErrorMsgs.Location = new System.Drawing.Point(441, 3);
+            this.chkLogErrorMsgs.Name = "chkLogErrorMsgs";
+            this.chkLogErrorMsgs.Size = new System.Drawing.Size(48, 17);
+            this.chkLogErrorMsgs.TabIndex = 38;
+            this.chkLogErrorMsgs.Text = "Error";
+            this.chkLogErrorMsgs.UseVisualStyleBackColor = true;
+            // 
             // chkLogToCurrentDir
             // 
-            this.chkLogToCurrentDir.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkLogToCurrentDir._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkLogToCurrentDir.AutoSize = true;
-            this.chkLogToCurrentDir.Location = new System.Drawing.Point(441, 20);
+            this.chkLogToCurrentDir.Location = new System.Drawing.Point(9, 18);
             this.chkLogToCurrentDir.Name = "chkLogToCurrentDir";
             this.chkLogToCurrentDir.Size = new System.Drawing.Size(153, 17);
             this.chkLogToCurrentDir.TabIndex = 40;
@@ -205,7 +276,8 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // buttonRestoreDefaultLogPath
             // 
-            this.buttonRestoreDefaultLogPath.Location = new System.Drawing.Point(495, 69);
+            this.buttonRestoreDefaultLogPath._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
+            this.buttonRestoreDefaultLogPath.Location = new System.Drawing.Point(495, 83);
             this.buttonRestoreDefaultLogPath.Name = "buttonRestoreDefaultLogPath";
             this.buttonRestoreDefaultLogPath.Size = new System.Drawing.Size(99, 23);
             this.buttonRestoreDefaultLogPath.TabIndex = 39;
@@ -215,7 +287,8 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // buttonOpenLogFile
             // 
-            this.buttonOpenLogFile.Location = new System.Drawing.Point(273, 68);
+            this.buttonOpenLogFile._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
+            this.buttonOpenLogFile.Location = new System.Drawing.Point(273, 82);
             this.buttonOpenLogFile.Name = "buttonOpenLogFile";
             this.buttonOpenLogFile.Size = new System.Drawing.Size(105, 23);
             this.buttonOpenLogFile.TabIndex = 30;
@@ -225,7 +298,8 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // buttonSelectLogPath
             // 
-            this.buttonSelectLogPath.Location = new System.Drawing.Point(384, 68);
+            this.buttonSelectLogPath._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
+            this.buttonSelectLogPath.Location = new System.Drawing.Point(384, 82);
             this.buttonSelectLogPath.Name = "buttonSelectLogPath";
             this.buttonSelectLogPath.Size = new System.Drawing.Size(105, 23);
             this.buttonSelectLogPath.TabIndex = 30;
@@ -236,132 +310,112 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // labelLogTheseMsgTypes
             // 
             this.labelLogTheseMsgTypes.AutoSize = true;
-            this.labelLogTheseMsgTypes.Location = new System.Drawing.Point(6, 26);
+            this.labelLogTheseMsgTypes.Location = new System.Drawing.Point(6, 108);
             this.labelLogTheseMsgTypes.Name = "labelLogTheseMsgTypes";
             this.labelLogTheseMsgTypes.Size = new System.Drawing.Size(130, 13);
             this.labelLogTheseMsgTypes.TabIndex = 34;
             this.labelLogTheseMsgTypes.Text = "Log these message types:";
             // 
-            // chkLogErrorMsgs
-            // 
-            this.chkLogErrorMsgs.AutoSize = true;
-            this.chkLogErrorMsgs.Location = new System.Drawing.Point(20, 114);
-            this.chkLogErrorMsgs.Name = "chkLogErrorMsgs";
-            this.chkLogErrorMsgs.Size = new System.Drawing.Size(48, 17);
-            this.chkLogErrorMsgs.TabIndex = 38;
-            this.chkLogErrorMsgs.Text = "Error";
-            this.chkLogErrorMsgs.UseVisualStyleBackColor = true;
-            // 
             // labelLogFilePath
             // 
             this.labelLogFilePath.AutoSize = true;
-            this.labelLogFilePath.Location = new System.Drawing.Point(192, 26);
+            this.labelLogFilePath.Location = new System.Drawing.Point(6, 38);
             this.labelLogFilePath.Name = "labelLogFilePath";
             this.labelLogFilePath.Size = new System.Drawing.Size(68, 13);
             this.labelLogFilePath.TabIndex = 30;
             this.labelLogFilePath.Text = "Log file path:";
             // 
-            // chkLogWarningMsgs
-            // 
-            this.chkLogWarningMsgs.AutoSize = true;
-            this.chkLogWarningMsgs.Location = new System.Drawing.Point(20, 91);
-            this.chkLogWarningMsgs.Name = "chkLogWarningMsgs";
-            this.chkLogWarningMsgs.Size = new System.Drawing.Size(66, 17);
-            this.chkLogWarningMsgs.TabIndex = 37;
-            this.chkLogWarningMsgs.Text = "Warning";
-            this.chkLogWarningMsgs.UseVisualStyleBackColor = true;
-            // 
             // textBoxLogPath
             // 
             this.textBoxLogPath.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.textBoxLogPath.Location = new System.Drawing.Point(195, 43);
+            this.textBoxLogPath.Location = new System.Drawing.Point(9, 57);
             this.textBoxLogPath.Name = "textBoxLogPath";
             this.textBoxLogPath.ReadOnly = true;
-            this.textBoxLogPath.Size = new System.Drawing.Size(399, 20);
+            this.textBoxLogPath.Size = new System.Drawing.Size(585, 20);
             this.textBoxLogPath.TabIndex = 0;
-            // 
-            // chkLogInfoMsgs
-            // 
-            this.chkLogInfoMsgs.AutoSize = true;
-            this.chkLogInfoMsgs.Location = new System.Drawing.Point(20, 68);
-            this.chkLogInfoMsgs.Name = "chkLogInfoMsgs";
-            this.chkLogInfoMsgs.Size = new System.Drawing.Size(78, 17);
-            this.chkLogInfoMsgs.TabIndex = 36;
-            this.chkLogInfoMsgs.Text = "Information";
-            this.chkLogInfoMsgs.UseVisualStyleBackColor = true;
-            // 
-            // chkLogDebugMsgs
-            // 
-            this.chkLogDebugMsgs.AutoSize = true;
-            this.chkLogDebugMsgs.Location = new System.Drawing.Point(20, 45);
-            this.chkLogDebugMsgs.Name = "chkLogDebugMsgs";
-            this.chkLogDebugMsgs.Size = new System.Drawing.Size(58, 17);
-            this.chkLogDebugMsgs.TabIndex = 35;
-            this.chkLogDebugMsgs.Text = "Debug";
-            this.chkLogDebugMsgs.UseVisualStyleBackColor = true;
             // 
             // groupBoxPopups
             // 
-            this.groupBoxPopups.Controls.Add(this.chkPopupError);
+            this.groupBoxPopups.Controls.Add(this.tblPopups);
             this.groupBoxPopups.Controls.Add(this.labelPopupShowTypes);
-            this.groupBoxPopups.Controls.Add(this.chkPopupWarning);
-            this.groupBoxPopups.Controls.Add(this.chkPopupDebug);
-            this.groupBoxPopups.Controls.Add(this.chkPopupInfo);
-            this.groupBoxPopups.Location = new System.Drawing.Point(4, 297);
+            this.groupBoxPopups.Location = new System.Drawing.Point(4, 313);
             this.groupBoxPopups.Name = "groupBoxPopups";
-            this.groupBoxPopups.Size = new System.Drawing.Size(603, 135);
+            this.groupBoxPopups.Size = new System.Drawing.Size(603, 74);
             this.groupBoxPopups.TabIndex = 30;
             this.groupBoxPopups.TabStop = false;
             this.groupBoxPopups.Text = "Pop-ups";
             // 
-            // chkPopupError
+            // tblPopups
             // 
-            this.chkPopupError.AutoSize = true;
-            this.chkPopupError.Location = new System.Drawing.Point(22, 110);
-            this.chkPopupError.Name = "chkPopupError";
-            this.chkPopupError.Size = new System.Drawing.Size(48, 17);
-            this.chkPopupError.TabIndex = 43;
-            this.chkPopupError.Text = "Error";
-            this.chkPopupError.UseVisualStyleBackColor = true;
-            // 
-            // labelPopupShowTypes
-            // 
-            this.labelPopupShowTypes.AutoSize = true;
-            this.labelPopupShowTypes.Location = new System.Drawing.Point(8, 25);
-            this.labelPopupShowTypes.Name = "labelPopupShowTypes";
-            this.labelPopupShowTypes.Size = new System.Drawing.Size(139, 13);
-            this.labelPopupShowTypes.TabIndex = 33;
-            this.labelPopupShowTypes.Text = "Show these message types:";
-            // 
-            // chkPopupWarning
-            // 
-            this.chkPopupWarning.AutoSize = true;
-            this.chkPopupWarning.Location = new System.Drawing.Point(22, 87);
-            this.chkPopupWarning.Name = "chkPopupWarning";
-            this.chkPopupWarning.Size = new System.Drawing.Size(66, 17);
-            this.chkPopupWarning.TabIndex = 42;
-            this.chkPopupWarning.Text = "Warning";
-            this.chkPopupWarning.UseVisualStyleBackColor = true;
+            this.tblPopups.ColumnCount = 4;
+            this.tblPopups.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tblPopups.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tblPopups.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tblPopups.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25F));
+            this.tblPopups.Controls.Add(this.chkPopupDebug, 0, 0);
+            this.tblPopups.Controls.Add(this.chkPopupError, 3, 0);
+            this.tblPopups.Controls.Add(this.chkPopupInfo, 1, 0);
+            this.tblPopups.Controls.Add(this.chkPopupWarning, 2, 0);
+            this.tblPopups.Location = new System.Drawing.Point(11, 40);
+            this.tblPopups.Name = "tblPopups";
+            this.tblPopups.RowCount = 1;
+            this.tblPopups.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tblPopups.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+            this.tblPopups.Size = new System.Drawing.Size(585, 25);
+            this.tblPopups.TabIndex = 44;
             // 
             // chkPopupDebug
             // 
+            this.chkPopupDebug._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkPopupDebug.AutoSize = true;
-            this.chkPopupDebug.Location = new System.Drawing.Point(22, 41);
+            this.chkPopupDebug.Location = new System.Drawing.Point(3, 3);
             this.chkPopupDebug.Name = "chkPopupDebug";
             this.chkPopupDebug.Size = new System.Drawing.Size(58, 17);
             this.chkPopupDebug.TabIndex = 40;
             this.chkPopupDebug.Text = "Debug";
             this.chkPopupDebug.UseVisualStyleBackColor = true;
             // 
+            // chkPopupError
+            // 
+            this.chkPopupError._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkPopupError.AutoSize = true;
+            this.chkPopupError.Location = new System.Drawing.Point(441, 3);
+            this.chkPopupError.Name = "chkPopupError";
+            this.chkPopupError.Size = new System.Drawing.Size(48, 17);
+            this.chkPopupError.TabIndex = 43;
+            this.chkPopupError.Text = "Error";
+            this.chkPopupError.UseVisualStyleBackColor = true;
+            // 
             // chkPopupInfo
             // 
+            this.chkPopupInfo._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkPopupInfo.AutoSize = true;
-            this.chkPopupInfo.Location = new System.Drawing.Point(22, 64);
+            this.chkPopupInfo.Location = new System.Drawing.Point(149, 3);
             this.chkPopupInfo.Name = "chkPopupInfo";
             this.chkPopupInfo.Size = new System.Drawing.Size(78, 17);
             this.chkPopupInfo.TabIndex = 41;
             this.chkPopupInfo.Text = "Information";
             this.chkPopupInfo.UseVisualStyleBackColor = true;
+            // 
+            // chkPopupWarning
+            // 
+            this.chkPopupWarning._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkPopupWarning.AutoSize = true;
+            this.chkPopupWarning.Location = new System.Drawing.Point(295, 3);
+            this.chkPopupWarning.Name = "chkPopupWarning";
+            this.chkPopupWarning.Size = new System.Drawing.Size(66, 17);
+            this.chkPopupWarning.TabIndex = 42;
+            this.chkPopupWarning.Text = "Warning";
+            this.chkPopupWarning.UseVisualStyleBackColor = true;
+            // 
+            // labelPopupShowTypes
+            // 
+            this.labelPopupShowTypes.AutoSize = true;
+            this.labelPopupShowTypes.Location = new System.Drawing.Point(8, 24);
+            this.labelPopupShowTypes.Name = "labelPopupShowTypes";
+            this.labelPopupShowTypes.Size = new System.Drawing.Size(139, 13);
+            this.labelPopupShowTypes.TabIndex = 33;
+            this.labelPopupShowTypes.Text = "Show these message types:";
             // 
             // NotificationsPage
             // 
@@ -377,8 +431,12 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.groupBoxNotifications.PerformLayout();
             this.groupBoxLogging.ResumeLayout(false);
             this.groupBoxLogging.PerformLayout();
+            this.tblLogging.ResumeLayout(false);
+            this.tblLogging.PerformLayout();
             this.groupBoxPopups.ResumeLayout(false);
             this.groupBoxPopups.PerformLayout();
+            this.tblPopups.ResumeLayout(false);
+            this.tblPopups.PerformLayout();
             this.ResumeLayout(false);
 
 		}
@@ -412,5 +470,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
         private Controls.Base.NGCheckBox chkPopupDebug;
         private Controls.Base.NGCheckBox chkPopupInfo;
         private Controls.Base.NGCheckBox chkLogToCurrentDir;
+        private System.Windows.Forms.TableLayoutPanel tblLogging;
+        private System.Windows.Forms.TableLayoutPanel tblPopups;
     }
 }

--- a/mRemoteV1/UI/Forms/OptionsPages/NotificationsPage.resx
+++ b/mRemoteV1/UI/Forms/OptionsPages/NotificationsPage.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="saveFileDialogLogging.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>17, 16</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.PageIcon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/mRemoteV1/UI/Forms/OptionsPages/OptionsPage.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/OptionsPage.cs
@@ -59,7 +59,8 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             this.Name = "OptionsPage";
             this.Size = new System.Drawing.Size(610, 489);
-            this.ResumeLayout(false); 
+            this.ResumeLayout(false);
+
         }
 
         public virtual void ApplyTheme()

--- a/mRemoteV1/UI/Forms/OptionsPages/SecurityPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/SecurityPage.Designer.cs
@@ -99,9 +99,9 @@
             this.groupAdvancedSecurityOptions.Controls.Add(this.comboBoxBlockCipher);
             this.groupAdvancedSecurityOptions.Controls.Add(this.labelBlockCipher);
             this.groupAdvancedSecurityOptions.Controls.Add(this.labelEncryptionEngine);
-            this.groupAdvancedSecurityOptions.Location = new System.Drawing.Point(3, 96);
+            this.groupAdvancedSecurityOptions.Location = new System.Drawing.Point(3, 30);
             this.groupAdvancedSecurityOptions.Name = "groupAdvancedSecurityOptions";
-            this.groupAdvancedSecurityOptions.Size = new System.Drawing.Size(358, 148);
+            this.groupAdvancedSecurityOptions.Size = new System.Drawing.Size(604, 128);
             this.groupAdvancedSecurityOptions.TabIndex = 24;
             this.groupAdvancedSecurityOptions.TabStop = false;
             this.groupAdvancedSecurityOptions.Text = "Advanced Security Options";
@@ -113,7 +113,7 @@
             0,
             0,
             0});
-            this.numberBoxKdfIterations.Location = new System.Drawing.Point(191, 95);
+            this.numberBoxKdfIterations.Location = new System.Drawing.Point(191, 88);
             this.numberBoxKdfIterations.Maximum = new decimal(new int[] {
             50000,
             0,
@@ -137,7 +137,7 @@
             // labelKdfIterations
             // 
             this.labelKdfIterations.AutoSize = true;
-            this.labelKdfIterations.Location = new System.Drawing.Point(6, 97);
+            this.labelKdfIterations.Location = new System.Drawing.Point(9, 90);
             this.labelKdfIterations.Name = "labelKdfIterations";
             this.labelKdfIterations.Size = new System.Drawing.Size(166, 13);
             this.labelKdfIterations.TabIndex = 24;

--- a/mRemoteV1/UI/Forms/OptionsPages/StartupExitPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/StartupExitPage.Designer.cs
@@ -30,68 +30,72 @@ namespace mRemoteNG.UI.Forms.OptionsPages
 		//Do not modify it using the code editor.
 		[System.Diagnostics.DebuggerStepThrough()]private void InitializeComponent()
 		{
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(StartupExitPage));
-			this.chkReconnectOnStart = new Controls.Base.NGCheckBox();
-			base.Load += new System.EventHandler(StartupExitPage_Load);
-			this.chkSaveConsOnExit = new Controls.Base.NGCheckBox();
-			this.chkSingleInstance = new Controls.Base.NGCheckBox();
-			this.chkProperInstallationOfComponentsAtStartup = new Controls.Base.NGCheckBox();
-			this.SuspendLayout();
-			//
-			//chkReconnectOnStart
-			//
-			this.chkReconnectOnStart.AutoSize = true;
-			this.chkReconnectOnStart.Location = new System.Drawing.Point(3, 24);
-			this.chkReconnectOnStart.Name = "chkReconnectOnStart";
-			this.chkReconnectOnStart.Size = new System.Drawing.Size(273, 17);
-			this.chkReconnectOnStart.TabIndex = 7;
-			this.chkReconnectOnStart.Text = "Reconnect to previously opened sessions on startup";
-			this.chkReconnectOnStart.UseVisualStyleBackColor = true;
-			//
-			//chkSaveConsOnExit
-			//
-			this.chkSaveConsOnExit.AutoSize = true;
-			this.chkSaveConsOnExit.Location = new System.Drawing.Point(3, 0);
-			this.chkSaveConsOnExit.Name = "chkSaveConsOnExit";
-			this.chkSaveConsOnExit.Size = new System.Drawing.Size(146, 17);
-			this.chkSaveConsOnExit.TabIndex = 6;
-			this.chkSaveConsOnExit.Text = "Save connections on exit";
-			this.chkSaveConsOnExit.UseVisualStyleBackColor = true;
-			//
-			//chkSingleInstance
-			//
-			this.chkSingleInstance.AutoSize = true;
-			this.chkSingleInstance.Location = new System.Drawing.Point(3, 48);
-			this.chkSingleInstance.Name = "chkSingleInstance";
-			this.chkSingleInstance.Size = new System.Drawing.Size(366, 17);
-			this.chkSingleInstance.TabIndex = 8;
-			this.chkSingleInstance.Text = "Allow only a single instance of the application (mRemote restart required)";
-			this.chkSingleInstance.UseVisualStyleBackColor = true;
-			//
-			//chkProperInstallationOfComponentsAtStartup
-			//
-			this.chkProperInstallationOfComponentsAtStartup.AutoSize = true;
-			this.chkProperInstallationOfComponentsAtStartup.Location = new System.Drawing.Point(3, 72);
-			this.chkProperInstallationOfComponentsAtStartup.Name = "chkProperInstallationOfComponentsAtStartup";
-			this.chkProperInstallationOfComponentsAtStartup.Size = new System.Drawing.Size(262, 17);
-			this.chkProperInstallationOfComponentsAtStartup.TabIndex = 9;
-			this.chkProperInstallationOfComponentsAtStartup.Text = "Check proper installation of components at startup";
-			this.chkProperInstallationOfComponentsAtStartup.UseVisualStyleBackColor = true;
-			//
-			//StartupExitPage
-			//
-			this.AutoScaleDimensions = new System.Drawing.SizeF((float) (6.0F), (float) (13.0F));
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this.chkReconnectOnStart);
-			this.Controls.Add(this.chkSaveConsOnExit);
-			this.Controls.Add(this.chkSingleInstance);
-			this.Controls.Add(this.chkProperInstallationOfComponentsAtStartup);
-			this.Name = "StartupExitPage";
-			this.PageIcon = (System.Drawing.Icon) (resources.GetObject("$this.PageIcon"));
-			this.Size = new System.Drawing.Size(610, 489);
-			this.ResumeLayout(false);
-			this.PerformLayout();
-				
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(StartupExitPage));
+            this.chkReconnectOnStart = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkSaveConsOnExit = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkSingleInstance = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkProperInstallationOfComponentsAtStartup = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.SuspendLayout();
+            // 
+            // chkReconnectOnStart
+            // 
+            this.chkReconnectOnStart._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkReconnectOnStart.AutoSize = true;
+            this.chkReconnectOnStart.Location = new System.Drawing.Point(3, 26);
+            this.chkReconnectOnStart.Name = "chkReconnectOnStart";
+            this.chkReconnectOnStart.Size = new System.Drawing.Size(273, 17);
+            this.chkReconnectOnStart.TabIndex = 7;
+            this.chkReconnectOnStart.Text = "Reconnect to previously opened sessions on startup";
+            this.chkReconnectOnStart.UseVisualStyleBackColor = true;
+            // 
+            // chkSaveConsOnExit
+            // 
+            this.chkSaveConsOnExit._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkSaveConsOnExit.AutoSize = true;
+            this.chkSaveConsOnExit.Location = new System.Drawing.Point(3, 2);
+            this.chkSaveConsOnExit.Name = "chkSaveConsOnExit";
+            this.chkSaveConsOnExit.Size = new System.Drawing.Size(146, 17);
+            this.chkSaveConsOnExit.TabIndex = 6;
+            this.chkSaveConsOnExit.Text = "Save connections on exit";
+            this.chkSaveConsOnExit.UseVisualStyleBackColor = true;
+            // 
+            // chkSingleInstance
+            // 
+            this.chkSingleInstance._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkSingleInstance.AutoSize = true;
+            this.chkSingleInstance.Location = new System.Drawing.Point(3, 50);
+            this.chkSingleInstance.Name = "chkSingleInstance";
+            this.chkSingleInstance.Size = new System.Drawing.Size(366, 17);
+            this.chkSingleInstance.TabIndex = 8;
+            this.chkSingleInstance.Text = "Allow only a single instance of the application (mRemote restart required)";
+            this.chkSingleInstance.UseVisualStyleBackColor = true;
+            // 
+            // chkProperInstallationOfComponentsAtStartup
+            // 
+            this.chkProperInstallationOfComponentsAtStartup._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkProperInstallationOfComponentsAtStartup.AutoSize = true;
+            this.chkProperInstallationOfComponentsAtStartup.Location = new System.Drawing.Point(3, 74);
+            this.chkProperInstallationOfComponentsAtStartup.Name = "chkProperInstallationOfComponentsAtStartup";
+            this.chkProperInstallationOfComponentsAtStartup.Size = new System.Drawing.Size(262, 17);
+            this.chkProperInstallationOfComponentsAtStartup.TabIndex = 9;
+            this.chkProperInstallationOfComponentsAtStartup.Text = "Check proper installation of components at startup";
+            this.chkProperInstallationOfComponentsAtStartup.UseVisualStyleBackColor = true;
+            // 
+            // StartupExitPage
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.chkReconnectOnStart);
+            this.Controls.Add(this.chkSaveConsOnExit);
+            this.Controls.Add(this.chkSingleInstance);
+            this.Controls.Add(this.chkProperInstallationOfComponentsAtStartup);
+            this.Name = "StartupExitPage";
+            this.PageIcon = ((System.Drawing.Icon)(resources.GetObject("$this.PageIcon")));
+            this.Size = new System.Drawing.Size(610, 489);
+            this.Load += new System.EventHandler(this.StartupExitPage_Load);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
 		}
 		internal Controls.Base.NGCheckBox chkReconnectOnStart;
 		internal Controls.Base.NGCheckBox chkSaveConsOnExit;

--- a/mRemoteV1/UI/Forms/OptionsPages/StartupExitPage.resx
+++ b/mRemoteV1/UI/Forms/OptionsPages/StartupExitPage.resx
@@ -112,12 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.PageIcon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA

--- a/mRemoteV1/UI/Forms/OptionsPages/TabsPanelsPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/TabsPanelsPage.Designer.cs
@@ -31,19 +31,20 @@ namespace mRemoteNG.UI.Forms.OptionsPages
 		[System.Diagnostics.DebuggerStepThrough()]private void InitializeComponent()
 		{
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(TabsPanelsPage));
-            this.chkAlwaysShowPanelTabs = new Controls.Base.NGCheckBox();
-            this.chkIdentifyQuickConnectTabs = new Controls.Base.NGCheckBox();
-            this.chkOpenNewTabRightOfSelected = new Controls.Base.NGCheckBox();
-            this.chkAlwaysShowPanelSelectionDlg = new Controls.Base.NGCheckBox();
-            this.chkShowLogonInfoOnTabs = new Controls.Base.NGCheckBox();
-            this.chkDoubleClickClosesTab = new Controls.Base.NGCheckBox();
-            this.chkShowProtocolOnTabs = new Controls.Base.NGCheckBox();
+            this.chkAlwaysShowPanelTabs = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkIdentifyQuickConnectTabs = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkOpenNewTabRightOfSelected = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkAlwaysShowPanelSelectionDlg = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkShowLogonInfoOnTabs = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkDoubleClickClosesTab = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkShowProtocolOnTabs = new mRemoteNG.UI.Controls.Base.NGCheckBox();
             this.SuspendLayout();
             // 
             // chkAlwaysShowPanelTabs
             // 
+            this.chkAlwaysShowPanelTabs._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkAlwaysShowPanelTabs.AutoSize = true;
-            this.chkAlwaysShowPanelTabs.Location = new System.Drawing.Point(3, 0);
+            this.chkAlwaysShowPanelTabs.Location = new System.Drawing.Point(3, 3);
             this.chkAlwaysShowPanelTabs.Name = "chkAlwaysShowPanelTabs";
             this.chkAlwaysShowPanelTabs.Size = new System.Drawing.Size(139, 17);
             this.chkAlwaysShowPanelTabs.TabIndex = 12;
@@ -52,8 +53,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkIdentifyQuickConnectTabs
             // 
+            this.chkIdentifyQuickConnectTabs._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkIdentifyQuickConnectTabs.AutoSize = true;
-            this.chkIdentifyQuickConnectTabs.Location = new System.Drawing.Point(3, 92);
+            this.chkIdentifyQuickConnectTabs.Location = new System.Drawing.Point(3, 95);
             this.chkIdentifyQuickConnectTabs.Name = "chkIdentifyQuickConnectTabs";
             this.chkIdentifyQuickConnectTabs.Size = new System.Drawing.Size(293, 17);
             this.chkIdentifyQuickConnectTabs.TabIndex = 16;
@@ -62,8 +64,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkOpenNewTabRightOfSelected
             // 
+            this.chkOpenNewTabRightOfSelected._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkOpenNewTabRightOfSelected.AutoSize = true;
-            this.chkOpenNewTabRightOfSelected.Location = new System.Drawing.Point(3, 23);
+            this.chkOpenNewTabRightOfSelected.Location = new System.Drawing.Point(3, 26);
             this.chkOpenNewTabRightOfSelected.Name = "chkOpenNewTabRightOfSelected";
             this.chkOpenNewTabRightOfSelected.Size = new System.Drawing.Size(280, 17);
             this.chkOpenNewTabRightOfSelected.TabIndex = 13;
@@ -72,8 +75,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkAlwaysShowPanelSelectionDlg
             // 
+            this.chkAlwaysShowPanelSelectionDlg._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkAlwaysShowPanelSelectionDlg.AutoSize = true;
-            this.chkAlwaysShowPanelSelectionDlg.Location = new System.Drawing.Point(3, 138);
+            this.chkAlwaysShowPanelSelectionDlg.Location = new System.Drawing.Point(3, 141);
             this.chkAlwaysShowPanelSelectionDlg.Name = "chkAlwaysShowPanelSelectionDlg";
             this.chkAlwaysShowPanelSelectionDlg.Size = new System.Drawing.Size(317, 17);
             this.chkAlwaysShowPanelSelectionDlg.TabIndex = 18;
@@ -82,8 +86,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkShowLogonInfoOnTabs
             // 
+            this.chkShowLogonInfoOnTabs._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkShowLogonInfoOnTabs.AutoSize = true;
-            this.chkShowLogonInfoOnTabs.Location = new System.Drawing.Point(3, 46);
+            this.chkShowLogonInfoOnTabs.Location = new System.Drawing.Point(3, 49);
             this.chkShowLogonInfoOnTabs.Name = "chkShowLogonInfoOnTabs";
             this.chkShowLogonInfoOnTabs.Size = new System.Drawing.Size(203, 17);
             this.chkShowLogonInfoOnTabs.TabIndex = 14;
@@ -92,8 +97,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkDoubleClickClosesTab
             // 
+            this.chkDoubleClickClosesTab._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkDoubleClickClosesTab.AutoSize = true;
-            this.chkDoubleClickClosesTab.Location = new System.Drawing.Point(3, 115);
+            this.chkDoubleClickClosesTab.Location = new System.Drawing.Point(3, 118);
             this.chkDoubleClickClosesTab.Name = "chkDoubleClickClosesTab";
             this.chkDoubleClickClosesTab.Size = new System.Drawing.Size(159, 17);
             this.chkDoubleClickClosesTab.TabIndex = 17;
@@ -102,8 +108,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkShowProtocolOnTabs
             // 
+            this.chkShowProtocolOnTabs._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkShowProtocolOnTabs.AutoSize = true;
-            this.chkShowProtocolOnTabs.Location = new System.Drawing.Point(3, 69);
+            this.chkShowProtocolOnTabs.Location = new System.Drawing.Point(3, 72);
             this.chkShowProtocolOnTabs.Name = "chkShowProtocolOnTabs";
             this.chkShowProtocolOnTabs.Size = new System.Drawing.Size(166, 17);
             this.chkShowProtocolOnTabs.TabIndex = 15;

--- a/mRemoteV1/UI/Forms/OptionsPages/ThemePage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/ThemePage.Designer.cs
@@ -46,7 +46,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // btnThemeDelete
             // 
             this.btnThemeDelete._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
-            this.btnThemeDelete.Location = new System.Drawing.Point(535, 0);
+            this.btnThemeDelete.Location = new System.Drawing.Point(535, 1);
             this.btnThemeDelete.Name = "btnThemeDelete";
             this.btnThemeDelete.Size = new System.Drawing.Size(75, 23);
             this.btnThemeDelete.TabIndex = 6;
@@ -57,7 +57,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // btnThemeNew
             // 
             this.btnThemeNew._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
-            this.btnThemeNew.Location = new System.Drawing.Point(454, 0);
+            this.btnThemeNew.Location = new System.Drawing.Point(454, 1);
             this.btnThemeNew.Name = "btnThemeNew";
             this.btnThemeNew.Size = new System.Drawing.Size(75, 23);
             this.btnThemeNew.TabIndex = 5;
@@ -70,7 +70,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.cboTheme._mice = mRemoteNG.UI.Controls.Base.NGComboBox.MouseState.HOVER;
             this.cboTheme.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboTheme.FormattingEnabled = true;
-            this.cboTheme.Location = new System.Drawing.Point(3, 1);
+            this.cboTheme.Location = new System.Drawing.Point(3, 2);
             this.cboTheme.Name = "cboTheme";
             this.cboTheme.Size = new System.Drawing.Size(445, 21);
             this.cboTheme.TabIndex = 4;
@@ -80,7 +80,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             this.themeEnableCombo._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.themeEnableCombo.AutoSize = true;
-            this.themeEnableCombo.Location = new System.Drawing.Point(487, 456);
+            this.themeEnableCombo.Location = new System.Drawing.Point(487, 457);
             this.themeEnableCombo.Name = "themeEnableCombo";
             this.themeEnableCombo.Size = new System.Drawing.Size(100, 17);
             this.themeEnableCombo.TabIndex = 8;
@@ -100,7 +100,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.ColorNameCol});
             this.listPalette.Cursor = System.Windows.Forms.Cursors.Default;
             this.listPalette.DecorateLines = true;
-            this.listPalette.Location = new System.Drawing.Point(3, 28);
+            this.listPalette.Location = new System.Drawing.Point(3, 29);
             this.listPalette.Name = "listPalette";
             this.listPalette.ShowGroups = false;
             this.listPalette.Size = new System.Drawing.Size(604, 413);
@@ -132,7 +132,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // labelRestart
             // 
             this.labelRestart.AutoSize = true;
-            this.labelRestart.Location = new System.Drawing.Point(23, 456);
+            this.labelRestart.Location = new System.Drawing.Point(23, 457);
             this.labelRestart.Name = "labelRestart";
             this.labelRestart.Size = new System.Drawing.Size(399, 13);
             this.labelRestart.TabIndex = 10;

--- a/mRemoteV1/UI/Forms/OptionsPages/UpdatesPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/UpdatesPage.Designer.cs
@@ -30,62 +30,94 @@ namespace mRemoteNG.UI.Forms.OptionsPages
 		[System.Diagnostics.DebuggerStepThrough()]private void InitializeComponent()
 		{
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(UpdatesPage));
-            this.lblUpdatesExplanation = new Controls.Base.NGLabel();
+            this.lblUpdatesExplanation = new mRemoteNG.UI.Controls.Base.NGLabel();
             this.pnlUpdateCheck = new System.Windows.Forms.Panel();
-            this.textBox1 = new Controls.Base.NGTextBox();
-            this.lblReleaseChannel = new Controls.Base.NGLabel();
-            this.cboReleaseChannel = new Controls.Base.NGComboBox();
-            this.btnUpdateCheckNow = new Controls.Base.NGButton();
-            this.chkCheckForUpdatesOnStartup = new Controls.Base.NGCheckBox();
-            this.cboUpdateCheckFrequency = new Controls.Base.NGComboBox();
+            this.btnUpdateCheckNow = new mRemoteNG.UI.Controls.Base.NGButton();
+            this.chkCheckForUpdatesOnStartup = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.cboUpdateCheckFrequency = new mRemoteNG.UI.Controls.Base.NGComboBox();
+            this.textBox1 = new mRemoteNG.UI.Controls.Base.NGTextBox();
+            this.lblReleaseChannel = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.cboReleaseChannel = new mRemoteNG.UI.Controls.Base.NGComboBox();
             this.pnlProxy = new System.Windows.Forms.Panel();
             this.pnlProxyBasic = new System.Windows.Forms.Panel();
-            this.lblProxyAddress = new Controls.Base.NGLabel();
-            this.txtProxyAddress = new Controls.Base.NGTextBox();
-            this.lblProxyPort = new Controls.Base.NGLabel();
-            this.numProxyPort = new Controls.Base.NGNumericUpDown();
-            this.chkUseProxyForAutomaticUpdates = new Controls.Base.NGCheckBox();
-            this.chkUseProxyAuthentication = new Controls.Base.NGCheckBox();
+            this.lblProxyAddress = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.txtProxyAddress = new mRemoteNG.UI.Controls.Base.NGTextBox();
+            this.lblProxyPort = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.numProxyPort = new mRemoteNG.UI.Controls.Base.NGNumericUpDown();
+            this.chkUseProxyForAutomaticUpdates = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkUseProxyAuthentication = new mRemoteNG.UI.Controls.Base.NGCheckBox();
             this.pnlProxyAuthentication = new System.Windows.Forms.Panel();
-            this.lblProxyUsername = new Controls.Base.NGLabel();
-            this.txtProxyUsername = new Controls.Base.NGTextBox();
-            this.lblProxyPassword = new Controls.Base.NGLabel();
-            this.txtProxyPassword = new Controls.Base.NGTextBox();
-            this.btnTestProxy = new Controls.Base.NGButton();
+            this.lblProxyUsername = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.txtProxyUsername = new mRemoteNG.UI.Controls.Base.NGTextBox();
+            this.lblProxyPassword = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.txtProxyPassword = new mRemoteNG.UI.Controls.Base.NGTextBox();
+            this.btnTestProxy = new mRemoteNG.UI.Controls.Base.NGButton();
+            this.pnlReleaseChannel = new System.Windows.Forms.Panel();
             this.pnlUpdateCheck.SuspendLayout();
             this.pnlProxy.SuspendLayout();
             this.pnlProxyBasic.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numProxyPort)).BeginInit();
             this.pnlProxyAuthentication.SuspendLayout();
+            this.pnlReleaseChannel.SuspendLayout();
             this.SuspendLayout();
             // 
             // lblUpdatesExplanation
             // 
-            this.lblUpdatesExplanation.Location = new System.Drawing.Point(3, 0);
+            this.lblUpdatesExplanation.Location = new System.Drawing.Point(3, 2);
             this.lblUpdatesExplanation.Name = "lblUpdatesExplanation";
-            this.lblUpdatesExplanation.Size = new System.Drawing.Size(536, 40);
+            this.lblUpdatesExplanation.Size = new System.Drawing.Size(536, 32);
             this.lblUpdatesExplanation.TabIndex = 3;
             this.lblUpdatesExplanation.Text = "mRemoteNG can periodically connect to the mRemoteNG website to check for updates." +
     "";
             // 
             // pnlUpdateCheck
             // 
-            this.pnlUpdateCheck.Controls.Add(this.textBox1);
-            this.pnlUpdateCheck.Controls.Add(this.lblReleaseChannel);
-            this.pnlUpdateCheck.Controls.Add(this.cboReleaseChannel);
             this.pnlUpdateCheck.Controls.Add(this.btnUpdateCheckNow);
             this.pnlUpdateCheck.Controls.Add(this.chkCheckForUpdatesOnStartup);
             this.pnlUpdateCheck.Controls.Add(this.cboUpdateCheckFrequency);
-            this.pnlUpdateCheck.Location = new System.Drawing.Point(0, 48);
+            this.pnlUpdateCheck.Location = new System.Drawing.Point(3, 38);
             this.pnlUpdateCheck.Name = "pnlUpdateCheck";
-            this.pnlUpdateCheck.Size = new System.Drawing.Size(610, 120);
+            this.pnlUpdateCheck.Size = new System.Drawing.Size(604, 96);
             this.pnlUpdateCheck.TabIndex = 4;
+            // 
+            // btnUpdateCheckNow
+            // 
+            this.btnUpdateCheckNow._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
+            this.btnUpdateCheckNow.Location = new System.Drawing.Point(3, 48);
+            this.btnUpdateCheckNow.Name = "btnUpdateCheckNow";
+            this.btnUpdateCheckNow.Size = new System.Drawing.Size(120, 32);
+            this.btnUpdateCheckNow.TabIndex = 2;
+            this.btnUpdateCheckNow.Text = "Check Now";
+            this.btnUpdateCheckNow.UseVisualStyleBackColor = true;
+            this.btnUpdateCheckNow.Click += new System.EventHandler(this.btnUpdateCheckNow_Click);
+            // 
+            // chkCheckForUpdatesOnStartup
+            // 
+            this.chkCheckForUpdatesOnStartup._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkCheckForUpdatesOnStartup.AutoSize = true;
+            this.chkCheckForUpdatesOnStartup.Location = new System.Drawing.Point(3, 3);
+            this.chkCheckForUpdatesOnStartup.Name = "chkCheckForUpdatesOnStartup";
+            this.chkCheckForUpdatesOnStartup.Size = new System.Drawing.Size(113, 17);
+            this.chkCheckForUpdatesOnStartup.TabIndex = 0;
+            this.chkCheckForUpdatesOnStartup.Text = "Check for updates";
+            this.chkCheckForUpdatesOnStartup.UseVisualStyleBackColor = true;
+            this.chkCheckForUpdatesOnStartup.CheckedChanged += new System.EventHandler(this.chkCheckForUpdatesOnStartup_CheckedChanged);
+            // 
+            // cboUpdateCheckFrequency
+            // 
+            this.cboUpdateCheckFrequency._mice = mRemoteNG.UI.Controls.Base.NGComboBox.MouseState.HOVER;
+            this.cboUpdateCheckFrequency.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboUpdateCheckFrequency.FormattingEnabled = true;
+            this.cboUpdateCheckFrequency.Location = new System.Drawing.Point(3, 21);
+            this.cboUpdateCheckFrequency.Name = "cboUpdateCheckFrequency";
+            this.cboUpdateCheckFrequency.Size = new System.Drawing.Size(120, 21);
+            this.cboUpdateCheckFrequency.TabIndex = 1;
             // 
             // textBox1
             // 
             this.textBox1.BackColor = System.Drawing.SystemColors.Control;
             this.textBox1.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.textBox1.Location = new System.Drawing.Point(226, 68);
+            this.textBox1.Location = new System.Drawing.Point(3, 42);
             this.textBox1.Multiline = true;
             this.textBox1.Name = "textBox1";
             this.textBox1.ReadOnly = true;
@@ -98,7 +130,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // lblReleaseChannel
             // 
             this.lblReleaseChannel.AutoSize = true;
-            this.lblReleaseChannel.Location = new System.Drawing.Point(223, 12);
+            this.lblReleaseChannel.Location = new System.Drawing.Point(0, -1);
             this.lblReleaseChannel.Name = "lblReleaseChannel";
             this.lblReleaseChannel.Size = new System.Drawing.Size(91, 13);
             this.lblReleaseChannel.TabIndex = 4;
@@ -106,42 +138,13 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // cboReleaseChannel
             // 
+            this.cboReleaseChannel._mice = mRemoteNG.UI.Controls.Base.NGComboBox.MouseState.HOVER;
             this.cboReleaseChannel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboReleaseChannel.FormattingEnabled = true;
-            this.cboReleaseChannel.Location = new System.Drawing.Point(226, 41);
+            this.cboReleaseChannel.Location = new System.Drawing.Point(3, 15);
             this.cboReleaseChannel.Name = "cboReleaseChannel";
-            this.cboReleaseChannel.Size = new System.Drawing.Size(121, 21);
+            this.cboReleaseChannel.Size = new System.Drawing.Size(120, 21);
             this.cboReleaseChannel.TabIndex = 3;
-            // 
-            // btnUpdateCheckNow
-            // 
-            this.btnUpdateCheckNow.Location = new System.Drawing.Point(3, 80);
-            this.btnUpdateCheckNow.Name = "btnUpdateCheckNow";
-            this.btnUpdateCheckNow.Size = new System.Drawing.Size(120, 32);
-            this.btnUpdateCheckNow.TabIndex = 2;
-            this.btnUpdateCheckNow.Text = "Check Now";
-            this.btnUpdateCheckNow.UseVisualStyleBackColor = true;
-            this.btnUpdateCheckNow.Click += new System.EventHandler(this.btnUpdateCheckNow_Click);
-            // 
-            // chkCheckForUpdatesOnStartup
-            // 
-            this.chkCheckForUpdatesOnStartup.AutoSize = true;
-            this.chkCheckForUpdatesOnStartup.Location = new System.Drawing.Point(3, 8);
-            this.chkCheckForUpdatesOnStartup.Name = "chkCheckForUpdatesOnStartup";
-            this.chkCheckForUpdatesOnStartup.Size = new System.Drawing.Size(113, 17);
-            this.chkCheckForUpdatesOnStartup.TabIndex = 0;
-            this.chkCheckForUpdatesOnStartup.Text = "Check for updates";
-            this.chkCheckForUpdatesOnStartup.UseVisualStyleBackColor = true;
-            this.chkCheckForUpdatesOnStartup.CheckedChanged += new System.EventHandler(this.chkCheckForUpdatesOnStartup_CheckedChanged);
-            // 
-            // cboUpdateCheckFrequency
-            // 
-            this.cboUpdateCheckFrequency.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cboUpdateCheckFrequency.FormattingEnabled = true;
-            this.cboUpdateCheckFrequency.Location = new System.Drawing.Point(3, 41);
-            this.cboUpdateCheckFrequency.Name = "cboUpdateCheckFrequency";
-            this.cboUpdateCheckFrequency.Size = new System.Drawing.Size(128, 21);
-            this.cboUpdateCheckFrequency.TabIndex = 1;
             // 
             // pnlProxy
             // 
@@ -150,9 +153,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.pnlProxy.Controls.Add(this.chkUseProxyAuthentication);
             this.pnlProxy.Controls.Add(this.pnlProxyAuthentication);
             this.pnlProxy.Controls.Add(this.btnTestProxy);
-            this.pnlProxy.Location = new System.Drawing.Point(0, 200);
+            this.pnlProxy.Location = new System.Drawing.Point(0, 243);
             this.pnlProxy.Name = "pnlProxy";
-            this.pnlProxy.Size = new System.Drawing.Size(610, 224);
+            this.pnlProxy.Size = new System.Drawing.Size(610, 219);
             this.pnlProxy.TabIndex = 5;
             // 
             // pnlProxyBasic
@@ -162,14 +165,14 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.pnlProxyBasic.Controls.Add(this.lblProxyPort);
             this.pnlProxyBasic.Controls.Add(this.numProxyPort);
             this.pnlProxyBasic.Enabled = false;
-            this.pnlProxyBasic.Location = new System.Drawing.Point(3, 32);
+            this.pnlProxyBasic.Location = new System.Drawing.Point(3, 22);
             this.pnlProxyBasic.Name = "pnlProxyBasic";
             this.pnlProxyBasic.Size = new System.Drawing.Size(604, 40);
             this.pnlProxyBasic.TabIndex = 1;
             // 
             // lblProxyAddress
             // 
-            this.lblProxyAddress.Location = new System.Drawing.Point(8, 4);
+            this.lblProxyAddress.Location = new System.Drawing.Point(8, 0);
             this.lblProxyAddress.Name = "lblProxyAddress";
             this.lblProxyAddress.Size = new System.Drawing.Size(96, 24);
             this.lblProxyAddress.TabIndex = 0;
@@ -179,14 +182,14 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // txtProxyAddress
             // 
             this.txtProxyAddress.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.txtProxyAddress.Location = new System.Drawing.Point(104, 8);
+            this.txtProxyAddress.Location = new System.Drawing.Point(110, 4);
             this.txtProxyAddress.Name = "txtProxyAddress";
             this.txtProxyAddress.Size = new System.Drawing.Size(240, 20);
             this.txtProxyAddress.TabIndex = 1;
             // 
             // lblProxyPort
             // 
-            this.lblProxyPort.Location = new System.Drawing.Point(350, 5);
+            this.lblProxyPort.Location = new System.Drawing.Point(350, 1);
             this.lblProxyPort.Name = "lblProxyPort";
             this.lblProxyPort.Size = new System.Drawing.Size(64, 23);
             this.lblProxyPort.TabIndex = 2;
@@ -196,7 +199,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // numProxyPort
             // 
             this.numProxyPort.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.numProxyPort.Location = new System.Drawing.Point(420, 8);
+            this.numProxyPort.Location = new System.Drawing.Point(420, 4);
             this.numProxyPort.Maximum = new decimal(new int[] {
             65535,
             0,
@@ -218,8 +221,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkUseProxyForAutomaticUpdates
             // 
+            this.chkUseProxyForAutomaticUpdates._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkUseProxyForAutomaticUpdates.AutoSize = true;
-            this.chkUseProxyForAutomaticUpdates.Location = new System.Drawing.Point(3, 8);
+            this.chkUseProxyForAutomaticUpdates.Location = new System.Drawing.Point(3, 0);
             this.chkUseProxyForAutomaticUpdates.Name = "chkUseProxyForAutomaticUpdates";
             this.chkUseProxyForAutomaticUpdates.Size = new System.Drawing.Size(168, 17);
             this.chkUseProxyForAutomaticUpdates.TabIndex = 0;
@@ -229,9 +233,10 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkUseProxyAuthentication
             // 
+            this.chkUseProxyAuthentication._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkUseProxyAuthentication.AutoSize = true;
             this.chkUseProxyAuthentication.Enabled = false;
-            this.chkUseProxyAuthentication.Location = new System.Drawing.Point(27, 80);
+            this.chkUseProxyAuthentication.Location = new System.Drawing.Point(27, 70);
             this.chkUseProxyAuthentication.Name = "chkUseProxyAuthentication";
             this.chkUseProxyAuthentication.Size = new System.Drawing.Size(216, 17);
             this.chkUseProxyAuthentication.TabIndex = 2;
@@ -246,14 +251,14 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.pnlProxyAuthentication.Controls.Add(this.lblProxyPassword);
             this.pnlProxyAuthentication.Controls.Add(this.txtProxyPassword);
             this.pnlProxyAuthentication.Enabled = false;
-            this.pnlProxyAuthentication.Location = new System.Drawing.Point(3, 104);
+            this.pnlProxyAuthentication.Location = new System.Drawing.Point(3, 94);
             this.pnlProxyAuthentication.Name = "pnlProxyAuthentication";
             this.pnlProxyAuthentication.Size = new System.Drawing.Size(604, 72);
             this.pnlProxyAuthentication.TabIndex = 3;
             // 
             // lblProxyUsername
             // 
-            this.lblProxyUsername.Location = new System.Drawing.Point(8, 4);
+            this.lblProxyUsername.Location = new System.Drawing.Point(8, 0);
             this.lblProxyUsername.Name = "lblProxyUsername";
             this.lblProxyUsername.Size = new System.Drawing.Size(96, 24);
             this.lblProxyUsername.TabIndex = 0;
@@ -263,14 +268,14 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // txtProxyUsername
             // 
             this.txtProxyUsername.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.txtProxyUsername.Location = new System.Drawing.Point(104, 8);
+            this.txtProxyUsername.Location = new System.Drawing.Point(110, 4);
             this.txtProxyUsername.Name = "txtProxyUsername";
             this.txtProxyUsername.Size = new System.Drawing.Size(240, 20);
             this.txtProxyUsername.TabIndex = 1;
             // 
             // lblProxyPassword
             // 
-            this.lblProxyPassword.Location = new System.Drawing.Point(8, 36);
+            this.lblProxyPassword.Location = new System.Drawing.Point(8, 26);
             this.lblProxyPassword.Name = "lblProxyPassword";
             this.lblProxyPassword.Size = new System.Drawing.Size(96, 24);
             this.lblProxyPassword.TabIndex = 2;
@@ -280,7 +285,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // txtProxyPassword
             // 
             this.txtProxyPassword.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.txtProxyPassword.Location = new System.Drawing.Point(104, 40);
+            this.txtProxyPassword.Location = new System.Drawing.Point(110, 30);
             this.txtProxyPassword.Name = "txtProxyPassword";
             this.txtProxyPassword.Size = new System.Drawing.Size(240, 20);
             this.txtProxyPassword.TabIndex = 3;
@@ -288,7 +293,8 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // btnTestProxy
             // 
-            this.btnTestProxy.Location = new System.Drawing.Point(3, 184);
+            this.btnTestProxy._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
+            this.btnTestProxy.Location = new System.Drawing.Point(6, 172);
             this.btnTestProxy.Name = "btnTestProxy";
             this.btnTestProxy.Size = new System.Drawing.Size(120, 32);
             this.btnTestProxy.TabIndex = 4;
@@ -296,10 +302,21 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.btnTestProxy.UseVisualStyleBackColor = true;
             this.btnTestProxy.Click += new System.EventHandler(this.btnTestProxy_Click);
             // 
+            // pnlReleaseChannel
+            // 
+            this.pnlReleaseChannel.Controls.Add(this.textBox1);
+            this.pnlReleaseChannel.Controls.Add(this.lblReleaseChannel);
+            this.pnlReleaseChannel.Controls.Add(this.cboReleaseChannel);
+            this.pnlReleaseChannel.Location = new System.Drawing.Point(3, 140);
+            this.pnlReleaseChannel.Name = "pnlReleaseChannel";
+            this.pnlReleaseChannel.Size = new System.Drawing.Size(604, 97);
+            this.pnlReleaseChannel.TabIndex = 6;
+            // 
             // UpdatesPage
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.pnlReleaseChannel);
             this.Controls.Add(this.lblUpdatesExplanation);
             this.Controls.Add(this.pnlUpdateCheck);
             this.Controls.Add(this.pnlProxy);
@@ -315,6 +332,8 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             ((System.ComponentModel.ISupportInitialize)(this.numProxyPort)).EndInit();
             this.pnlProxyAuthentication.ResumeLayout(false);
             this.pnlProxyAuthentication.PerformLayout();
+            this.pnlReleaseChannel.ResumeLayout(false);
+            this.pnlReleaseChannel.PerformLayout();
             this.ResumeLayout(false);
 
 		}
@@ -340,5 +359,6 @@ namespace mRemoteNG.UI.Forms.OptionsPages
         private Controls.Base.NGLabel lblReleaseChannel;
         private Controls.Base.NGComboBox cboReleaseChannel;
         private Controls.Base.NGTextBox textBox1;
+        private System.Windows.Forms.Panel pnlReleaseChannel;
     }
 }


### PR DESCRIPTION
Rearranged some elements from the settings to prevent that translated strings overlap with these elements. Issue #784

<!--
Please provide as much detail as possible with what your pull request does.
Include a reference to a filed issue if it exists.
-->
