### PR TITLE
Add context menu items to close other and other to the right tabs

### DIFF
--- a/mRemoteV1/Resources/Language/Language.Designer.cs
+++ b/mRemoteV1/Resources/Language/Language.Designer.cs
@@ -1284,11 +1284,29 @@ namespace mRemoteNG {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Do you want to close other connection except the &quot;{0}&quot;?.
+        /// </summary>
+        internal static string strConfirmCloseConnectionOthersInstruction {
+            get {
+                return ResourceManager.GetString("strConfirmCloseConnectionOthersInstruction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to close the panel, &quot;{0}&quot;? Any connections that it contains will also be closed..
         /// </summary>
         internal static string strConfirmCloseConnectionPanelMainInstruction {
             get {
                 return ResourceManager.GetString("strConfirmCloseConnectionPanelMainInstruction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do you want to close connections right to the &quot;{0}&quot;?.
+        /// </summary>
+        internal static string strConfirmCloseConnectionRightInstruction {
+            get {
+                return ResourceManager.GetString("strConfirmCloseConnectionRightInstruction", resourceCulture);
             }
         }
         
@@ -3278,6 +3296,24 @@ namespace mRemoteNG {
         internal static string strMenuDisconnect {
             get {
                 return ResourceManager.GetString("strMenuDisconnect", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disconnect Other Tabs.
+        /// </summary>
+        internal static string strMenuDisconnectOthers {
+            get {
+                return ResourceManager.GetString("strMenuDisconnectOthers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disconnect Tabs To The Right.
+        /// </summary>
+        internal static string strMenuDisconnectOthersRight {
+            get {
+                return ResourceManager.GetString("strMenuDisconnectOthersRight", resourceCulture);
             }
         }
         

--- a/mRemoteV1/Resources/Language/Language.resx
+++ b/mRemoteV1/Resources/Language/Language.resx
@@ -2634,4 +2634,16 @@ This page will walk you through the process of upgrading your connections file o
   <data name="TimeoutInSeconds" xml:space="preserve">
     <value>Timeout (seconds)</value>
   </data>
+  <data name="strMenuDisconnectOthersRight" xml:space="preserve">
+    <value>Disconnect Tabs To The Right</value>
+  </data>
+  <data name="strMenuDisconnectOthers" xml:space="preserve">
+    <value>Disconnect Other Tabs</value>
+  </data>
+  <data name="strConfirmCloseConnectionOthersInstruction" xml:space="preserve">
+    <value>Do you want to close other connection except the "{0}"?</value>
+  </data>
+  <data name="strConfirmCloseConnectionRightInstruction" xml:space="preserve">
+    <value>Do you want to close connections right to the "{0}"?</value>
+  </data>
 </root>

--- a/mRemoteV1/Resources/Language/Language.ru.resx
+++ b/mRemoteV1/Resources/Language/Language.ru.resx
@@ -2191,4 +2191,16 @@ mRemoteNG сейчас прекратит работу и начнет проц�
   <data name="strMenuReconnectAll" xml:space="preserve">
     <value>Переподключить все открытые соединения</value>
   </data>
+  <data name="strMenuDisconnectOther" xml:space="preserve">
+    <value>Отключить остальные вкладки</value>
+  </data>
+  <data name="strMenuDisconnectOthersRight" xml:space="preserve">
+    <value>Отключить вкладки справа</value>
+  </data>
+  <data name="strConfirmCloseConnectionOthersInstruction" xml:space="preserve">
+    <value>Хотите закрыть все подключения, кроме "{0}"?</value>
+  </data>
+  <data name="strConfirmCloseConnectionRightInstruction" xml:space="preserve">
+    <value>Хотите закрыть все подключения справа от "{0}"?</value>
+  </data>
 </root>

--- a/mRemoteV1/UI/Window/ConnectionWindow.Designer.cs
+++ b/mRemoteV1/UI/Window/ConnectionWindow.Designer.cs
@@ -18,6 +18,8 @@ namespace mRemoteNG.UI.Window
         private ToolStripMenuItem cmenTabRenameTab;
         private ToolStripMenuItem cmenTabDuplicateTab;
         private ToolStripMenuItem cmenTabDisconnect;
+        private ToolStripMenuItem cmenTabDisconnectOthers;
+        private ToolStripMenuItem cmenTabDisconnectOthersRight;
         private ToolStripMenuItem cmenTabSmartSize;
         private ToolStripMenuItem cmenTabSendSpecialKeysCtrlAltDel;
         private ToolStripMenuItem cmenTabSendSpecialKeysCtrlEsc;
@@ -53,6 +55,8 @@ namespace mRemoteNG.UI.Window
             cmenTabDuplicateTab = new ToolStripMenuItem();
             cmenTabReconnect = new ToolStripMenuItem();
             cmenTabDisconnect = new ToolStripMenuItem();
+            cmenTabDisconnectOthers = new ToolStripMenuItem();
+            cmenTabDisconnectOthersRight = new ToolStripMenuItem();
             cmenTabPuttySettings = new ToolStripMenuItem();
             cmenTab.SuspendLayout();
             SuspendLayout();
@@ -91,7 +95,9 @@ namespace mRemoteNG.UI.Window
                 cmenTabRenameTab,
                 cmenTabDuplicateTab,
                 cmenTabReconnect,
-                cmenTabDisconnect
+                cmenTabDisconnect,
+                cmenTabDisconnectOthers,
+                cmenTabDisconnectOthersRight
             });
             cmenTab.Name = "cmenTab";
             cmenTab.RenderMode = ToolStripRenderMode.Professional;
@@ -213,6 +219,20 @@ namespace mRemoteNG.UI.Window
             cmenTabDisconnect.Name = "cmenTabDisconnect";
             cmenTabDisconnect.Size = new Size(201, 22);
             cmenTabDisconnect.Text = @"Disconnect";
+            //
+            //cmenTabDisconnectOthers
+            //
+            cmenTabDisconnectOthers.Image = Resources.Pause;
+            cmenTabDisconnectOthers.Name = "cmenTabDisconnectOthers";
+            cmenTabDisconnectOthers.Size = new Size(201, 22);
+            cmenTabDisconnectOthers.Text = @"Disconnect Other Tabs";
+            //
+            //cmenTabDisconnectOthersRight
+            //
+            cmenTabDisconnectOthersRight.Image = Resources.Pause;
+            cmenTabDisconnectOthersRight.Name = "cmenTabDisconnectOthersRight";
+            cmenTabDisconnectOthersRight.Size = new Size(201, 22);
+            cmenTabDisconnectOthersRight.Text = @"Disconnect Tabs To The Right";
             //
             //cmenTabPuttySettings
             //

--- a/mRemoteV1/UI/Window/ConnectionWindow.cs
+++ b/mRemoteV1/UI/Window/ConnectionWindow.cs
@@ -92,6 +92,8 @@ namespace mRemoteNG.UI.Window
             cmenTabDuplicateTab.Click += (sender, args) => DuplicateTab();
             cmenTabReconnect.Click += (sender, args) => Reconnect();
             cmenTabDisconnect.Click += (sender, args) => CloseTabMenu();
+            cmenTabDisconnectOthers.Click += (sender, args) => CloseOtherTabs();
+            cmenTabDisconnectOthersRight.Click += (sender, args) => CloseOtherTabsToTheRight();
             cmenTabPuttySettings.Click += (sender, args) => ShowPuttySettingsDialog();
         }
 
@@ -234,6 +236,8 @@ namespace mRemoteNG.UI.Window
             cmenTabDuplicateTab.Text = Language.strMenuDuplicateTab;
             cmenTabReconnect.Text = Language.strMenuReconnect;
             cmenTabDisconnect.Text = Language.strMenuDisconnect;
+            cmenTabDisconnectOthers.Text = Language.strMenuDisconnectOthers;
+            cmenTabDisconnectOthersRight.Text = Language.strMenuDisconnectOthersRight;
             cmenTabPuttySettings.Text = Language.strPuttySettings;
         }
 
@@ -654,6 +658,92 @@ namespace mRemoteNG.UI.Window
             {
                 var interfaceControl = TabController.SelectedTab?.Tag as InterfaceControl;
                 interfaceControl?.Protocol.Close();
+            }
+            catch (Exception ex)
+            {
+                Runtime.MessageCollector.AddExceptionMessage("CloseTabMenu (UI.Window.ConnectionWindow) failed", ex);
+            }
+        }
+
+        private void CloseOtherTabs()
+        {
+            try
+            {
+                if (Settings.Default.ConfirmCloseConnection == (int)ConfirmCloseEnum.Multiple)
+                {
+                    var result = CTaskDialog.MessageBox(this, GeneralAppInfo.ProductName, string.Format(Language.strConfirmCloseConnectionOthersInstruction, TabController.SelectedTab.Title), "", "", "", Language.strCheckboxDoNotShowThisMessageAgain, ETaskDialogButtons.YesNo, ESysIcons.Question, ESysIcons.Question);
+                    if (CTaskDialog.VerificationChecked)
+                    {
+                        Settings.Default.ConfirmCloseConnection--;
+                    }
+                    if (result == DialogResult.No)
+                    {
+                        return;
+                    }
+                }
+                foreach (TabPage tab in TabController.TabPages)
+                {
+                    if (TabController.TabPages.IndexOf(tab) != TabController.TabPages.IndexOf(TabController.SelectedTab))
+                    {
+                        if (Settings.Default.ConfirmCloseConnection == (int)ConfirmCloseEnum.All)
+                        {
+                            var result = CTaskDialog.MessageBox(this, GeneralAppInfo.ProductName, string.Format(Language.strConfirmCloseConnectionMainInstruction, tab.Title), "", "", "", Language.strCheckboxDoNotShowThisMessageAgain, ETaskDialogButtons.YesNo, ESysIcons.Question, ESysIcons.Question);
+                            if (CTaskDialog.VerificationChecked)
+                            {
+                                Settings.Default.ConfirmCloseConnection--;
+                            }
+                            if (result == DialogResult.No)
+                            {
+                                continue;
+                            }
+                        }
+                        var interfaceControl = tab.Tag as InterfaceControl;
+                        interfaceControl?.Protocol.Close();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Runtime.MessageCollector.AddExceptionMessage("CloseTabMenu (UI.Window.ConnectionWindow) failed", ex);
+            }
+        }
+
+        private void CloseOtherTabsToTheRight()
+        {
+            try
+            {
+                if (Settings.Default.ConfirmCloseConnection == (int)ConfirmCloseEnum.Multiple)
+                {
+                    var result = CTaskDialog.MessageBox(this, GeneralAppInfo.ProductName, string.Format(Language.strConfirmCloseConnectionRightInstruction, TabController.SelectedTab.Title), "", "", "", Language.strCheckboxDoNotShowThisMessageAgain, ETaskDialogButtons.YesNo, ESysIcons.Question, ESysIcons.Question);
+                    if (CTaskDialog.VerificationChecked)
+                    {
+                        Settings.Default.ConfirmCloseConnection--;
+                    }
+                    if (result == DialogResult.No)
+                    {
+                        return;
+                    }
+                }
+                foreach (TabPage tab in TabController.TabPages)
+                {
+                    if (TabController.TabPages.IndexOf(tab) > TabController.TabPages.IndexOf(TabController.SelectedTab))
+                    {
+                        if (Settings.Default.ConfirmCloseConnection == (int)ConfirmCloseEnum.All)
+                        {
+                            var result = CTaskDialog.MessageBox(this, GeneralAppInfo.ProductName, string.Format(Language.strConfirmCloseConnectionMainInstruction, tab.Title), "", "", "", Language.strCheckboxDoNotShowThisMessageAgain, ETaskDialogButtons.YesNo, ESysIcons.Question, ESysIcons.Question);
+                            if (CTaskDialog.VerificationChecked)
+                            {
+                                Settings.Default.ConfirmCloseConnection--;
+                            }
+                            if (result == DialogResult.No)
+                            {
+                                continue;
+                            }
+                        }
+                        var interfaceControl = tab.Tag as InterfaceControl;
+                        interfaceControl?.Protocol.Close();
+                    }
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Description
In connection tab context menu added 2 new items: "Disconnect Other Tabs" and "Disconnect Tabs To The Right"

## Motivation and Context
It is problematic to close many tabs one by one if you need to close not ALL tabs.

## How Has This Been Tested?
Tested by hand. Sorry, I don't know how to test this automatically.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/12498008/38040914-3ad09f2a-32b9-11e8-83fd-c9cfe39acc6e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
