### PR TITLE
Further design optimizations on settings

### DIFF
--- a/mRemoteV1/UI/Forms/OptionsPages/AdvancedPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/AdvancedPage.Designer.cs
@@ -31,29 +31,30 @@ namespace mRemoteNG.UI.Forms.OptionsPages
         private void InitializeComponent()
 		{
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AdvancedPage));
-            this.chkAutomaticallyGetSessionInfo = new Controls.Base.NGCheckBox();
-            this.lblMaximumPuttyWaitTime = new Controls.Base.NGLabel();
-            this.chkAutomaticReconnect = new Controls.Base.NGCheckBox();
-            this.numPuttyWaitTime = new Controls.Base.NGNumericUpDown();
-            this.chkUseCustomPuttyPath = new Controls.Base.NGCheckBox();
-            this.lblConfigurePuttySessions = new Controls.Base.NGLabel();
-            this.numUVNCSCPort = new Controls.Base.NGNumericUpDown();
-            this.txtCustomPuttyPath = new Controls.Base.NGTextBox();
-            this.btnLaunchPutty = new Controls.Base.NGButton();
-            this.lblUVNCSCPort = new Controls.Base.NGLabel();
-            this.lblSeconds = new Controls.Base.NGLabel();
-            this.btnBrowseCustomPuttyPath = new Controls.Base.NGButton();
+            this.chkAutomaticallyGetSessionInfo = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.lblMaximumPuttyWaitTime = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.chkAutomaticReconnect = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.numPuttyWaitTime = new mRemoteNG.UI.Controls.Base.NGNumericUpDown();
+            this.chkUseCustomPuttyPath = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.lblConfigurePuttySessions = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.numUVNCSCPort = new mRemoteNG.UI.Controls.Base.NGNumericUpDown();
+            this.txtCustomPuttyPath = new mRemoteNG.UI.Controls.Base.NGTextBox();
+            this.btnLaunchPutty = new mRemoteNG.UI.Controls.Base.NGButton();
+            this.lblUVNCSCPort = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.lblSeconds = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.btnBrowseCustomPuttyPath = new mRemoteNG.UI.Controls.Base.NGButton();
             ((System.ComponentModel.ISupportInitialize)(this.numPuttyWaitTime)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numUVNCSCPort)).BeginInit();
             this.SuspendLayout();
             // 
             // chkAutomaticallyGetSessionInfo
             // 
+            this.chkAutomaticallyGetSessionInfo._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkAutomaticallyGetSessionInfo.AutoSize = true;
             this.chkAutomaticallyGetSessionInfo.Location = new System.Drawing.Point(3, 3);
             this.chkAutomaticallyGetSessionInfo.Name = "chkAutomaticallyGetSessionInfo";
             this.chkAutomaticallyGetSessionInfo.Size = new System.Drawing.Size(198, 17);
-            this.chkAutomaticallyGetSessionInfo.TabIndex = 19;
+            this.chkAutomaticallyGetSessionInfo.TabIndex = 0;
             this.chkAutomaticallyGetSessionInfo.Text = "Automatically get session information";
             this.chkAutomaticallyGetSessionInfo.UseVisualStyleBackColor = true;
             // 
@@ -62,17 +63,18 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.lblMaximumPuttyWaitTime.Location = new System.Drawing.Point(3, 152);
             this.lblMaximumPuttyWaitTime.Name = "lblMaximumPuttyWaitTime";
             this.lblMaximumPuttyWaitTime.Size = new System.Drawing.Size(364, 13);
-            this.lblMaximumPuttyWaitTime.TabIndex = 26;
+            this.lblMaximumPuttyWaitTime.TabIndex = 7;
             this.lblMaximumPuttyWaitTime.Text = "Maximum PuTTY wait time:";
             this.lblMaximumPuttyWaitTime.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // chkAutomaticReconnect
             // 
+            this.chkAutomaticReconnect._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkAutomaticReconnect.AutoSize = true;
             this.chkAutomaticReconnect.Location = new System.Drawing.Point(3, 26);
             this.chkAutomaticReconnect.Name = "chkAutomaticReconnect";
             this.chkAutomaticReconnect.Size = new System.Drawing.Size(399, 17);
-            this.chkAutomaticReconnect.TabIndex = 20;
+            this.chkAutomaticReconnect.TabIndex = 1;
             this.chkAutomaticReconnect.Text = "Automatically try to reconnect when disconnected from server (RDP && ICA only)";
             this.chkAutomaticReconnect.UseVisualStyleBackColor = true;
             // 
@@ -87,7 +89,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             0});
             this.numPuttyWaitTime.Name = "numPuttyWaitTime";
             this.numPuttyWaitTime.Size = new System.Drawing.Size(49, 20);
