### PR TITLE
Implemented connection search filtering feature

### DIFF
--- a/CHANGELOG.TXT
+++ b/CHANGELOG.TXT
@@ -14,6 +14,7 @@ Features/Enhancements:
 #468: Default connection info Panel property is now saved
 #429: Added Czech translation
 #421: When a connection file cannot be loaded, we will now prompt for how to proceed rather than always exiting.
+#338: Added option to filter connection tree when searching
 #357: Updated GeckoFX to v45.45.0.32
 #225: Added support for importing Remote Desktop Connection Manager v2.7 RDG files
 #207: Can now specify a working directory for external tools

--- a/mRemoteV1/Properties/Settings.Designer.cs
+++ b/mRemoteV1/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace mRemoteNG {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.3.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -2612,6 +2612,18 @@ namespace mRemoteNG {
             }
             set {
                 this["SaveConnectionsAfterEveryEdit"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool UseFilterSearch {
+            get {
+                return ((bool)(this["UseFilterSearch"]));
+            }
+            set {
+                this["UseFilterSearch"] = value;
             }
         }
     }

--- a/mRemoteV1/Properties/Settings.settings
+++ b/mRemoteV1/Properties/Settings.settings
@@ -650,5 +650,8 @@
     <Setting Name="SaveConnectionsAfterEveryEdit" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="UseFilterSearch" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/mRemoteV1/Resources/Language/Language.Designer.cs
+++ b/mRemoteV1/Resources/Language/Language.Designer.cs
@@ -19,7 +19,7 @@ namespace mRemoteNG {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Language {
@@ -138,6 +138,15 @@ namespace mRemoteNG {
         internal static string DatabaseNotAvailable {
             get {
                 return ResourceManager.GetString("DatabaseNotAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filter search matches in connection tree.
+        /// </summary>
+        internal static string FilterSearchMatchesInConnectionTree {
+            get {
+                return ResourceManager.GetString("FilterSearchMatchesInConnectionTree", resourceCulture);
             }
         }
         

--- a/mRemoteV1/Resources/Language/Language.resx
+++ b/mRemoteV1/Resources/Language/Language.resx
@@ -2619,4 +2619,7 @@ This page will walk you through the process of upgrading your connections file o
   <data name="SaveConnectionsAfterEveryEdit" xml:space="preserve">
     <value>Save connections after every edit</value>
   </data>
+  <data name="FilterSearchMatchesInConnectionTree" xml:space="preserve">
+    <value>Filter search matches in connection tree</value>
+  </data>
 </root>

--- a/mRemoteV1/UI/Controls/ConnectionTree/ConnectionTreeSearchTextFilter.cs
+++ b/mRemoteV1/UI/Controls/ConnectionTree/ConnectionTreeSearchTextFilter.cs
@@ -1,0 +1,26 @@
+﻿using BrightIdeasSoftware;
+using mRemoteNG.Connection;
+
+namespace mRemoteNG.UI.Controls
+{
+    public class ConnectionTreeSearchTextFilter : IModelFilter
+    {
+        public string FilterText { get; set; } = "";
+
+        public bool Filter(object modelObject)
+        {
+            var objectAsConnectionInfo = modelObject as ConnectionInfo;
+            if (objectAsConnectionInfo == null)
+                return false;
+
+            var filterTextLower = FilterText.ToLowerInvariant();
+
+            if (objectAsConnectionInfo.Name.ToLowerInvariant().Contains(filterTextLower) ||
+                objectAsConnectionInfo.Hostname.ToLowerInvariant().Contains(filterTextLower) ||
+                objectAsConnectionInfo.Description.ToLowerInvariant().Contains(filterTextLower))
+                return true;
+
+            return false;
+        }
+    }
+}

--- a/mRemoteV1/UI/Forms/OptionsPages/ConnectionsPage.Designer.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/ConnectionsPage.Designer.cs
@@ -50,6 +50,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.pnlRdpConnectionTimeout = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.chkSaveConnectionsAfterEveryEdit = new mRemoteNG.UI.Controls.Base.NGCheckBox();
+            this.chkUseFilterSearch = new mRemoteNG.UI.Controls.Base.NGCheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.numRDPConTimeout)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numRdpReconnectionCount)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numAutoSave)).BeginInit();
@@ -183,7 +184,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.pnlConfirmCloseConnection.Controls.Add(this.radCloseWarnMultiple);
             this.pnlConfirmCloseConnection.Controls.Add(this.radCloseWarnExit);
             this.pnlConfirmCloseConnection.Controls.Add(this.radCloseWarnNever);
-            this.pnlConfirmCloseConnection.Location = new System.Drawing.Point(2, 191);
+            this.pnlConfirmCloseConnection.Location = new System.Drawing.Point(3, 214);
             this.pnlConfirmCloseConnection.Name = "pnlConfirmCloseConnection";
             this.pnlConfirmCloseConnection.Size = new System.Drawing.Size(595, 137);
             this.pnlConfirmCloseConnection.TabIndex = 6;
@@ -248,7 +249,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.pnlRdpReconnectionCount.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 55F));
             this.pnlRdpReconnectionCount.Controls.Add(this.lblRdpReconnectionCount, 0, 0);
             this.pnlRdpReconnectionCount.Controls.Add(this.numRdpReconnectionCount, 1, 0);
-            this.pnlRdpReconnectionCount.Location = new System.Drawing.Point(3, 95);
+            this.pnlRdpReconnectionCount.Location = new System.Drawing.Point(4, 118);
             this.pnlRdpReconnectionCount.Name = "pnlRdpReconnectionCount";
             this.pnlRdpReconnectionCount.RowCount = 1;
             this.pnlRdpReconnectionCount.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
@@ -263,7 +264,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.pnlRdpConnectionTimeout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 55F));
             this.pnlRdpConnectionTimeout.Controls.Add(this.numRDPConTimeout, 1, 0);
             this.pnlRdpConnectionTimeout.Controls.Add(this.lblRDPConTimeout, 0, 0);
