### PR TITLE
top-most on tray double-click

### DIFF
--- a/mRemoteV1/Tools/NotificationAreaIcon.cs
+++ b/mRemoteV1/Tools/NotificationAreaIcon.cs
@@ -101,6 +101,7 @@ namespace mRemoteNG.Tools
         {
             FrmMain.Show();
             FrmMain.WindowState = FrmMain.PreviousWindowState;
+            FrmMain.TopMost = true;
 
             if (Settings.Default.ShowSystemTrayIcon) return;
             Runtime.NotificationAreaIcon.Dispose();


### PR DESCRIPTION
fixed window not automatically being top-most when double-clicking tray icon