-            this.numPuttyWaitTime.TabIndex = 27;
+            this.numPuttyWaitTime.TabIndex = 8;
             this.numPuttyWaitTime.Value = new decimal(new int[] {
             5,
             0,
@@ -96,11 +98,12 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // chkUseCustomPuttyPath
             // 
+            this.chkUseCustomPuttyPath._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkUseCustomPuttyPath.AutoSize = true;
             this.chkUseCustomPuttyPath.Location = new System.Drawing.Point(3, 49);
             this.chkUseCustomPuttyPath.Name = "chkUseCustomPuttyPath";
             this.chkUseCustomPuttyPath.Size = new System.Drawing.Size(146, 17);
-            this.chkUseCustomPuttyPath.TabIndex = 21;
+            this.chkUseCustomPuttyPath.TabIndex = 2;
             this.chkUseCustomPuttyPath.Text = "Use custom PuTTY path:";
             this.chkUseCustomPuttyPath.UseVisualStyleBackColor = true;
             this.chkUseCustomPuttyPath.CheckedChanged += new System.EventHandler(this.chkUseCustomPuttyPath_CheckedChanged);
@@ -110,14 +113,14 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.lblConfigurePuttySessions.Location = new System.Drawing.Point(3, 121);
             this.lblConfigurePuttySessions.Name = "lblConfigurePuttySessions";
             this.lblConfigurePuttySessions.Size = new System.Drawing.Size(364, 13);
-            this.lblConfigurePuttySessions.TabIndex = 24;
+            this.lblConfigurePuttySessions.TabIndex = 5;
             this.lblConfigurePuttySessions.Text = "To configure PuTTY sessions click this button:";
             this.lblConfigurePuttySessions.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // numUVNCSCPort
             // 
             this.numUVNCSCPort.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.numUVNCSCPort.Location = new System.Drawing.Point(370, 193);
+            this.numUVNCSCPort.Location = new System.Drawing.Point(373, 193);
             this.numUVNCSCPort.Maximum = new decimal(new int[] {
             65535,
             0,
@@ -125,7 +128,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             0});
             this.numUVNCSCPort.Name = "numUVNCSCPort";
             this.numUVNCSCPort.Size = new System.Drawing.Size(72, 20);
-            this.numUVNCSCPort.TabIndex = 33;
+            this.numUVNCSCPort.TabIndex = 11;
             this.numUVNCSCPort.Value = new decimal(new int[] {
             5500,
             0,
@@ -140,17 +143,18 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.txtCustomPuttyPath.Location = new System.Drawing.Point(21, 72);
             this.txtCustomPuttyPath.Name = "txtCustomPuttyPath";
             this.txtCustomPuttyPath.Size = new System.Drawing.Size(346, 20);
-            this.txtCustomPuttyPath.TabIndex = 22;
+            this.txtCustomPuttyPath.TabIndex = 3;
             this.txtCustomPuttyPath.TextChanged += new System.EventHandler(this.txtCustomPuttyPath_TextChanged);
             // 
             // btnLaunchPutty
             // 
+            this.btnLaunchPutty._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
             this.btnLaunchPutty.Image = global::mRemoteNG.Resources.PuttyConfig;
             this.btnLaunchPutty.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnLaunchPutty.Location = new System.Drawing.Point(373, 116);
+            this.btnLaunchPutty.Location = new System.Drawing.Point(373, 115);
             this.btnLaunchPutty.Name = "btnLaunchPutty";
-            this.btnLaunchPutty.Size = new System.Drawing.Size(110, 23);
-            this.btnLaunchPutty.TabIndex = 25;
+            this.btnLaunchPutty.Size = new System.Drawing.Size(110, 25);
+            this.btnLaunchPutty.TabIndex = 6;
             this.btnLaunchPutty.Text = "Launch PuTTY";
             this.btnLaunchPutty.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.btnLaunchPutty.UseVisualStyleBackColor = true;
@@ -158,10 +162,10 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             // lblUVNCSCPort
             // 
-            this.lblUVNCSCPort.Location = new System.Drawing.Point(0, 195);
+            this.lblUVNCSCPort.Location = new System.Drawing.Point(3, 195);
             this.lblUVNCSCPort.Name = "lblUVNCSCPort";
             this.lblUVNCSCPort.Size = new System.Drawing.Size(364, 13);
-            this.lblUVNCSCPort.TabIndex = 32;
+            this.lblUVNCSCPort.TabIndex = 10;
             this.lblUVNCSCPort.Text = "UltraVNC SingleClick Listening Port:";
             this.lblUVNCSCPort.TextAlign = System.Drawing.ContentAlignment.TopRight;
             this.lblUVNCSCPort.Visible = false;
@@ -172,16 +176,17 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.lblSeconds.Location = new System.Drawing.Point(428, 152);
             this.lblSeconds.Name = "lblSeconds";
             this.lblSeconds.Size = new System.Drawing.Size(47, 13);
-            this.lblSeconds.TabIndex = 28;
+            this.lblSeconds.TabIndex = 9;
             this.lblSeconds.Text = "seconds";
             // 
             // btnBrowseCustomPuttyPath
             // 
+            this.btnBrowseCustomPuttyPath._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
             this.btnBrowseCustomPuttyPath.Enabled = false;
             this.btnBrowseCustomPuttyPath.Location = new System.Drawing.Point(373, 70);
             this.btnBrowseCustomPuttyPath.Name = "btnBrowseCustomPuttyPath";
             this.btnBrowseCustomPuttyPath.Size = new System.Drawing.Size(75, 23);
-            this.btnBrowseCustomPuttyPath.TabIndex = 23;
+            this.btnBrowseCustomPuttyPath.TabIndex = 4;
             this.btnBrowseCustomPuttyPath.Text = "Browse...";
             this.btnBrowseCustomPuttyPath.UseVisualStyleBackColor = true;
             this.btnBrowseCustomPuttyPath.Click += new System.EventHandler(this.btnBrowseCustomPuttyPath_Click);

--- a/mRemoteV1/UI/Forms/OptionsPages/AppearancePage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/AppearancePage.Designer.cs
@@ -46,7 +46,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.lblLanguageRestartRequired.Location = new System.Drawing.Point(3, 56);
             this.lblLanguageRestartRequired.Name = "lblLanguageRestartRequired";
             this.lblLanguageRestartRequired.Size = new System.Drawing.Size(380, 13);
-            this.lblLanguageRestartRequired.TabIndex = 9;
+            this.lblLanguageRestartRequired.TabIndex = 2;
             this.lblLanguageRestartRequired.Text = "mRemoteNG must be restarted before changes to the language will take effect.";
             // 
             // cboLanguage
@@ -58,7 +58,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.cboLanguage.Name = "cboLanguage";
             this.cboLanguage.Size = new System.Drawing.Size(304, 21);
             this.cboLanguage.Sorted = true;
-            this.cboLanguage.TabIndex = 8;
+            this.cboLanguage.TabIndex = 1;
             // 
             // lblLanguage
             // 
@@ -66,7 +66,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.lblLanguage.Location = new System.Drawing.Point(3, 3);
             this.lblLanguage.Name = "lblLanguage";
             this.lblLanguage.Size = new System.Drawing.Size(55, 13);
-            this.lblLanguage.TabIndex = 7;
+            this.lblLanguage.TabIndex = 0;
             this.lblLanguage.Text = "Language";
             // 
             // chkShowFullConnectionsFilePathInTitle
@@ -76,7 +76,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkShowFullConnectionsFilePathInTitle.Location = new System.Drawing.Point(3, 127);
             this.chkShowFullConnectionsFilePathInTitle.Name = "chkShowFullConnectionsFilePathInTitle";
             this.chkShowFullConnectionsFilePathInTitle.Size = new System.Drawing.Size(239, 17);
-            this.chkShowFullConnectionsFilePathInTitle.TabIndex = 11;
+            this.chkShowFullConnectionsFilePathInTitle.TabIndex = 4;
             this.chkShowFullConnectionsFilePathInTitle.Text = "Show full connections file path in window title";
             this.chkShowFullConnectionsFilePathInTitle.UseVisualStyleBackColor = true;
             // 
@@ -87,7 +87,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkShowDescriptionTooltipsInTree.Location = new System.Drawing.Point(3, 104);
             this.chkShowDescriptionTooltipsInTree.Name = "chkShowDescriptionTooltipsInTree";
             this.chkShowDescriptionTooltipsInTree.Size = new System.Drawing.Size(231, 17);
-            this.chkShowDescriptionTooltipsInTree.TabIndex = 10;
+            this.chkShowDescriptionTooltipsInTree.TabIndex = 3;
             this.chkShowDescriptionTooltipsInTree.Text = "Show description tooltips in connection tree";
             this.chkShowDescriptionTooltipsInTree.UseVisualStyleBackColor = true;
             // 
@@ -98,7 +98,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkShowSystemTrayIcon.Location = new System.Drawing.Point(3, 173);
             this.chkShowSystemTrayIcon.Name = "chkShowSystemTrayIcon";
             this.chkShowSystemTrayIcon.Size = new System.Drawing.Size(172, 17);
-            this.chkShowSystemTrayIcon.TabIndex = 12;
+            this.chkShowSystemTrayIcon.TabIndex = 5;
             this.chkShowSystemTrayIcon.Text = "Always show System Tray Icon";
             this.chkShowSystemTrayIcon.UseVisualStyleBackColor = true;
             // 
@@ -109,7 +109,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkMinimizeToSystemTray.Location = new System.Drawing.Point(3, 196);
             this.chkMinimizeToSystemTray.Name = "chkMinimizeToSystemTray";
             this.chkMinimizeToSystemTray.Size = new System.Drawing.Size(139, 17);
-            this.chkMinimizeToSystemTray.TabIndex = 13;
+            this.chkMinimizeToSystemTray.TabIndex = 6;
             this.chkMinimizeToSystemTray.Text = "Minimize to System Tray";
             this.chkMinimizeToSystemTray.UseVisualStyleBackColor = true;
             // 

--- a/mRemoteV1/UI/Forms/OptionsPages/ConnectionsPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/ConnectionsPage.Designer.cs
@@ -74,7 +74,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             0});
             this.numRDPConTimeout.Name = "numRDPConTimeout";
             this.numRDPConTimeout.Size = new System.Drawing.Size(53, 20);
-            this.numRDPConTimeout.TabIndex = 3;
+            this.numRDPConTimeout.TabIndex = 1;
             this.numRDPConTimeout.Value = new decimal(new int[] {
             20,
             0,
@@ -87,7 +87,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.lblRDPConTimeout.Location = new System.Drawing.Point(3, 6);
             this.lblRDPConTimeout.Name = "lblRDPConTimeout";
             this.lblRDPConTimeout.Size = new System.Drawing.Size(137, 13);
-            this.lblRDPConTimeout.TabIndex = 2;
+            this.lblRDPConTimeout.TabIndex = 0;
             this.lblRDPConTimeout.Text = "RDP Connection Timeout";
             this.lblRDPConTimeout.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -126,7 +126,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkSingleClickOnConnectionOpensIt.Location = new System.Drawing.Point(3, 3);
             this.chkSingleClickOnConnectionOpensIt.Name = "chkSingleClickOnConnectionOpensIt";
             this.chkSingleClickOnConnectionOpensIt.Size = new System.Drawing.Size(191, 17);
-            this.chkSingleClickOnConnectionOpensIt.TabIndex = 7;
+            this.chkSingleClickOnConnectionOpensIt.TabIndex = 0;
             this.chkSingleClickOnConnectionOpensIt.Text = "Single click on connection opens it";
             this.chkSingleClickOnConnectionOpensIt.UseVisualStyleBackColor = true;
             // 
@@ -137,7 +137,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkHostnameLikeDisplayName.Location = new System.Drawing.Point(3, 49);
             this.chkHostnameLikeDisplayName.Name = "chkHostnameLikeDisplayName";
             this.chkHostnameLikeDisplayName.Size = new System.Drawing.Size(328, 17);
-            this.chkHostnameLikeDisplayName.TabIndex = 9;
+            this.chkHostnameLikeDisplayName.TabIndex = 2;
             this.chkHostnameLikeDisplayName.Text = "Set hostname like display name when creating new connections";
             this.chkHostnameLikeDisplayName.UseVisualStyleBackColor = true;
             // 
@@ -148,7 +148,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkSingleClickOnOpenedConnectionSwitchesToIt.Location = new System.Drawing.Point(3, 26);
             this.chkSingleClickOnOpenedConnectionSwitchesToIt.Name = "chkSingleClickOnOpenedConnectionSwitchesToIt";
             this.chkSingleClickOnOpenedConnectionSwitchesToIt.Size = new System.Drawing.Size(457, 17);
-            this.chkSingleClickOnOpenedConnectionSwitchesToIt.TabIndex = 8;
+            this.chkSingleClickOnOpenedConnectionSwitchesToIt.TabIndex = 1;
             this.chkSingleClickOnOpenedConnectionSwitchesToIt.Text = global::mRemoteNG.Language.strSingleClickOnOpenConnectionSwitchesToIt;
             this.chkSingleClickOnOpenedConnectionSwitchesToIt.UseVisualStyleBackColor = true;
             // 
@@ -185,7 +185,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.pnlConfirmCloseConnection.Location = new System.Drawing.Point(3, 171);
             this.pnlConfirmCloseConnection.Name = "pnlConfirmCloseConnection";
             this.pnlConfirmCloseConnection.Size = new System.Drawing.Size(595, 137);
-            this.pnlConfirmCloseConnection.TabIndex = 13;
+            this.pnlConfirmCloseConnection.TabIndex = 6;
             // 
             // lblClosingConnections
             // 
@@ -251,9 +251,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.pnlRdpReconnectionCount.Name = "pnlRdpReconnectionCount";
             this.pnlRdpReconnectionCount.RowCount = 1;
             this.pnlRdpReconnectionCount.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.pnlRdpReconnectionCount.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.pnlRdpReconnectionCount.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 26F));
             this.pnlRdpReconnectionCount.Size = new System.Drawing.Size(595, 26);
-            this.pnlRdpReconnectionCount.TabIndex = 14;
+            this.pnlRdpReconnectionCount.TabIndex = 3;
             // 
             // pnlRdpConnectionTimeout
             // 
@@ -266,9 +266,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.pnlRdpConnectionTimeout.Name = "pnlRdpConnectionTimeout";
             this.pnlRdpConnectionTimeout.RowCount = 1;
             this.pnlRdpConnectionTimeout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.pnlRdpConnectionTimeout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.pnlRdpConnectionTimeout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 26F));
             this.pnlRdpConnectionTimeout.Size = new System.Drawing.Size(595, 26);
-            this.pnlRdpConnectionTimeout.TabIndex = 15;
+            this.pnlRdpConnectionTimeout.TabIndex = 4;
             // 
             // tableLayoutPanel1
             // 
@@ -283,7 +283,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(595, 26);
-            this.tableLayoutPanel1.TabIndex = 16;
+            this.tableLayoutPanel1.TabIndex = 5;
             // 
             // ConnectionsPage
             // 

--- a/mRemoteV1/UI/Forms/OptionsPages/CredentialsPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/CredentialsPage.Designer.cs
@@ -58,7 +58,7 @@
             this.pnlDefaultCredentials.Location = new System.Drawing.Point(3, 3);
             this.pnlDefaultCredentials.Name = "pnlDefaultCredentials";
             this.pnlDefaultCredentials.Size = new System.Drawing.Size(596, 175);
-            this.pnlDefaultCredentials.TabIndex = 13;
+            this.pnlDefaultCredentials.TabIndex = 0;
             // 
             // radCredentialsCustom
             // 