-            this.pnlRdpConnectionTimeout.Location = new System.Drawing.Point(3, 127);
+            this.pnlRdpConnectionTimeout.Location = new System.Drawing.Point(4, 150);
             this.pnlRdpConnectionTimeout.Name = "pnlRdpConnectionTimeout";
             this.pnlRdpConnectionTimeout.RowCount = 1;
             this.pnlRdpConnectionTimeout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
@@ -278,11 +279,11 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 55F));
             this.tableLayoutPanel1.Controls.Add(this.numAutoSave, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.lblAutoSave1, 0, 0);
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 159);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(4, 182);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 1;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 26F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(595, 26);
             this.tableLayoutPanel1.TabIndex = 5;
             // 
@@ -297,10 +298,22 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             this.chkSaveConnectionsAfterEveryEdit.Text = "Save connections after every edit";
             this.chkSaveConnectionsAfterEveryEdit.UseVisualStyleBackColor = true;
             // 
+            // chkUseFilterSearch
+            // 
+            this.chkUseFilterSearch._mice = mRemoteNG.UI.Controls.Base.NGCheckBox.MouseState.HOVER;
+            this.chkUseFilterSearch.AutoSize = true;
+            this.chkUseFilterSearch.Location = new System.Drawing.Point(4, 95);
+            this.chkUseFilterSearch.Name = "chkUseFilterSearch";
+            this.chkUseFilterSearch.Size = new System.Drawing.Size(214, 17);
+            this.chkUseFilterSearch.TabIndex = 8;
+            this.chkUseFilterSearch.Text = "Filter search matches in connection tree";
+            this.chkUseFilterSearch.UseVisualStyleBackColor = true;
+            // 
             // ConnectionsPage
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.chkUseFilterSearch);
             this.Controls.Add(this.chkSaveConnectionsAfterEveryEdit);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.pnlRdpConnectionTimeout);
@@ -343,5 +356,6 @@ namespace mRemoteNG.UI.Forms.OptionsPages
         private System.Windows.Forms.TableLayoutPanel pnlRdpConnectionTimeout;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         internal Controls.Base.NGCheckBox chkSaveConnectionsAfterEveryEdit;
+        private Controls.Base.NGCheckBox chkUseFilterSearch;
     }
 }

--- a/mRemoteV1/UI/Forms/OptionsPages/ConnectionsPage.cs
+++ b/mRemoteV1/UI/Forms/OptionsPages/ConnectionsPage.cs
@@ -27,6 +27,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             chkSingleClickOnOpenedConnectionSwitchesToIt.Text = Language.strSingleClickOnOpenConnectionSwitchesToIt;
             chkHostnameLikeDisplayName.Text = Language.strSetHostnameLikeDisplayName;
             chkSaveConnectionsAfterEveryEdit.Text = Language.SaveConnectionsAfterEveryEdit;
+            chkUseFilterSearch.Text = Language.FilterSearchMatchesInConnectionTree;
 
             lblRdpReconnectionCount.Text = Language.strRdpReconnectCount;
             lblRDPConTimeout.Text = Language.strRDPOverallConnectionTimeout;
@@ -47,6 +48,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             chkSingleClickOnOpenedConnectionSwitchesToIt.Checked = Settings.Default.SingleClickSwitchesToOpenConnection;
             chkHostnameLikeDisplayName.Checked = Settings.Default.SetHostnameLikeDisplayName;
             chkSaveConnectionsAfterEveryEdit.Checked = Settings.Default.SaveConnectionsAfterEveryEdit;