--- a/mRemoteV1/UI/Forms/OptionsPages/NotificationsPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/NotificationsPage.Designer.cs
@@ -75,7 +75,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.labelSwitchToErrorsAndInfos.Location = new System.Drawing.Point(177, 25);
             this.labelSwitchToErrorsAndInfos.Name = "labelSwitchToErrorsAndInfos";
             this.labelSwitchToErrorsAndInfos.Size = new System.Drawing.Size(159, 13);
-            this.labelSwitchToErrorsAndInfos.TabIndex = 24;
+            this.labelSwitchToErrorsAndInfos.TabIndex = 5;
             this.labelSwitchToErrorsAndInfos.Text = "Switch to Notifications panel on:";
             // 
             // chkSwitchToMCInformation
@@ -85,7 +85,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkSwitchToMCInformation.Location = new System.Drawing.Point(195, 67);
             this.chkSwitchToMCInformation.Name = "chkSwitchToMCInformation";
             this.chkSwitchToMCInformation.Size = new System.Drawing.Size(78, 17);
-            this.chkSwitchToMCInformation.TabIndex = 25;
+            this.chkSwitchToMCInformation.TabIndex = 6;
             this.chkSwitchToMCInformation.Text = "Information";
             this.chkSwitchToMCInformation.UseVisualStyleBackColor = true;
             // 
@@ -96,7 +96,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkSwitchToMCErrors.Location = new System.Drawing.Point(195, 113);
             this.chkSwitchToMCErrors.Name = "chkSwitchToMCErrors";
             this.chkSwitchToMCErrors.Size = new System.Drawing.Size(48, 17);
-            this.chkSwitchToMCErrors.TabIndex = 27;
+            this.chkSwitchToMCErrors.TabIndex = 8;
             this.chkSwitchToMCErrors.Text = "Error";
             this.chkSwitchToMCErrors.UseVisualStyleBackColor = true;
             // 
@@ -107,7 +107,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkSwitchToMCWarnings.Location = new System.Drawing.Point(195, 90);
             this.chkSwitchToMCWarnings.Name = "chkSwitchToMCWarnings";
             this.chkSwitchToMCWarnings.Size = new System.Drawing.Size(66, 17);
-            this.chkSwitchToMCWarnings.TabIndex = 26;
+            this.chkSwitchToMCWarnings.TabIndex = 7;
             this.chkSwitchToMCWarnings.Text = "Warning";
             this.chkSwitchToMCWarnings.UseVisualStyleBackColor = true;
             // 
@@ -125,7 +125,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.groupBoxNotifications.Location = new System.Drawing.Point(6, 2);
             this.groupBoxNotifications.Name = "groupBoxNotifications";
             this.groupBoxNotifications.Size = new System.Drawing.Size(601, 141);
-            this.groupBoxNotifications.TabIndex = 28;
+            this.groupBoxNotifications.TabIndex = 0;
             this.groupBoxNotifications.TabStop = false;
             this.groupBoxNotifications.Text = "Notifications Panel";
             // 
@@ -135,7 +135,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.labelNotificationsShowTypes.Location = new System.Drawing.Point(6, 25);
             this.labelNotificationsShowTypes.Name = "labelNotificationsShowTypes";
             this.labelNotificationsShowTypes.Size = new System.Drawing.Size(139, 13);
-            this.labelNotificationsShowTypes.TabIndex = 29;
+            this.labelNotificationsShowTypes.TabIndex = 0;
             this.labelNotificationsShowTypes.Text = "Show these message types:";
             // 
             // chkShowErrorInMC
@@ -145,7 +145,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkShowErrorInMC.Location = new System.Drawing.Point(20, 113);
             this.chkShowErrorInMC.Name = "chkShowErrorInMC";
             this.chkShowErrorInMC.Size = new System.Drawing.Size(48, 17);
-            this.chkShowErrorInMC.TabIndex = 32;
+            this.chkShowErrorInMC.TabIndex = 4;
             this.chkShowErrorInMC.Text = "Error";
             this.chkShowErrorInMC.UseVisualStyleBackColor = true;
             // 
@@ -156,7 +156,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkShowWarningInMC.Location = new System.Drawing.Point(20, 90);
             this.chkShowWarningInMC.Name = "chkShowWarningInMC";
             this.chkShowWarningInMC.Size = new System.Drawing.Size(66, 17);
-            this.chkShowWarningInMC.TabIndex = 31;
+            this.chkShowWarningInMC.TabIndex = 3;
             this.chkShowWarningInMC.Text = "Warning";
             this.chkShowWarningInMC.UseVisualStyleBackColor = true;
             // 
@@ -167,7 +167,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkShowInfoInMC.Location = new System.Drawing.Point(20, 67);
             this.chkShowInfoInMC.Name = "chkShowInfoInMC";
             this.chkShowInfoInMC.Size = new System.Drawing.Size(78, 17);
-            this.chkShowInfoInMC.TabIndex = 30;
+            this.chkShowInfoInMC.TabIndex = 2;
             this.chkShowInfoInMC.Text = "Information";
             this.chkShowInfoInMC.UseVisualStyleBackColor = true;
             // 
@@ -178,7 +178,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkShowDebugInMC.Location = new System.Drawing.Point(20, 44);
             this.chkShowDebugInMC.Name = "chkShowDebugInMC";
             this.chkShowDebugInMC.Size = new System.Drawing.Size(58, 17);
-            this.chkShowDebugInMC.TabIndex = 29;
+            this.chkShowDebugInMC.TabIndex = 1;
             this.chkShowDebugInMC.Text = "Debug";
             this.chkShowDebugInMC.UseVisualStyleBackColor = true;
             // 
@@ -195,7 +195,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.groupBoxLogging.Location = new System.Drawing.Point(6, 149);
             this.groupBoxLogging.Name = "groupBoxLogging";
             this.groupBoxLogging.Size = new System.Drawing.Size(601, 158);
-            this.groupBoxLogging.TabIndex = 29;
+            this.groupBoxLogging.TabIndex = 1;
             this.groupBoxLogging.TabStop = false;
             this.groupBoxLogging.Text = "Logging";
             // 
@@ -216,7 +216,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.tblLogging.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tblLogging.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
             this.tblLogging.Size = new System.Drawing.Size(585, 25);
-            this.tblLogging.TabIndex = 31;
+            this.tblLogging.TabIndex = 7;
             // 
             // chkLogDebugMsgs
             // 
@@ -225,7 +225,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkLogDebugMsgs.Location = new System.Drawing.Point(3, 3);
             this.chkLogDebugMsgs.Name = "chkLogDebugMsgs";
             this.chkLogDebugMsgs.Size = new System.Drawing.Size(58, 17);
-            this.chkLogDebugMsgs.TabIndex = 35;
+            this.chkLogDebugMsgs.TabIndex = 0;
             this.chkLogDebugMsgs.Text = "Debug";
             this.chkLogDebugMsgs.UseVisualStyleBackColor = true;
             // 
@@ -236,7 +236,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkLogInfoMsgs.Location = new System.Drawing.Point(149, 3);
             this.chkLogInfoMsgs.Name = "chkLogInfoMsgs";
             this.chkLogInfoMsgs.Size = new System.Drawing.Size(78, 17);
-            this.chkLogInfoMsgs.TabIndex = 36;
+            this.chkLogInfoMsgs.TabIndex = 1;
             this.chkLogInfoMsgs.Text = "Information";
             this.chkLogInfoMsgs.UseVisualStyleBackColor = true;
             // 
@@ -247,7 +247,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkLogWarningMsgs.Location = new System.Drawing.Point(295, 3);
             this.chkLogWarningMsgs.Name = "chkLogWarningMsgs";
             this.chkLogWarningMsgs.Size = new System.Drawing.Size(66, 17);
-            this.chkLogWarningMsgs.TabIndex = 37;
+            this.chkLogWarningMsgs.TabIndex = 2;
             this.chkLogWarningMsgs.Text = "Warning";
             this.chkLogWarningMsgs.UseVisualStyleBackColor = true;
             // 
@@ -258,7 +258,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkLogErrorMsgs.Location = new System.Drawing.Point(441, 3);
             this.chkLogErrorMsgs.Name = "chkLogErrorMsgs";
             this.chkLogErrorMsgs.Size = new System.Drawing.Size(48, 17);
-            this.chkLogErrorMsgs.TabIndex = 38;
+            this.chkLogErrorMsgs.TabIndex = 3;
             this.chkLogErrorMsgs.Text = "Error";
             this.chkLogErrorMsgs.UseVisualStyleBackColor = true;
             // 
@@ -269,7 +269,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkLogToCurrentDir.Location = new System.Drawing.Point(9, 18);
             this.chkLogToCurrentDir.Name = "chkLogToCurrentDir";
             this.chkLogToCurrentDir.Size = new System.Drawing.Size(153, 17);
-            this.chkLogToCurrentDir.TabIndex = 40;
+            this.chkLogToCurrentDir.TabIndex = 0;
             this.chkLogToCurrentDir.Text = "Log to application directory";
             this.chkLogToCurrentDir.UseVisualStyleBackColor = true;
             this.chkLogToCurrentDir.CheckedChanged += new System.EventHandler(this.chkLogToCurrentDir_CheckedChanged);
@@ -280,7 +280,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.buttonRestoreDefaultLogPath.Location = new System.Drawing.Point(495, 83);
             this.buttonRestoreDefaultLogPath.Name = "buttonRestoreDefaultLogPath";
             this.buttonRestoreDefaultLogPath.Size = new System.Drawing.Size(99, 23);
-            this.buttonRestoreDefaultLogPath.TabIndex = 39;
+            this.buttonRestoreDefaultLogPath.TabIndex = 5;
             this.buttonRestoreDefaultLogPath.Text = "Use Default";
             this.buttonRestoreDefaultLogPath.UseVisualStyleBackColor = true;
             this.buttonRestoreDefaultLogPath.Click += new System.EventHandler(this.buttonRestoreDefaultLogPath_Click);
@@ -291,7 +291,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.buttonOpenLogFile.Location = new System.Drawing.Point(273, 82);
             this.buttonOpenLogFile.Name = "buttonOpenLogFile";
             this.buttonOpenLogFile.Size = new System.Drawing.Size(105, 23);
-            this.buttonOpenLogFile.TabIndex = 30;
+            this.buttonOpenLogFile.TabIndex = 3;
             this.buttonOpenLogFile.Text = "Open File";
             this.buttonOpenLogFile.UseVisualStyleBackColor = true;
             this.buttonOpenLogFile.Click += new System.EventHandler(this.buttonOpenLogFile_Click);
@@ -302,7 +302,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.buttonSelectLogPath.Location = new System.Drawing.Point(384, 82);
             this.buttonSelectLogPath.Name = "buttonSelectLogPath";
             this.buttonSelectLogPath.Size = new System.Drawing.Size(105, 23);
-            this.buttonSelectLogPath.TabIndex = 30;
+            this.buttonSelectLogPath.TabIndex = 4;
             this.buttonSelectLogPath.Text = "Choose Path";
             this.buttonSelectLogPath.UseVisualStyleBackColor = true;
             this.buttonSelectLogPath.Click += new System.EventHandler(this.buttonSelectLogPath_Click);
@@ -313,7 +313,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.labelLogTheseMsgTypes.Location = new System.Drawing.Point(6, 108);
             this.labelLogTheseMsgTypes.Name = "labelLogTheseMsgTypes";
             this.labelLogTheseMsgTypes.Size = new System.Drawing.Size(130, 13);
-            this.labelLogTheseMsgTypes.TabIndex = 34;
+            this.labelLogTheseMsgTypes.TabIndex = 6;
             this.labelLogTheseMsgTypes.Text = "Log these message types:";
             // 
             // labelLogFilePath
@@ -322,7 +322,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.labelLogFilePath.Location = new System.Drawing.Point(6, 38);
             this.labelLogFilePath.Name = "labelLogFilePath";
             this.labelLogFilePath.Size = new System.Drawing.Size(68, 13);
-            this.labelLogFilePath.TabIndex = 30;
+            this.labelLogFilePath.TabIndex = 1;
             this.labelLogFilePath.Text = "Log file path:";
             // 
             // textBoxLogPath
@@ -332,16 +332,16 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.textBoxLogPath.Name = "textBoxLogPath";
             this.textBoxLogPath.ReadOnly = true;
             this.textBoxLogPath.Size = new System.Drawing.Size(585, 20);
-            this.textBoxLogPath.TabIndex = 0;
+            this.textBoxLogPath.TabIndex = 2;
             // 
             // groupBoxPopups
             // 
             this.groupBoxPopups.Controls.Add(this.tblPopups);
             this.groupBoxPopups.Controls.Add(this.labelPopupShowTypes);
-            this.groupBoxPopups.Location = new System.Drawing.Point(4, 313);
+            this.groupBoxPopups.Location = new System.Drawing.Point(6, 313);
             this.groupBoxPopups.Name = "groupBoxPopups";
-            this.groupBoxPopups.Size = new System.Drawing.Size(603, 74);
-            this.groupBoxPopups.TabIndex = 30;
+            this.groupBoxPopups.Size = new System.Drawing.Size(601, 74);
+            this.groupBoxPopups.TabIndex = 2;
             this.groupBoxPopups.TabStop = false;
             this.groupBoxPopups.Text = "Pop-ups";
             // 
@@ -362,7 +362,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.tblPopups.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tblPopups.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
             this.tblPopups.Size = new System.Drawing.Size(585, 25);
-            this.tblPopups.TabIndex = 44;
+            this.tblPopups.TabIndex = 1;
             // 
             // chkPopupDebug
             // 
@@ -371,7 +371,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkPopupDebug.Location = new System.Drawing.Point(3, 3);
             this.chkPopupDebug.Name = "chkPopupDebug";
             this.chkPopupDebug.Size = new System.Drawing.Size(58, 17);
-            this.chkPopupDebug.TabIndex = 40;
+            this.chkPopupDebug.TabIndex = 0;
             this.chkPopupDebug.Text = "Debug";
             this.chkPopupDebug.UseVisualStyleBackColor = true;
             // 
@@ -382,7 +382,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkPopupError.Location = new System.Drawing.Point(441, 3);
             this.chkPopupError.Name = "chkPopupError";
             this.chkPopupError.Size = new System.Drawing.Size(48, 17);
-            this.chkPopupError.TabIndex = 43;
+            this.chkPopupError.TabIndex = 3;
             this.chkPopupError.Text = "Error";
             this.chkPopupError.UseVisualStyleBackColor = true;
             // 
@@ -393,7 +393,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkPopupInfo.Location = new System.Drawing.Point(149, 3);
             this.chkPopupInfo.Name = "chkPopupInfo";
             this.chkPopupInfo.Size = new System.Drawing.Size(78, 17);
-            this.chkPopupInfo.TabIndex = 41;
+            this.chkPopupInfo.TabIndex = 1;
             this.chkPopupInfo.Text = "Information";
             this.chkPopupInfo.UseVisualStyleBackColor = true;
             // 
@@ -404,7 +404,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkPopupWarning.Location = new System.Drawing.Point(295, 3);
             this.chkPopupWarning.Name = "chkPopupWarning";
             this.chkPopupWarning.Size = new System.Drawing.Size(66, 17);
-            this.chkPopupWarning.TabIndex = 42;
+            this.chkPopupWarning.TabIndex = 2;
             this.chkPopupWarning.Text = "Warning";
             this.chkPopupWarning.UseVisualStyleBackColor = true;
             // 
@@ -414,7 +414,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.labelPopupShowTypes.Location = new System.Drawing.Point(8, 24);
             this.labelPopupShowTypes.Name = "labelPopupShowTypes";
             this.labelPopupShowTypes.Size = new System.Drawing.Size(139, 13);
-            this.labelPopupShowTypes.TabIndex = 33;
+            this.labelPopupShowTypes.TabIndex = 0;
             this.labelPopupShowTypes.Text = "Show these message types:";
             // 
             // NotificationsPage

--- a/mRemoteV1/UI/Forms/OptionsPages/SecurityPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/SecurityPage.Designer.cs
@@ -48,7 +48,7 @@
             this.chkEncryptCompleteFile.Location = new System.Drawing.Point(3, 3);
             this.chkEncryptCompleteFile.Name = "chkEncryptCompleteFile";
             this.chkEncryptCompleteFile.Size = new System.Drawing.Size(180, 17);
-            this.chkEncryptCompleteFile.TabIndex = 19;
+            this.chkEncryptCompleteFile.TabIndex = 0;
             this.chkEncryptCompleteFile.Text = "Encrypt complete connection file";
             this.chkEncryptCompleteFile.UseVisualStyleBackColor = true;
             // 
@@ -61,7 +61,7 @@
             this.comboBoxEncryptionEngine.Name = "comboBoxEncryptionEngine";
             this.comboBoxEncryptionEngine.Size = new System.Drawing.Size(123, 21);
             this.comboBoxEncryptionEngine.Sorted = true;
-            this.comboBoxEncryptionEngine.TabIndex = 20;
+            this.comboBoxEncryptionEngine.TabIndex = 1;
             // 
             // labelEncryptionEngine
             // 
@@ -69,7 +69,7 @@
             this.labelEncryptionEngine.Location = new System.Drawing.Point(9, 28);
             this.labelEncryptionEngine.Name = "labelEncryptionEngine";
             this.labelEncryptionEngine.Size = new System.Drawing.Size(93, 13);
-            this.labelEncryptionEngine.TabIndex = 21;
+            this.labelEncryptionEngine.TabIndex = 0;
             this.labelEncryptionEngine.Text = "Encryption Engine";
             // 
             // labelBlockCipher
@@ -78,7 +78,7 @@
             this.labelBlockCipher.Location = new System.Drawing.Point(9, 60);
             this.labelBlockCipher.Name = "labelBlockCipher";
             this.labelBlockCipher.Size = new System.Drawing.Size(97, 13);
-            this.labelBlockCipher.TabIndex = 22;
+            this.labelBlockCipher.TabIndex = 2;
             this.labelBlockCipher.Text = "Block Cipher Mode";
             // 
             // comboBoxBlockCipher
@@ -89,7 +89,7 @@
             this.comboBoxBlockCipher.Location = new System.Drawing.Point(191, 57);
             this.comboBoxBlockCipher.Name = "comboBoxBlockCipher";
             this.comboBoxBlockCipher.Size = new System.Drawing.Size(123, 21);
-            this.comboBoxBlockCipher.TabIndex = 23;
+            this.comboBoxBlockCipher.TabIndex = 3;
             // 
             // groupAdvancedSecurityOptions
             // 
@@ -102,7 +102,7 @@
             this.groupAdvancedSecurityOptions.Location = new System.Drawing.Point(3, 30);
             this.groupAdvancedSecurityOptions.Name = "groupAdvancedSecurityOptions";
             this.groupAdvancedSecurityOptions.Size = new System.Drawing.Size(604, 128);
-            this.groupAdvancedSecurityOptions.TabIndex = 24;
+            this.groupAdvancedSecurityOptions.TabIndex = 1;
             this.groupAdvancedSecurityOptions.TabStop = false;
             this.groupAdvancedSecurityOptions.Text = "Advanced Security Options";
             // 
@@ -126,7 +126,7 @@
             0});
             this.numberBoxKdfIterations.Name = "numberBoxKdfIterations";
             this.numberBoxKdfIterations.Size = new System.Drawing.Size(90, 20);