+            chkUseFilterSearch.Checked = Settings.Default.UseFilterSearch;
 
             numRdpReconnectionCount.Value = Convert.ToDecimal(Settings.Default.RdpReconnectionCount);
             numRDPConTimeout.Value = Convert.ToDecimal(Settings.Default.ConRDPOverallConnectionTimeout);
@@ -75,6 +77,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             Settings.Default.SingleClickSwitchesToOpenConnection = chkSingleClickOnOpenedConnectionSwitchesToIt.Checked;
             Settings.Default.SetHostnameLikeDisplayName = chkHostnameLikeDisplayName.Checked;
             Settings.Default.SaveConnectionsAfterEveryEdit = chkSaveConnectionsAfterEveryEdit.Checked;
+            Settings.Default.UseFilterSearch = chkUseFilterSearch.Checked;
 
             Settings.Default.RdpReconnectionCount = (int) numRdpReconnectionCount.Value;
             Settings.Default.ConRDPOverallConnectionTimeout = (int) numRDPConTimeout.Value;

--- a/mRemoteV1/UI/Window/ConnectionTreeWindow.cs
+++ b/mRemoteV1/UI/Window/ConnectionTreeWindow.cs
@@ -19,6 +19,7 @@ namespace mRemoteNG.UI.Window
 	    private readonly ConnectionContextMenu _contextMenu;
         private readonly IConnectionInitiator _connectionInitiator = new ConnectionInitiator();
 		private ThemeManager _themeManager;
+	    private readonly ConnectionTreeSearchTextFilter _connectionTreeSearchTextFilter = new ConnectionTreeSearchTextFilter();
 
 		public ConnectionInfo SelectedNode => olvConnections.SelectedNode;
 
@@ -42,6 +43,7 @@ namespace mRemoteNG.UI.Window
 			SetMenuEventHandlers();
 		    SetConnectionTreeEventHandlers();
 		    Settings.Default.PropertyChanged += (sender, args) => SetConnectionTreeEventHandlers();
+            olvConnections.ModelFilter = _connectionTreeSearchTextFilter;
         }
 
 	    
@@ -242,9 +244,24 @@ namespace mRemoteNG.UI.Window
 
         private void txtSearch_TextChanged(object sender, EventArgs e)
 		{
-            if (txtSearch.Text == "") return;
-            olvConnections.NodeSearcher?.SearchByName(txtSearch.Text);
-            JumpToNode(olvConnections.NodeSearcher?.CurrentMatch);
+		    if (Settings.Default.UseFilterSearch)
+		    {
+		        if (txtSearch.Text == "" || txtSearch.Text == Language.strSearchPrompt)
+		        {
+		            olvConnections.UseFiltering = false;
+		            olvConnections.ResetColumnFiltering();
+                    return;
+		        }
+		        olvConnections.UseFiltering = true;
+		        _connectionTreeSearchTextFilter.FilterText = txtSearch.Text;
+		        olvConnections.ModelFilter = _connectionTreeSearchTextFilter;
+		    }
+		    else
+		    {
+                if (txtSearch.Text == "") return;
+                olvConnections.NodeSearcher?.SearchByName(txtSearch.Text);
+                JumpToNode(olvConnections.NodeSearcher?.CurrentMatch);
+		    }
         }
 
 	    private void JumpToNode(ConnectionInfo connectionInfo)

--- a/mRemoteV1/app.config
+++ b/mRemoteV1/app.config
@@ -671,6 +671,9 @@
       <setting name="SaveConnectionsAfterEveryEdit" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="UseFilterSearch" serializeAs="String">
+        <value>False</value>
+      </setting>
     </mRemoteNG.Settings>
   </userSettings>
   <applicationSettings>

--- a/mRemoteV1/mRemoteV1.csproj
+++ b/mRemoteV1/mRemoteV1.csproj
@@ -381,6 +381,7 @@
     <Compile Include="UI\Controls\ConnectionTree\ConnectionTree.Designer.cs">
       <DependentUpon>ConnectionTree.cs</DependentUpon>
     </Compile>
+    <Compile Include="UI\Controls\ConnectionTree\ConnectionTreeSearchTextFilter.cs" />
     <Compile Include="UI\Controls\CredentialRecordComboBox.cs">
       <SubType>Component</SubType>
     </Compile>


### PR DESCRIPTION
Partially implements #338 

Implementation is done, though there is a caveat to the filtering at the moment. Filtering only considers items that are currently expanded. If a folder is collapsed, its children are not considered in filtering. We should revisit this feature later to remove this flaw