-            this.numberBoxKdfIterations.TabIndex = 25;
+            this.numberBoxKdfIterations.TabIndex = 5;
             this.numberBoxKdfIterations.ThousandsSeparator = true;
             this.numberBoxKdfIterations.Value = new decimal(new int[] {
             1000,
@@ -140,7 +140,7 @@
             this.labelKdfIterations.Location = new System.Drawing.Point(9, 90);
             this.labelKdfIterations.Name = "labelKdfIterations";
             this.labelKdfIterations.Size = new System.Drawing.Size(166, 13);
-            this.labelKdfIterations.TabIndex = 24;
+            this.labelKdfIterations.TabIndex = 4;
             this.labelKdfIterations.Text = "Key Derivation Function Iterations";
             // 
             // SecurityPage

--- a/mRemoteV1/UI/Forms/OptionsPages/SqlServerPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/SqlServerPage.Designer.cs
@@ -30,157 +30,158 @@ namespace mRemoteNG.UI.Forms.OptionsPages
 		//Do not modify it using the code editor.
 		[System.Diagnostics.DebuggerStepThrough()]private void InitializeComponent()
 		{
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SqlServerPage));
-			this.lblSQLDatabaseName = new Controls.Base.NGLabel();
-			this.txtSQLDatabaseName = new Controls.Base.NGTextBox();
-			this.lblExperimental = new Controls.Base.NGLabel();
-			this.chkUseSQLServer = new Controls.Base.NGCheckBox();
-			this.chkUseSQLServer.CheckedChanged += new System.EventHandler(this.chkUseSQLServer_CheckedChanged);
-			this.lblSQLUsername = new Controls.Base.NGLabel();
-			this.txtSQLPassword = new Controls.Base.NGTextBox();
-			this.lblSQLInfo = new Controls.Base.NGLabel();
-			this.lblSQLServer = new Controls.Base.NGLabel();
-			this.txtSQLUsername = new Controls.Base.NGTextBox();
-			this.txtSQLServer = new Controls.Base.NGTextBox();
-			this.lblSQLPassword = new Controls.Base.NGLabel();
-			this.SuspendLayout();
-			//
-			//lblSQLDatabaseName
-			//
-			this.lblSQLDatabaseName.Enabled = false;
-			this.lblSQLDatabaseName.Location = new System.Drawing.Point(23, 132);
-			this.lblSQLDatabaseName.Name = "lblSQLDatabaseName";
-			this.lblSQLDatabaseName.Size = new System.Drawing.Size(111, 13);
-			this.lblSQLDatabaseName.TabIndex = 16;
-			this.lblSQLDatabaseName.Text = "Database:";
-			this.lblSQLDatabaseName.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			//
-			//txtSQLDatabaseName
-			//
-			this.txtSQLDatabaseName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtSQLDatabaseName.Enabled = false;
-			this.txtSQLDatabaseName.Location = new System.Drawing.Point(140, 130);
-			this.txtSQLDatabaseName.Name = "txtSQLDatabaseName";
-			this.txtSQLDatabaseName.Size = new System.Drawing.Size(153, 20);
-			this.txtSQLDatabaseName.TabIndex = 17;
-			//
-			//lblExperimental
-			//
-			this.lblExperimental.Anchor = (System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-				| System.Windows.Forms.AnchorStyles.Left) 
-				| System.Windows.Forms.AnchorStyles.Right);
-			this.lblExperimental.Font = new System.Drawing.Font("Segoe UI", 12.0F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.World);
-			this.lblExperimental.ForeColor = System.Drawing.Color.FromArgb(System.Convert.ToInt32(System.Convert.ToByte(192)), System.Convert.ToInt32(System.Convert.ToByte(0)), System.Convert.ToInt32(System.Convert.ToByte(0)));
-			this.lblExperimental.Location = new System.Drawing.Point(3, 0);
-			this.lblExperimental.Name = "lblExperimental";
-			this.lblExperimental.Size = new System.Drawing.Size(596, 25);
-			this.lblExperimental.TabIndex = 11;
-			this.lblExperimental.Text = "EXPERIMENTAL";
-			this.lblExperimental.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			//
-			//chkUseSQLServer
-			//
-			this.chkUseSQLServer.AutoSize = true;
-			this.chkUseSQLServer.Location = new System.Drawing.Point(3, 76);
-			this.chkUseSQLServer.Name = "chkUseSQLServer";
-			this.chkUseSQLServer.Size = new System.Drawing.Size(234, 17);
-			this.chkUseSQLServer.TabIndex = 13;
-			this.chkUseSQLServer.Text = "Use SQL Server to load && save connections";
-			this.chkUseSQLServer.UseVisualStyleBackColor = true;
-			//
-			//lblSQLUsername
-			//
-			this.lblSQLUsername.Enabled = false;
-			this.lblSQLUsername.Location = new System.Drawing.Point(23, 158);
-			this.lblSQLUsername.Name = "lblSQLUsername";
-			this.lblSQLUsername.Size = new System.Drawing.Size(111, 13);
-			this.lblSQLUsername.TabIndex = 18;
-			this.lblSQLUsername.Text = "Username:";
-			this.lblSQLUsername.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			//
-			//txtSQLPassword
-			//
-			this.txtSQLPassword.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtSQLPassword.Enabled = false;
-			this.txtSQLPassword.Location = new System.Drawing.Point(140, 182);
-			this.txtSQLPassword.Name = "txtSQLPassword";
-			this.txtSQLPassword.Size = new System.Drawing.Size(153, 20);
-			this.txtSQLPassword.TabIndex = 21;
-			this.txtSQLPassword.UseSystemPasswordChar = true;
-			//
-			//lblSQLInfo
-			//
-			this.lblSQLInfo.Anchor = (System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-				| System.Windows.Forms.AnchorStyles.Left) 
-				| System.Windows.Forms.AnchorStyles.Right);
-			this.lblSQLInfo.Font = new System.Drawing.Font("Segoe UI", 12.0F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.World);
-			this.lblSQLInfo.ForeColor = System.Drawing.Color.FromArgb(System.Convert.ToInt32(System.Convert.ToByte(192)), System.Convert.ToInt32(System.Convert.ToByte(0)), System.Convert.ToInt32(System.Convert.ToByte(0)));
-			this.lblSQLInfo.Location = new System.Drawing.Point(3, 25);
-			this.lblSQLInfo.Name = "lblSQLInfo";
-			this.lblSQLInfo.Size = new System.Drawing.Size(596, 25);
-			this.lblSQLInfo.TabIndex = 12;
-			this.lblSQLInfo.Text = "Please see Help - Getting started - SQL Configuration for more Info!";
-			this.lblSQLInfo.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			//
-			//lblSQLServer
-			//
-			this.lblSQLServer.Enabled = false;
-			this.lblSQLServer.Location = new System.Drawing.Point(23, 106);
-			this.lblSQLServer.Name = "lblSQLServer";
-			this.lblSQLServer.Size = new System.Drawing.Size(111, 13);
-			this.lblSQLServer.TabIndex = 14;
-			this.lblSQLServer.Text = "SQL Server:";
-			this.lblSQLServer.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			//
-			//txtSQLUsername
-			//
-			this.txtSQLUsername.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtSQLUsername.Enabled = false;
-			this.txtSQLUsername.Location = new System.Drawing.Point(140, 156);
-			this.txtSQLUsername.Name = "txtSQLUsername";
-			this.txtSQLUsername.Size = new System.Drawing.Size(153, 20);
-			this.txtSQLUsername.TabIndex = 19;
-			//
-			//txtSQLServer
-			//
-			this.txtSQLServer.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-			this.txtSQLServer.Enabled = false;
-			this.txtSQLServer.Location = new System.Drawing.Point(140, 103);
-			this.txtSQLServer.Name = "txtSQLServer";
-			this.txtSQLServer.Size = new System.Drawing.Size(153, 20);
-			this.txtSQLServer.TabIndex = 15;
-			//
-			//lblSQLPassword
-			//
-			this.lblSQLPassword.Enabled = false;
-			this.lblSQLPassword.Location = new System.Drawing.Point(23, 184);
-			this.lblSQLPassword.Name = "lblSQLPassword";
-			this.lblSQLPassword.Size = new System.Drawing.Size(111, 13);
-			this.lblSQLPassword.TabIndex = 20;
-			this.lblSQLPassword.Text = "Password:";
-			this.lblSQLPassword.TextAlign = System.Drawing.ContentAlignment.TopRight;
-			//
-			//SqlServerPage
-			//
-			this.AutoScaleDimensions = new System.Drawing.SizeF((float) (6.0F), (float) (13.0F));
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this.lblSQLDatabaseName);
-			this.Controls.Add(this.txtSQLDatabaseName);
-			this.Controls.Add(this.lblExperimental);
-			this.Controls.Add(this.chkUseSQLServer);
-			this.Controls.Add(this.lblSQLUsername);
-			this.Controls.Add(this.txtSQLPassword);
-			this.Controls.Add(this.lblSQLInfo);
-			this.Controls.Add(this.lblSQLServer);
-			this.Controls.Add(this.txtSQLUsername);
-			this.Controls.Add(this.txtSQLServer);
-			this.Controls.Add(this.lblSQLPassword);
-			this.Name = "SqlServerPage";
-			this.PageIcon = (System.Drawing.Icon) (resources.GetObject("$this.PageIcon"));
-			this.Size = new System.Drawing.Size(610, 489);
-			this.ResumeLayout(false);
-			this.PerformLayout();
-				
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SqlServerPage));
+            this.lblSQLDatabaseName = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.txtSQLDatabaseName = new mRemoteNG.UI.Controls.Base.NGTextBox();
+            this.lblExperimental = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.chkUseSQLServer = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.lblSQLUsername = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.txtSQLPassword = new mRemoteNG.UI.Controls.Base.NGTextBox();
+            this.lblSQLInfo = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.lblSQLServer = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.txtSQLUsername = new mRemoteNG.UI.Controls.Base.NGTextBox();
+            this.txtSQLServer = new mRemoteNG.UI.Controls.Base.NGTextBox();
+            this.lblSQLPassword = new mRemoteNG.UI.Controls.Base.NGLabel();
+            this.SuspendLayout();
+            // 
+            // lblSQLDatabaseName
+            // 
+            this.lblSQLDatabaseName.Enabled = false;
+            this.lblSQLDatabaseName.Location = new System.Drawing.Point(23, 132);
+            this.lblSQLDatabaseName.Name = "lblSQLDatabaseName";
+            this.lblSQLDatabaseName.Size = new System.Drawing.Size(111, 13);
+            this.lblSQLDatabaseName.TabIndex = 5;
+            this.lblSQLDatabaseName.Text = "Database:";
+            this.lblSQLDatabaseName.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // txtSQLDatabaseName
+            // 
+            this.txtSQLDatabaseName.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtSQLDatabaseName.Enabled = false;
+            this.txtSQLDatabaseName.Location = new System.Drawing.Point(140, 130);
+            this.txtSQLDatabaseName.Name = "txtSQLDatabaseName";
+            this.txtSQLDatabaseName.Size = new System.Drawing.Size(153, 20);
+            this.txtSQLDatabaseName.TabIndex = 6;
+            // 
+            // lblExperimental
+            // 
+            this.lblExperimental.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblExperimental.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.World);
+            this.lblExperimental.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.lblExperimental.Location = new System.Drawing.Point(3, 0);
+            this.lblExperimental.Name = "lblExperimental";
+            this.lblExperimental.Size = new System.Drawing.Size(596, 25);
+            this.lblExperimental.TabIndex = 0;
+            this.lblExperimental.Text = "EXPERIMENTAL";
+            this.lblExperimental.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // chkUseSQLServer
+            // 
+            this.chkUseSQLServer._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkUseSQLServer.AutoSize = true;
+            this.chkUseSQLServer.Location = new System.Drawing.Point(3, 76);
+            this.chkUseSQLServer.Name = "chkUseSQLServer";
+            this.chkUseSQLServer.Size = new System.Drawing.Size(234, 17);
+            this.chkUseSQLServer.TabIndex = 2;
+            this.chkUseSQLServer.Text = "Use SQL Server to load && save connections";
+            this.chkUseSQLServer.UseVisualStyleBackColor = true;
+            this.chkUseSQLServer.CheckedChanged += new System.EventHandler(this.chkUseSQLServer_CheckedChanged);
+            // 
+            // lblSQLUsername
+            // 
+            this.lblSQLUsername.Enabled = false;
+            this.lblSQLUsername.Location = new System.Drawing.Point(23, 158);
+            this.lblSQLUsername.Name = "lblSQLUsername";
+            this.lblSQLUsername.Size = new System.Drawing.Size(111, 13);
+            this.lblSQLUsername.TabIndex = 7;
+            this.lblSQLUsername.Text = "Username:";
+            this.lblSQLUsername.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // txtSQLPassword
+            // 
+            this.txtSQLPassword.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtSQLPassword.Enabled = false;
+            this.txtSQLPassword.Location = new System.Drawing.Point(140, 182);
+            this.txtSQLPassword.Name = "txtSQLPassword";
+            this.txtSQLPassword.Size = new System.Drawing.Size(153, 20);
+            this.txtSQLPassword.TabIndex = 10;
+            this.txtSQLPassword.UseSystemPasswordChar = true;
+            // 
+            // lblSQLInfo
+            // 
+            this.lblSQLInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblSQLInfo.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.World);
+            this.lblSQLInfo.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.lblSQLInfo.Location = new System.Drawing.Point(3, 25);
+            this.lblSQLInfo.Name = "lblSQLInfo";
+            this.lblSQLInfo.Size = new System.Drawing.Size(596, 25);
+            this.lblSQLInfo.TabIndex = 1;
+            this.lblSQLInfo.Text = "Please see Help - Getting started - SQL Configuration for more Info!";
+            this.lblSQLInfo.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // lblSQLServer
+            // 
+            this.lblSQLServer.Enabled = false;
+            this.lblSQLServer.Location = new System.Drawing.Point(23, 106);
+            this.lblSQLServer.Name = "lblSQLServer";
+            this.lblSQLServer.Size = new System.Drawing.Size(111, 13);
+            this.lblSQLServer.TabIndex = 3;
+            this.lblSQLServer.Text = "SQL Server:";
+            this.lblSQLServer.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // txtSQLUsername
+            // 
+            this.txtSQLUsername.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtSQLUsername.Enabled = false;
+            this.txtSQLUsername.Location = new System.Drawing.Point(140, 156);
+            this.txtSQLUsername.Name = "txtSQLUsername";
+            this.txtSQLUsername.Size = new System.Drawing.Size(153, 20);
+            this.txtSQLUsername.TabIndex = 8;
+            // 
+            // txtSQLServer
+            // 
+            this.txtSQLServer.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtSQLServer.Enabled = false;
+            this.txtSQLServer.Location = new System.Drawing.Point(140, 103);
+            this.txtSQLServer.Name = "txtSQLServer";
+            this.txtSQLServer.Size = new System.Drawing.Size(153, 20);
+            this.txtSQLServer.TabIndex = 4;
+            // 
+            // lblSQLPassword
+            // 
+            this.lblSQLPassword.Enabled = false;
+            this.lblSQLPassword.Location = new System.Drawing.Point(23, 184);
+            this.lblSQLPassword.Name = "lblSQLPassword";
+            this.lblSQLPassword.Size = new System.Drawing.Size(111, 13);
+            this.lblSQLPassword.TabIndex = 9;
+            this.lblSQLPassword.Text = "Password:";
+            this.lblSQLPassword.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // SqlServerPage
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.lblSQLDatabaseName);
+            this.Controls.Add(this.txtSQLDatabaseName);
+            this.Controls.Add(this.lblExperimental);
+            this.Controls.Add(this.chkUseSQLServer);
+            this.Controls.Add(this.lblSQLUsername);
+            this.Controls.Add(this.txtSQLPassword);
+            this.Controls.Add(this.lblSQLInfo);
+            this.Controls.Add(this.lblSQLServer);
+            this.Controls.Add(this.txtSQLUsername);
+            this.Controls.Add(this.txtSQLServer);
+            this.Controls.Add(this.lblSQLPassword);
+            this.Name = "SqlServerPage";
+            this.PageIcon = ((System.Drawing.Icon)(resources.GetObject("$this.PageIcon")));
+            this.Size = new System.Drawing.Size(610, 489);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
 		}
 		internal Controls.Base.NGLabel lblSQLDatabaseName;
 		internal Controls.Base.NGTextBox txtSQLDatabaseName;

--- a/mRemoteV1/UI/Forms/OptionsPages/SqlServerPage.resx
+++ b/mRemoteV1/UI/Forms/OptionsPages/SqlServerPage.resx
@@ -112,12 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.PageIcon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA

--- a/mRemoteV1/UI/Forms/OptionsPages/StartupExitPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/StartupExitPage.Designer.cs
@@ -44,7 +44,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkReconnectOnStart.Location = new System.Drawing.Point(3, 26);
             this.chkReconnectOnStart.Name = "chkReconnectOnStart";
             this.chkReconnectOnStart.Size = new System.Drawing.Size(273, 17);
-            this.chkReconnectOnStart.TabIndex = 7;
+            this.chkReconnectOnStart.TabIndex = 1;
             this.chkReconnectOnStart.Text = "Reconnect to previously opened sessions on startup";
             this.chkReconnectOnStart.UseVisualStyleBackColor = true;
             // 
@@ -55,7 +55,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkSaveConsOnExit.Location = new System.Drawing.Point(3, 2);
             this.chkSaveConsOnExit.Name = "chkSaveConsOnExit";
             this.chkSaveConsOnExit.Size = new System.Drawing.Size(146, 17);
-            this.chkSaveConsOnExit.TabIndex = 6;
+            this.chkSaveConsOnExit.TabIndex = 0;
             this.chkSaveConsOnExit.Text = "Save connections on exit";
             this.chkSaveConsOnExit.UseVisualStyleBackColor = true;
             // 
@@ -66,7 +66,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkSingleInstance.Location = new System.Drawing.Point(3, 50);
             this.chkSingleInstance.Name = "chkSingleInstance";
             this.chkSingleInstance.Size = new System.Drawing.Size(366, 17);
-            this.chkSingleInstance.TabIndex = 8;
+            this.chkSingleInstance.TabIndex = 2;
             this.chkSingleInstance.Text = "Allow only a single instance of the application (mRemote restart required)";
             this.chkSingleInstance.UseVisualStyleBackColor = true;
             // 
@@ -77,7 +77,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkProperInstallationOfComponentsAtStartup.Location = new System.Drawing.Point(3, 74);
             this.chkProperInstallationOfComponentsAtStartup.Name = "chkProperInstallationOfComponentsAtStartup";
             this.chkProperInstallationOfComponentsAtStartup.Size = new System.Drawing.Size(262, 17);
-            this.chkProperInstallationOfComponentsAtStartup.TabIndex = 9;
+            this.chkProperInstallationOfComponentsAtStartup.TabIndex = 3;
             this.chkProperInstallationOfComponentsAtStartup.Text = "Check proper installation of components at startup";
             this.chkProperInstallationOfComponentsAtStartup.UseVisualStyleBackColor = true;
             // 

--- a/mRemoteV1/UI/Forms/OptionsPages/TabsPanelsPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/TabsPanelsPage.Designer.cs
@@ -47,7 +47,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkAlwaysShowPanelTabs.Location = new System.Drawing.Point(3, 3);
             this.chkAlwaysShowPanelTabs.Name = "chkAlwaysShowPanelTabs";
             this.chkAlwaysShowPanelTabs.Size = new System.Drawing.Size(139, 17);
-            this.chkAlwaysShowPanelTabs.TabIndex = 12;
+            this.chkAlwaysShowPanelTabs.TabIndex = 0;
             this.chkAlwaysShowPanelTabs.Text = "Always show panel tabs";
             this.chkAlwaysShowPanelTabs.UseVisualStyleBackColor = true;
             // 
@@ -58,7 +58,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkIdentifyQuickConnectTabs.Location = new System.Drawing.Point(3, 95);
             this.chkIdentifyQuickConnectTabs.Name = "chkIdentifyQuickConnectTabs";
             this.chkIdentifyQuickConnectTabs.Size = new System.Drawing.Size(293, 17);
-            this.chkIdentifyQuickConnectTabs.TabIndex = 16;
+            this.chkIdentifyQuickConnectTabs.TabIndex = 4;
             this.chkIdentifyQuickConnectTabs.Text = global::mRemoteNG.Language.strIdentifyQuickConnectTabs;
             this.chkIdentifyQuickConnectTabs.UseVisualStyleBackColor = true;
             // 
@@ -69,7 +69,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkOpenNewTabRightOfSelected.Location = new System.Drawing.Point(3, 26);
             this.chkOpenNewTabRightOfSelected.Name = "chkOpenNewTabRightOfSelected";
             this.chkOpenNewTabRightOfSelected.Size = new System.Drawing.Size(280, 17);
-            this.chkOpenNewTabRightOfSelected.TabIndex = 13;
+            this.chkOpenNewTabRightOfSelected.TabIndex = 1;
             this.chkOpenNewTabRightOfSelected.Text = "Open new tab to the right of the currently selected tab";
             this.chkOpenNewTabRightOfSelected.UseVisualStyleBackColor = true;
             // 
@@ -80,7 +80,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkAlwaysShowPanelSelectionDlg.Location = new System.Drawing.Point(3, 141);
             this.chkAlwaysShowPanelSelectionDlg.Name = "chkAlwaysShowPanelSelectionDlg";
             this.chkAlwaysShowPanelSelectionDlg.Size = new System.Drawing.Size(317, 17);
-            this.chkAlwaysShowPanelSelectionDlg.TabIndex = 18;
+            this.chkAlwaysShowPanelSelectionDlg.TabIndex = 6;
             this.chkAlwaysShowPanelSelectionDlg.Text = "Always show panel selection dialog when opening connectins";
             this.chkAlwaysShowPanelSelectionDlg.UseVisualStyleBackColor = true;
             // 
@@ -91,7 +91,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkShowLogonInfoOnTabs.Location = new System.Drawing.Point(3, 49);
             this.chkShowLogonInfoOnTabs.Name = "chkShowLogonInfoOnTabs";
             this.chkShowLogonInfoOnTabs.Size = new System.Drawing.Size(203, 17);
-            this.chkShowLogonInfoOnTabs.TabIndex = 14;
+            this.chkShowLogonInfoOnTabs.TabIndex = 2;
             this.chkShowLogonInfoOnTabs.Text = "Show logon information on tab names";
             this.chkShowLogonInfoOnTabs.UseVisualStyleBackColor = true;
             // 
@@ -102,7 +102,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkDoubleClickClosesTab.Location = new System.Drawing.Point(3, 118);
             this.chkDoubleClickClosesTab.Name = "chkDoubleClickClosesTab";
             this.chkDoubleClickClosesTab.Size = new System.Drawing.Size(159, 17);
-            this.chkDoubleClickClosesTab.TabIndex = 17;
+            this.chkDoubleClickClosesTab.TabIndex = 5;
             this.chkDoubleClickClosesTab.Text = "Double click on tab closes it";
             this.chkDoubleClickClosesTab.UseVisualStyleBackColor = true;
             // 
@@ -113,7 +113,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkShowProtocolOnTabs.Location = new System.Drawing.Point(3, 72);
             this.chkShowProtocolOnTabs.Name = "chkShowProtocolOnTabs";
             this.chkShowProtocolOnTabs.Size = new System.Drawing.Size(166, 17);
-            this.chkShowProtocolOnTabs.TabIndex = 15;
+            this.chkShowProtocolOnTabs.TabIndex = 3;
             this.chkShowProtocolOnTabs.Text = "Show protocols on tab names";
             this.chkShowProtocolOnTabs.UseVisualStyleBackColor = true;
             // 

--- a/mRemoteV1/UI/Forms/OptionsPages/ThemePage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/ThemePage.Designer.cs
@@ -49,7 +49,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.btnThemeDelete.Location = new System.Drawing.Point(535, 1);
             this.btnThemeDelete.Name = "btnThemeDelete";
             this.btnThemeDelete.Size = new System.Drawing.Size(75, 23);
-            this.btnThemeDelete.TabIndex = 6;
+            this.btnThemeDelete.TabIndex = 2;
             this.btnThemeDelete.Text = "&Delete";
             this.btnThemeDelete.UseVisualStyleBackColor = true;
             this.btnThemeDelete.Click += new System.EventHandler(this.btnThemeDelete_Click);
@@ -60,7 +60,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.btnThemeNew.Location = new System.Drawing.Point(454, 1);
             this.btnThemeNew.Name = "btnThemeNew";
             this.btnThemeNew.Size = new System.Drawing.Size(75, 23);
-            this.btnThemeNew.TabIndex = 5;
+            this.btnThemeNew.TabIndex = 1;
             this.btnThemeNew.Text = "&New";
             this.btnThemeNew.UseVisualStyleBackColor = true;
             this.btnThemeNew.Click += new System.EventHandler(this.btnThemeNew_Click);
@@ -73,7 +73,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.cboTheme.Location = new System.Drawing.Point(3, 2);
             this.cboTheme.Name = "cboTheme";
             this.cboTheme.Size = new System.Drawing.Size(445, 21);
-            this.cboTheme.TabIndex = 4;
+            this.cboTheme.TabIndex = 0;
             this.cboTheme.SelectionChangeCommitted += new System.EventHandler(this.cboTheme_SelectionChangeCommitted);
             // 
             // themeEnableCombo
@@ -83,7 +83,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.themeEnableCombo.Location = new System.Drawing.Point(487, 457);
             this.themeEnableCombo.Name = "themeEnableCombo";
             this.themeEnableCombo.Size = new System.Drawing.Size(100, 17);
-            this.themeEnableCombo.TabIndex = 8;
+            this.themeEnableCombo.TabIndex = 5;
             this.themeEnableCombo.Text = "Enable Themes";
             this.themeEnableCombo.UseVisualStyleBackColor = true;
             this.themeEnableCombo.CheckedChanged += new System.EventHandler(this.themeEnableCombo_CheckedChanged);
@@ -104,7 +104,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.listPalette.Name = "listPalette";
             this.listPalette.ShowGroups = false;
             this.listPalette.Size = new System.Drawing.Size(604, 413);
-            this.listPalette.TabIndex = 9;
+            this.listPalette.TabIndex = 3;
             this.listPalette.UseCellFormatEvents = true;
             this.listPalette.UseCompatibleStateImageBehavior = false;
             this.listPalette.View = System.Windows.Forms.View.Details;
@@ -135,7 +135,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.labelRestart.Location = new System.Drawing.Point(23, 457);
             this.labelRestart.Name = "labelRestart";
             this.labelRestart.Size = new System.Drawing.Size(399, 13);
-            this.labelRestart.TabIndex = 10;
+            this.labelRestart.TabIndex = 4;
             this.labelRestart.Text = "Warning: Restart is required to disable the themes or to completely apply a new o" +
     "ne";
             // 

--- a/mRemoteV1/UI/Forms/OptionsPages/UpdatesPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/UpdatesPage.Designer.cs
@@ -66,7 +66,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.lblUpdatesExplanation.Location = new System.Drawing.Point(3, 2);
             this.lblUpdatesExplanation.Name = "lblUpdatesExplanation";
             this.lblUpdatesExplanation.Size = new System.Drawing.Size(536, 32);
-            this.lblUpdatesExplanation.TabIndex = 3;
+            this.lblUpdatesExplanation.TabIndex = 0;
             this.lblUpdatesExplanation.Text = "mRemoteNG can periodically connect to the mRemoteNG website to check for updates." +
     "";
             // 
@@ -77,15 +77,15 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.pnlUpdateCheck.Controls.Add(this.cboUpdateCheckFrequency);
             this.pnlUpdateCheck.Location = new System.Drawing.Point(3, 38);
             this.pnlUpdateCheck.Name = "pnlUpdateCheck";
-            this.pnlUpdateCheck.Size = new System.Drawing.Size(604, 96);
-            this.pnlUpdateCheck.TabIndex = 4;
+            this.pnlUpdateCheck.Size = new System.Drawing.Size(604, 79);
+            this.pnlUpdateCheck.TabIndex = 1;
             // 
             // btnUpdateCheckNow
             // 
             this.btnUpdateCheckNow._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
-            this.btnUpdateCheckNow.Location = new System.Drawing.Point(3, 48);
+            this.btnUpdateCheckNow.Location = new System.Drawing.Point(3, 49);
             this.btnUpdateCheckNow.Name = "btnUpdateCheckNow";
-            this.btnUpdateCheckNow.Size = new System.Drawing.Size(120, 32);
+            this.btnUpdateCheckNow.Size = new System.Drawing.Size(120, 23);
             this.btnUpdateCheckNow.TabIndex = 2;
             this.btnUpdateCheckNow.Text = "Check Now";
             this.btnUpdateCheckNow.UseVisualStyleBackColor = true;
@@ -95,7 +95,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             this.chkCheckForUpdatesOnStartup._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkCheckForUpdatesOnStartup.AutoSize = true;
-            this.chkCheckForUpdatesOnStartup.Location = new System.Drawing.Point(3, 3);
+            this.chkCheckForUpdatesOnStartup.Location = new System.Drawing.Point(3, 4);
             this.chkCheckForUpdatesOnStartup.Name = "chkCheckForUpdatesOnStartup";
             this.chkCheckForUpdatesOnStartup.Size = new System.Drawing.Size(113, 17);
             this.chkCheckForUpdatesOnStartup.TabIndex = 0;
@@ -108,7 +108,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.cboUpdateCheckFrequency._mice = mRemoteNG.UI.Controls.Base.NGComboBox.MouseState.HOVER;
             this.cboUpdateCheckFrequency.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboUpdateCheckFrequency.FormattingEnabled = true;
-            this.cboUpdateCheckFrequency.Location = new System.Drawing.Point(3, 21);
+            this.cboUpdateCheckFrequency.Location = new System.Drawing.Point(3, 22);
             this.cboUpdateCheckFrequency.Name = "cboUpdateCheckFrequency";
             this.cboUpdateCheckFrequency.Size = new System.Drawing.Size(120, 21);
             this.cboUpdateCheckFrequency.TabIndex = 1;
@@ -117,12 +117,12 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             this.textBox1.BackColor = System.Drawing.SystemColors.Control;
             this.textBox1.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.textBox1.Location = new System.Drawing.Point(3, 42);
+            this.textBox1.Location = new System.Drawing.Point(3, 47);
             this.textBox1.Multiline = true;
             this.textBox1.Name = "textBox1";
             this.textBox1.ReadOnly = true;
             this.textBox1.Size = new System.Drawing.Size(366, 44);
-            this.textBox1.TabIndex = 5;
+            this.textBox1.TabIndex = 2;
             this.textBox1.Text = "Stable channel includes final releases only.\r\nBeta channel includes Betas & Relea" +
     "se Candidates.\r\nDevelopment Channel includes Alphas, Betas & Release Candidates." +
     "";
@@ -130,10 +130,11 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // lblReleaseChannel
             // 
             this.lblReleaseChannel.AutoSize = true;
-            this.lblReleaseChannel.Location = new System.Drawing.Point(0, -1);
+            this.lblReleaseChannel.Location = new System.Drawing.Point(0, 3);
+            this.lblReleaseChannel.Margin = new System.Windows.Forms.Padding(3);
             this.lblReleaseChannel.Name = "lblReleaseChannel";
             this.lblReleaseChannel.Size = new System.Drawing.Size(91, 13);
-            this.lblReleaseChannel.TabIndex = 4;
+            this.lblReleaseChannel.TabIndex = 0;
             this.lblReleaseChannel.Text = "Release Channel:";
             // 
             // cboReleaseChannel
@@ -141,10 +142,10 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.cboReleaseChannel._mice = mRemoteNG.UI.Controls.Base.NGComboBox.MouseState.HOVER;
             this.cboReleaseChannel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboReleaseChannel.FormattingEnabled = true;
-            this.cboReleaseChannel.Location = new System.Drawing.Point(3, 15);
+            this.cboReleaseChannel.Location = new System.Drawing.Point(3, 20);
             this.cboReleaseChannel.Name = "cboReleaseChannel";
             this.cboReleaseChannel.Size = new System.Drawing.Size(120, 21);
-            this.cboReleaseChannel.TabIndex = 3;
+            this.cboReleaseChannel.TabIndex = 1;
             // 
             // pnlProxy
             // 
@@ -153,10 +154,10 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.pnlProxy.Controls.Add(this.chkUseProxyAuthentication);
             this.pnlProxy.Controls.Add(this.pnlProxyAuthentication);
             this.pnlProxy.Controls.Add(this.btnTestProxy);
-            this.pnlProxy.Location = new System.Drawing.Point(0, 243);
+            this.pnlProxy.Location = new System.Drawing.Point(0, 226);
             this.pnlProxy.Name = "pnlProxy";
-            this.pnlProxy.Size = new System.Drawing.Size(610, 219);
-            this.pnlProxy.TabIndex = 5;
+            this.pnlProxy.Size = new System.Drawing.Size(610, 203);
+            this.pnlProxy.TabIndex = 3;
             // 
             // pnlProxyBasic
             // 
@@ -223,7 +224,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             this.chkUseProxyForAutomaticUpdates._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
             this.chkUseProxyForAutomaticUpdates.AutoSize = true;
-            this.chkUseProxyForAutomaticUpdates.Location = new System.Drawing.Point(3, 0);
+            this.chkUseProxyForAutomaticUpdates.Location = new System.Drawing.Point(6, 0);
             this.chkUseProxyForAutomaticUpdates.Name = "chkUseProxyForAutomaticUpdates";
             this.chkUseProxyForAutomaticUpdates.Size = new System.Drawing.Size(168, 17);
             this.chkUseProxyForAutomaticUpdates.TabIndex = 0;
@@ -296,7 +297,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.btnTestProxy._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
             this.btnTestProxy.Location = new System.Drawing.Point(6, 172);
             this.btnTestProxy.Name = "btnTestProxy";
-            this.btnTestProxy.Size = new System.Drawing.Size(120, 32);
+            this.btnTestProxy.Size = new System.Drawing.Size(120, 23);
             this.btnTestProxy.TabIndex = 4;
             this.btnTestProxy.Text = "Test Proxy";
             this.btnTestProxy.UseVisualStyleBackColor = true;
@@ -307,10 +308,10 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.pnlReleaseChannel.Controls.Add(this.textBox1);
             this.pnlReleaseChannel.Controls.Add(this.lblReleaseChannel);
             this.pnlReleaseChannel.Controls.Add(this.cboReleaseChannel);
-            this.pnlReleaseChannel.Location = new System.Drawing.Point(3, 140);
+            this.pnlReleaseChannel.Location = new System.Drawing.Point(3, 123);
             this.pnlReleaseChannel.Name = "pnlReleaseChannel";
             this.pnlReleaseChannel.Size = new System.Drawing.Size(604, 97);
-            this.pnlReleaseChannel.TabIndex = 6;
+            this.pnlReleaseChannel.TabIndex = 2;
             // 
             // UpdatesPage
             // 

--- a/mRemoteV1/UI/Forms/frmOptions.Designer.cs
+++ b/mRemoteV1/UI/Forms/frmOptions.Designer.cs
@@ -30,13 +30,13 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmOptions));
             this.pnlBottom = new System.Windows.Forms.Panel();
-            this.btnCancel = new mRemoteNG.UI.Controls.Base.NGButton();
-            this.btnOK = new mRemoteNG.UI.Controls.Base.NGButton();
             this.splitter1 = new System.Windows.Forms.Splitter();
-            this.lstOptionPages = new mRemoteNG.UI.Controls.Base.NGListView();
-            this.PageName = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.splitter2 = new System.Windows.Forms.Splitter();
             this.pnlMain = new System.Windows.Forms.Panel();
+            this.lstOptionPages = new mRemoteNG.UI.Controls.Base.NGListView();
+            this.PageName = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.btnCancel = new mRemoteNG.UI.Controls.Base.NGButton();
+            this.btnOK = new mRemoteNG.UI.Controls.Base.NGButton();
             this.pnlBottom.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.lstOptionPages)).BeginInit();
             this.SuspendLayout();
@@ -48,47 +48,39 @@
             this.pnlBottom.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.pnlBottom.Location = new System.Drawing.Point(0, 492);
             this.pnlBottom.Name = "pnlBottom";
-            this.pnlBottom.Size = new System.Drawing.Size(772, 66);
+            this.pnlBottom.Size = new System.Drawing.Size(764, 35);
             this.pnlBottom.TabIndex = 0;
-            // 
-            // btnCancel
-            // 
-            this.btnCancel._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
-            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(681, 22);
-            this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(75, 23);
-            this.btnCancel.TabIndex = 1;
-            this.btnCancel.Text = "Cancel";
-            this.btnCancel.UseVisualStyleBackColor = true;
-            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
-            // 
-            // btnOK
-            // 
-            this.btnOK._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
-            this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btnOK.Location = new System.Drawing.Point(600, 22);
-            this.btnOK.Name = "btnOK";
-            this.btnOK.Size = new System.Drawing.Size(75, 23);
-            this.btnOK.TabIndex = 0;
-            this.btnOK.Text = "OK";
-            this.btnOK.UseVisualStyleBackColor = true;
-            this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
             // 
             // splitter1
             // 
             this.splitter1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.splitter1.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.splitter1.Location = new System.Drawing.Point(0, 489);
+            this.splitter1.Location = new System.Drawing.Point(0, 491);
             this.splitter1.Name = "splitter1";
-            this.splitter1.Size = new System.Drawing.Size(772, 3);
+            this.splitter1.Size = new System.Drawing.Size(764, 1);
             this.splitter1.TabIndex = 1;
             this.splitter1.TabStop = false;
+            // 
+            // splitter2
+            // 
+            this.splitter2.Location = new System.Drawing.Point(151, 0);
+            this.splitter2.Name = "splitter2";
+            this.splitter2.Size = new System.Drawing.Size(1, 491);
+            this.splitter2.TabIndex = 3;
+            this.splitter2.TabStop = false;
+            // 
+            // pnlMain
+            // 
+            this.pnlMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pnlMain.Location = new System.Drawing.Point(152, 0);
+            this.pnlMain.Name = "pnlMain";
+            this.pnlMain.Size = new System.Drawing.Size(612, 491);
+            this.pnlMain.TabIndex = 4;
             // 
             // lstOptionPages
             // 
             this.lstOptionPages.AllColumns.Add(this.PageName);
-            this.lstOptionPages.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.lstOptionPages.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.lstOptionPages.CellEditUseWholeCell = false;
             this.lstOptionPages.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.PageName});
@@ -105,7 +97,7 @@
             this.lstOptionPages.RowHeight = 25;
             this.lstOptionPages.ShowGroups = false;
             this.lstOptionPages.ShowImagesOnSubItems = true;
-            this.lstOptionPages.Size = new System.Drawing.Size(151, 489);
+            this.lstOptionPages.Size = new System.Drawing.Size(151, 491);
             this.lstOptionPages.TabIndex = 2;
             this.lstOptionPages.TileSize = new System.Drawing.Size(168, 40);
             this.lstOptionPages.UseCompatibleStateImageBehavior = false;
@@ -119,27 +111,35 @@
             this.PageName.ImageAspectName = "IconImage";
             this.PageName.IsEditable = false;
             // 
-            // splitter2
+            // btnCancel
             // 
-            this.splitter2.Location = new System.Drawing.Point(151, 0);
-            this.splitter2.Name = "splitter2";
-            this.splitter2.Size = new System.Drawing.Size(3, 489);
-            this.splitter2.TabIndex = 3;
-            this.splitter2.TabStop = false;
+            this.btnCancel._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(681, 6);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.TabIndex = 1;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
             // 
-            // pnlMain
+            // btnOK
             // 
-            this.pnlMain.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pnlMain.Location = new System.Drawing.Point(154, 0);
-            this.pnlMain.Name = "pnlMain";
-            this.pnlMain.Size = new System.Drawing.Size(618, 489);
-            this.pnlMain.TabIndex = 4;
+            this.btnOK._mice = mRemoteNG.UI.Controls.Base.NGButton.MouseState.HOVER;
+            this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.btnOK.Location = new System.Drawing.Point(600, 6);
+            this.btnOK.Name = "btnOK";
+            this.btnOK.Size = new System.Drawing.Size(75, 23);
+            this.btnOK.TabIndex = 0;
+            this.btnOK.Text = "OK";
+            this.btnOK.UseVisualStyleBackColor = true;
+            this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
             // 
             // frmOptions
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(772, 558);
+            this.ClientSize = new System.Drawing.Size(764, 527);
             this.Controls.Add(this.pnlMain);
             this.Controls.Add(this.splitter2);
             this.Controls.Add(this.lstOptionPages);


### PR DESCRIPTION
Small layout fixes to frmOptions and option pages:
_-unified button heights
-fixed tab order on some option pages elements
-resized "Launch PuTTY"-button under  Options>Advanced to display PuTTY Icon in full size
-resized main panel in frmOption to fit size of option panes
-reduced size of bottom panel in frmOptions to waste less space
-fixed distance to form border of"OK" and "Cancel" buttons in frmOptions
-unified all border styles of panels in frmOptions to none. (This makes the design look a little bit more flat and cleaner, also removes the strange edge  in the title bar where the two panels meet)
-set width of deviders on frmOptions to 1px (also looks a lot cleaner)
-fixed alignment of some elements in options_

Some of these changes can be seen in the screenshots:
**Before:**
![1](https://user-images.githubusercontent.com/22905106/32671671-a10ee43c-c648-11e7-8d5e-08d87869c150.png)
**After:**
![2](https://user-images.githubusercontent.com/22905106/32671676-a3e6ae4c-c648-11e7-842c-7ff801039b5e.png)