### PR TITLE
Implemented clipboard sharing setting for RDP protocol

### DIFF
--- a/mRemoteV1/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsDeserializerMremotengFormat.cs
+++ b/mRemoteV1/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsDeserializerMremotengFormat.cs
@@ -234,6 +234,12 @@ namespace mRemoteNG.Config.Serializers.Csv
                 if (bool.TryParse(connectionCsv[headers.IndexOf("RedirectPrinters")], out value))
                     connectionRecord.RedirectPrinters = value;
             }
+            if (headers.Contains("RedirectClipboard"))
+            {
+                bool value;
+                if (bool.TryParse(connectionCsv[headers.IndexOf("RedirectClipboard")], out value))
+                    connectionRecord.RedirectClipboard = value;
+            }
 
             if (headers.Contains("RedirectSmartCards"))
             {
@@ -451,6 +457,13 @@ namespace mRemoteNG.Config.Serializers.Csv
                 bool value;
                 if (bool.TryParse(connectionCsv[headers.IndexOf("InheritRedirectPrinters")], out value))
                     connectionRecord.Inheritance.RedirectPrinters = value;
+            }
+
+            if (headers.Contains("InheritRedirectClipboard"))
+            {
+                bool value;
+                if (bool.TryParse(connectionCsv[headers.IndexOf("InheritRedirectClipboard")], out value))
+                    connectionRecord.Inheritance.RedirectClipboard = value;
             }
 
             if (headers.Contains("InheritRedirectSmartCards"))

--- a/mRemoteV1/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsSerializerMremotengFormat.cs
+++ b/mRemoteV1/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsSerializerMremotengFormat.cs
@@ -52,7 +52,7 @@ namespace mRemoteNG.Config.Serializers.Csv
                 sb.Append("Password;");
             if (_saveFilter.SaveDomain)
                 sb.Append("Domain;");
-            sb.Append("Hostname;Protocol;PuttySession;Port;ConnectToConsole;UseCredSsp;RenderingEngine;ICAEncryptionStrength;RDPAuthenticationLevel;LoadBalanceInfo;Colors;Resolution;AutomaticResize;DisplayWallpaper;DisplayThemes;EnableFontSmoothing;EnableDesktopComposition;CacheBitmaps;RedirectDiskDrives;RedirectPorts;RedirectPrinters;RedirectSmartCards;RedirectSound;RedirectKeys;PreExtApp;PostExtApp;MacAddress;UserField;ExtApp;VNCCompression;VNCEncoding;VNCAuthMode;VNCProxyType;VNCProxyIP;VNCProxyPort;VNCProxyUsername;VNCProxyPassword;VNCColors;VNCSmartSizeMode;VNCViewOnly;RDGatewayUsageMethod;RDGatewayHostname;RDGatewayUseConnectionCredentials;RDGatewayUsername;RDGatewayPassword;RDGatewayDomain;");
+            sb.Append("Hostname;Protocol;PuttySession;Port;ConnectToConsole;UseCredSsp;RenderingEngine;ICAEncryptionStrength;RDPAuthenticationLevel;LoadBalanceInfo;Colors;Resolution;AutomaticResize;DisplayWallpaper;DisplayThemes;EnableFontSmoothing;EnableDesktopComposition;CacheBitmaps;RedirectDiskDrives;RedirectPorts;RedirectPrinters;RedirectClipboard;RedirectSmartCards;RedirectSound;RedirectKeys;PreExtApp;PostExtApp;MacAddress;UserField;ExtApp;VNCCompression;VNCEncoding;VNCAuthMode;VNCProxyType;VNCProxyIP;VNCProxyPort;VNCProxyUsername;VNCProxyPassword;VNCColors;VNCSmartSizeMode;VNCViewOnly;RDGatewayUsageMethod;RDGatewayHostname;RDGatewayUseConnectionCredentials;RDGatewayUsername;RDGatewayPassword;RDGatewayDomain;");
             if (_saveFilter.SaveInheritance)
                 sb.Append("InheritCacheBitmaps;InheritColors;InheritDescription;InheritDisplayThemes;InheritDisplayWallpaper;InheritEnableFontSmoothing;InheritEnableDesktopComposition;InheritDomain;InheritIcon;InheritPanel;InheritPassword;InheritPort;InheritProtocol;InheritPuttySession;InheritRedirectDiskDrives;InheritRedirectKeys;InheritRedirectPorts;InheritRedirectPrinters;InheritRedirectSmartCards;InheritRedirectSound;InheritResolution;InheritAutomaticResize;InheritUseConsoleSession;InheritUseCredSsp;InheritRenderingEngine;InheritUsername;InheritICAEncryptionStrength;InheritRDPAuthenticationLevel;InheritLoadBalanceInfo;InheritPreExtApp;InheritPostExtApp;InheritMacAddress;InheritUserField;InheritExtApp;InheritVNCCompression;InheritVNCEncoding;InheritVNCAuthMode;InheritVNCProxyType;InheritVNCProxyIP;InheritVNCProxyPort;InheritVNCProxyUsername;InheritVNCProxyPassword;InheritVNCColors;InheritVNCSmartSizeMode;InheritVNCViewOnly;InheritRDGatewayUsageMethod;InheritRDGatewayHostname;InheritRDGatewayUseConnectionCredentials;InheritRDGatewayUsername;InheritRDGatewayPassword;InheritRDGatewayDomain;InheritRDPAlertIdleTimeout;InheritRDPMinutesToIdleTimeout;InheritSoundQuality");
         }
@@ -116,6 +116,7 @@ namespace mRemoteNG.Config.Serializers.Csv
                 .Append(FormatForCsv(con.RedirectDiskDrives))
                 .Append(FormatForCsv(con.RedirectPorts))
                 .Append(FormatForCsv(con.RedirectPrinters))
+                .Append(FormatForCsv(con.RedirectClipboard))
                 .Append(FormatForCsv(con.RedirectSmartCards))
                 .Append(FormatForCsv(con.RedirectSound))
                 .Append(FormatForCsv(con.RedirectKeys))
@@ -164,6 +165,7 @@ namespace mRemoteNG.Config.Serializers.Csv
                 .Append(FormatForCsv(con.Inheritance.RedirectKeys))
                 .Append(FormatForCsv(con.Inheritance.RedirectPorts))
                 .Append(FormatForCsv(con.Inheritance.RedirectPrinters))
+                .Append(FormatForCsv(con.Inheritance.RedirectClipboard))
                 .Append(FormatForCsv(con.Inheritance.RedirectSmartCards))
                 .Append(FormatForCsv(con.Inheritance.RedirectSound))
                 .Append(FormatForCsv(con.Inheritance.Resolution))

--- a/mRemoteV1/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer26.cs
+++ b/mRemoteV1/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer26.cs
@@ -84,6 +84,7 @@ namespace mRemoteNG.Config.Serializers.Xml
             element.Add(new XAttribute("RedirectDiskDrives", connectionInfo.RedirectDiskDrives.ToString().ToLowerInvariant()));
             element.Add(new XAttribute("RedirectPorts", connectionInfo.RedirectPorts.ToString().ToLowerInvariant()));
             element.Add(new XAttribute("RedirectPrinters", connectionInfo.RedirectPrinters.ToString().ToLowerInvariant()));
+            element.Add(new XAttribute("RedirectClipboard", connectionInfo.RedirectClipboard.ToString().ToLowerInvariant()));
             element.Add(new XAttribute("RedirectSmartCards", connectionInfo.RedirectSmartCards.ToString().ToLowerInvariant()));
             element.Add(new XAttribute("RedirectSound", connectionInfo.RedirectSound.ToString()));
             element.Add(new XAttribute("SoundQuality", connectionInfo.SoundQuality.ToString()));
@@ -153,6 +154,7 @@ namespace mRemoteNG.Config.Serializers.Xml
                 element.Add(new XAttribute("InheritRedirectKeys", connectionInfo.Inheritance.RedirectKeys.ToString().ToLowerInvariant()));
                 element.Add(new XAttribute("InheritRedirectPorts", connectionInfo.Inheritance.RedirectPorts.ToString().ToLowerInvariant()));
                 element.Add(new XAttribute("InheritRedirectPrinters", connectionInfo.Inheritance.RedirectPrinters.ToString().ToLowerInvariant()));
+                element.Add(new XAttribute("InheritRedirectClipboard", connectionInfo.Inheritance.RedirectClipboard.ToString().ToLowerInvariant()));
                 element.Add(new XAttribute("InheritRedirectSmartCards", connectionInfo.Inheritance.RedirectSmartCards.ToString().ToLowerInvariant()));
                 element.Add(new XAttribute("InheritRedirectSound", connectionInfo.Inheritance.RedirectSound.ToString().ToLowerInvariant()));
                 element.Add(new XAttribute("InheritSoundQuality", connectionInfo.Inheritance.SoundQuality.ToString().ToLowerInvariant()));
@@ -211,6 +213,7 @@ namespace mRemoteNG.Config.Serializers.Xml
                 element.Add(new XAttribute("InheritRedirectKeys", falseString));
                 element.Add(new XAttribute("InheritRedirectPorts", falseString));
                 element.Add(new XAttribute("InheritRedirectPrinters", falseString));
+                element.Add(new XAttribute("InheritRedirectClipboard", falseString));
                 element.Add(new XAttribute("InheritRedirectSmartCards", falseString));
                 element.Add(new XAttribute("InheritRedirectSound", falseString));
                 element.Add(new XAttribute("InheritSoundQuality", falseString));

--- a/mRemoteV1/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
+++ b/mRemoteV1/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
@@ -287,6 +287,7 @@ namespace mRemoteNG.Config.Serializers.Xml
                 {
                     connectionInfo.RedirectDiskDrives = bool.Parse(xmlnode.Attributes["RedirectDiskDrives"].Value);
                     connectionInfo.RedirectPrinters = bool.Parse(xmlnode.Attributes["RedirectPrinters"].Value);
+                    connectionInfo.RedirectClipboard = bool.Parse(xmlnode.Attributes["RedirectClipboard"].Value);
                     connectionInfo.RedirectPorts = bool.Parse(xmlnode.Attributes["RedirectPorts"].Value);
                     connectionInfo.RedirectSmartCards = bool.Parse(xmlnode.Attributes["RedirectSmartCards"].Value);
                 }
@@ -294,6 +295,7 @@ namespace mRemoteNG.Config.Serializers.Xml
                 {
                     connectionInfo.RedirectDiskDrives = false;
                     connectionInfo.RedirectPrinters = false;
+                    connectionInfo.RedirectClipboard = false;
                     connectionInfo.RedirectPorts = false;
                     connectionInfo.RedirectSmartCards = false;
                 }

--- a/mRemoteV1/Config/Serializers/DataTableDeserializer.cs
+++ b/mRemoteV1/Config/Serializers/DataTableDeserializer.cs
@@ -101,6 +101,7 @@ namespace mRemoteNG.Config.Serializers
             connectionInfo.RedirectDiskDrives = (bool)dataRow["RedirectDiskDrives"];
             connectionInfo.RedirectPorts = (bool)dataRow["RedirectPorts"];
             connectionInfo.RedirectPrinters = (bool)dataRow["RedirectPrinters"];
+            connectionInfo.RedirectClipboard = (bool)dataRow["RedirectClipboard"];
             connectionInfo.RedirectSmartCards = (bool)dataRow["RedirectSmartCards"];
             connectionInfo.RedirectSound = (RdpProtocol.RDPSounds)Enum.Parse(typeof(RdpProtocol.RDPSounds), (string)dataRow["RedirectSound"]);
             connectionInfo.SoundQuality = (RdpProtocol.RDPSoundQuality)Enum.Parse(typeof(RdpProtocol.RDPSoundQuality), (string)dataRow["SoundQuality"]);
@@ -147,6 +148,7 @@ namespace mRemoteNG.Config.Serializers
             connectionInfo.Inheritance.RedirectKeys = (bool)dataRow["InheritRedirectKeys"];
             connectionInfo.Inheritance.RedirectPorts = (bool)dataRow["InheritRedirectPorts"];
             connectionInfo.Inheritance.RedirectPrinters = (bool)dataRow["InheritRedirectPrinters"];
+            connectionInfo.Inheritance.RedirectClipboard = (bool)dataRow["InheritRedirectClipboard"];
             connectionInfo.Inheritance.RedirectSmartCards = (bool)dataRow["InheritRedirectSmartCards"];
             connectionInfo.Inheritance.RedirectSound = (bool)dataRow["InheritRedirectSound"];
             connectionInfo.Inheritance.SoundQuality = (bool)dataRow["InheritSoundQuality"];

--- a/mRemoteV1/Config/Serializers/DataTableSerializer.cs
+++ b/mRemoteV1/Config/Serializers/DataTableSerializer.cs
@@ -91,6 +91,7 @@ namespace mRemoteNG.Config.Serializers
             dataTable.Columns.Add("RedirectDiskDrives", typeof(bool));
             dataTable.Columns.Add("RedirectPorts", typeof(bool));
             dataTable.Columns.Add("RedirectPrinters", typeof(bool));
+            dataTable.Columns.Add("RedirectClipboard", typeof(bool));
             dataTable.Columns.Add("RedirectSmartCards", typeof(bool));
             dataTable.Columns.Add("RedirectSound", typeof(string));
             dataTable.Columns.Add("RedirectKeys", typeof(bool));
@@ -135,6 +136,7 @@ namespace mRemoteNG.Config.Serializers
             dataTable.Columns.Add("InheritRedirectKeys", typeof(bool));
             dataTable.Columns.Add("InheritRedirectPorts", typeof(bool));
             dataTable.Columns.Add("InheritRedirectPrinters", typeof(bool));
+            dataTable.Columns.Add("InheritRedirectClipboard", typeof(bool));
             dataTable.Columns.Add("InheritRedirectSmartCards", typeof(bool));
             dataTable.Columns.Add("InheritRedirectSound", typeof(bool));
             dataTable.Columns.Add("InheritResolution", typeof(bool));
@@ -235,6 +237,7 @@ namespace mRemoteNG.Config.Serializers
             dataRow["RedirectDiskDrives"] = connectionInfo.RedirectDiskDrives;
             dataRow["RedirectPorts"] = connectionInfo.RedirectPorts;
             dataRow["RedirectPrinters"] = connectionInfo.RedirectPrinters;
+            dataRow["RedirectClipboard"] = connectionInfo.RedirectClipboard;
             dataRow["RedirectSmartCards"] = connectionInfo.RedirectSmartCards;
             dataRow["RedirectSound"] = connectionInfo.RedirectSound;
             dataRow["SoundQuality"] = connectionInfo.SoundQuality;
@@ -282,6 +285,7 @@ namespace mRemoteNG.Config.Serializers
                 dataRow["InheritRedirectKeys"] = connectionInfo.Inheritance.RedirectKeys;
                 dataRow["InheritRedirectPorts"] = connectionInfo.Inheritance.RedirectPorts;
                 dataRow["InheritRedirectPrinters"] = connectionInfo.Inheritance.RedirectPrinters;
+                dataRow["InheritRedirectClipboard"] = connectionInfo.Inheritance.RedirectClipboard;
                 dataRow["InheritRedirectSmartCards"] = connectionInfo.Inheritance.RedirectSmartCards;
                 dataRow["InheritRedirectSound"] = connectionInfo.Inheritance.RedirectSound;
                 dataRow["InheritSoundQuality"] = connectionInfo.Inheritance.SoundQuality;
@@ -339,6 +343,7 @@ namespace mRemoteNG.Config.Serializers
                 dataRow["InheritRedirectKeys"] = false;
                 dataRow["InheritRedirectPorts"] = false;
                 dataRow["InheritRedirectPrinters"] = false;
+                dataRow["InheritRedirectClipboard"] = false;
                 dataRow["InheritRedirectSmartCards"] = false;
                 dataRow["InheritRedirectSound"] = false;
                 dataRow["InheritSoundQuality"] = false;

--- a/mRemoteV1/Connection/AbstractConnectionRecord.cs
+++ b/mRemoteV1/Connection/AbstractConnectionRecord.cs
@@ -57,6 +57,7 @@ namespace mRemoteNG.Connection
         private bool _redirectKeys;
         private bool _redirectDiskDrives;
         private bool _redirectPrinters;
+        private bool _redirectClipboard;
         private bool _redirectPorts;
         private bool _redirectSmartCards;
         private RdpProtocol.RDPSounds _redirectSound;
@@ -453,6 +454,16 @@ namespace mRemoteNG.Connection
         {
             get { return GetPropertyValue("RedirectPrinters", _redirectPrinters); }
             set { SetField(ref _redirectPrinters, value, "RedirectPrinters"); }
+        }
+
+        [LocalizedAttributes.LocalizedCategory("strCategoryRedirect", 6),
+            LocalizedAttributes.LocalizedDisplayName("strPropertyNameRedirectClipboard"),
+            LocalizedAttributes.LocalizedDescription("strPropertyDescriptionRedirectClipboard"),
+            TypeConverter(typeof(MiscTools.YesNoTypeConverter))]
+        public bool RedirectClipboard
+        {
+            get { return GetPropertyValue("RedirectClipboard", _redirectClipboard); }
+            set { SetField(ref _redirectClipboard, value, "RedirectClipboard"); }
         }
 
         [LocalizedAttributes.LocalizedCategory("strCategoryRedirect", 6),

--- a/mRemoteV1/Connection/ConnectionInfoInheritance.cs
+++ b/mRemoteV1/Connection/ConnectionInfoInheritance.cs
@@ -215,8 +215,14 @@ namespace mRemoteNG.Connection
 		LocalizedAttributes.LocalizedDisplayNameInheritAttribute("strPropertyNameRedirectPrinters"), 
 		LocalizedAttributes.LocalizedDescriptionInheritAttribute("strPropertyDescriptionRedirectPrinters"), 
 		TypeConverter(typeof(MiscTools.YesNoTypeConverter))]public bool RedirectPrinters {get; set;}
-				
-		[LocalizedAttributes.LocalizedCategory("strCategoryRedirect", 7), 
+
+        [LocalizedAttributes.LocalizedCategory("strCategoryClipboard", 7),
+        LocalizedAttributes.LocalizedDisplayNameInheritAttribute("strPropertyNameRedirectClipboard"),
+        LocalizedAttributes.LocalizedDescriptionInheritAttribute("strPropertyDescriptionRedirectClipboard"),
+        TypeConverter(typeof(MiscTools.YesNoTypeConverter))]
+        public bool RedirectClipboard { get; set; }
+
+        [LocalizedAttributes.LocalizedCategory("strCategoryRedirect", 7), 
 		LocalizedAttributes.LocalizedDisplayNameInheritAttribute("strPropertyNameRedirectPorts"), 
 		LocalizedAttributes.LocalizedDescriptionInheritAttribute("strPropertyDescriptionRedirectPorts"), 
 		TypeConverter(typeof(MiscTools.YesNoTypeConverter))]public bool RedirectPorts {get; set;}

--- a/mRemoteV1/Connection/Protocol/RDP/RdpProtocol.cs
+++ b/mRemoteV1/Connection/Protocol/RDP/RdpProtocol.cs
@@ -543,6 +543,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
 				_rdpClient.AdvancedSettings2.RedirectPrinters = _connectionInfo.RedirectPrinters;
 				_rdpClient.AdvancedSettings2.RedirectSmartCards = _connectionInfo.RedirectSmartCards;
 				_rdpClient.SecuredSettings2.AudioRedirectionMode = (int)_connectionInfo.RedirectSound;
+                _rdpClient.AdvancedSettings.DisableRdpdr = _connectionInfo.RedirectClipboard ? 0 : 1;
 			}
 			catch (Exception ex)
 			{

--- a/mRemoteV1/Properties/Settings.Designer.cs
+++ b/mRemoteV1/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace mRemoteNG {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -566,6 +566,18 @@ namespace mRemoteNG {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ConDefaultRedirectClipboard {
+            get {
+                return ((bool)(this["ConDefaultRedirectClipboard"]));
+            }
+            set {
+                this["ConDefaultRedirectClipboard"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool ConDefaultRedirectPorts {
             get {
                 return ((bool)(this["ConDefaultRedirectPorts"]));
@@ -980,6 +992,18 @@ namespace mRemoteNG {
             }
             set {
                 this["InhDefaultRedirectPrinters"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool InhDefaultRedirectClipboard {
+            get {
+                return ((bool)(this["InhDefaultRedirectClipboard"]));
+            }
+            set {
+                this["InhDefaultRedirectClipboard"] = value;
             }
         }
         

--- a/mRemoteV1/Properties/Settings.settings
+++ b/mRemoteV1/Properties/Settings.settings
@@ -137,6 +137,9 @@
     <Setting Name="ConDefaultRedirectPrinters" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ConDefaultRedirectClipboard" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="ConDefaultRedirectPorts" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
@@ -240,6 +243,9 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="InhDefaultRedirectPrinters" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="InhDefaultRedirectClipboard" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="InhDefaultRedirectSmartCards" Type="System.Boolean" Scope="User">

--- a/mRemoteV1/Resources/Language/Language.es.resx
+++ b/mRemoteV1/Resources/Language/Language.es.resx
@@ -1295,6 +1295,9 @@ Ver el articulo de soporte de Microsoft en http://support.microsoft.com/kb/81183
   <data name="strPropertyDescriptionRedirectPrinters" xml:space="preserve">
     <value>Seleccione si las impresoras locales deben ser mostradas en el host remoto.</value>
   </data>
+  <data name="strPropertyDescriptionRedirectClipboard" xml:space="preserve">
+    <value>Seleccione si el portapapeles debe compartirse con el host remoto.</value>
+  </data>
   <data name="strPropertyDescriptionRedirectSmartCards" xml:space="preserve">
     <value>Seleccione si las tarjetas inteligentes deben presentarse a la máquina remota.</value>
   </data>
@@ -1444,6 +1447,9 @@ Ver el articulo de soporte de Microsoft en http://support.microsoft.com/kb/81183
   </data>
   <data name="strPropertyNameRedirectPrinters" xml:space="preserve">
     <value>Impresoras</value>
+  </data>
+  <data name="strPropertyNameRedirectClipboard" xml:space="preserve">
+    <value>Portapapeles</value>
   </data>
   <data name="strPropertyNameRedirectSmartCards" xml:space="preserve">
     <value>Tarjetas Inteligentes</value>

--- a/mRemoteV1/Resources/Language/Language.resx
+++ b/mRemoteV1/Resources/Language/Language.resx
@@ -1472,6 +1472,9 @@ If you run into such an error, please create a new connection file!</value>
   <data name="strPropertyDescriptionRedirectPrinters" xml:space="preserve">
     <value>Select whether local printers should be shown on the remote host.</value>
   </data>
+  <data name="strPropertyDescriptionRedirecClipboard" xml:space="preserve">
+    <value>Select whether clipboard should be shared.</value>
+  </data>
   <data name="strPropertyDescriptionRedirectSmartCards" xml:space="preserve">
     <value>Select whether local smart cards should be available on the remote host.</value>
   </data>
@@ -1630,6 +1633,9 @@ If you run into such an error, please create a new connection file!</value>
   </data>
   <data name="strPropertyNameRedirectPrinters" xml:space="preserve">
     <value>Printers</value>
+  </data>
+  <data name="strPropertyNameRedirectClipboard" xml:space="preserve">
+    <value>Clipboard</value>
   </data>
   <data name="strPropertyNameRedirectSmartCards" xml:space="preserve">
     <value>Smart Cards</value>

--- a/mRemoteV1/UI/Window/ConfigWindow.cs
+++ b/mRemoteV1/UI/Window/ConfigWindow.cs
@@ -819,6 +819,7 @@ namespace mRemoteNG.UI.Window
                     strHide.Add("RedirectKeys");
                     strHide.Add("RedirectPorts");
                     strHide.Add("RedirectPrinters");
+                    strHide.Add("RedirectClipboard");
                     strHide.Add("RedirectSmartCards");
                     strHide.Add("RedirectSound");
                     strHide.Add("RenderingEngine");
@@ -925,7 +926,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
 							strHide.Add("RedirectPrinters");
-							strHide.Add("RedirectSmartCards");
+                            strHide.Add("RedirectClipboard");
+                            strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
 							strHide.Add("Resolution");
@@ -970,7 +972,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
 							strHide.Add("RedirectPrinters");
-							strHide.Add("RedirectSmartCards");
+                            strHide.Add("RedirectClipboard");
+                            strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
 							strHide.Add("Resolution");
@@ -1014,7 +1017,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
 							strHide.Add("RedirectPrinters");
-							strHide.Add("RedirectSmartCards");
+                            strHide.Add("RedirectClipboard");
+                            strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
 							strHide.Add("Resolution");
@@ -1059,7 +1063,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
 							strHide.Add("RedirectPrinters");
-							strHide.Add("RedirectSmartCards");
+                            strHide.Add("RedirectClipboard");
+                            strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
 							strHide.Add("Resolution");
@@ -1105,7 +1110,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
 							strHide.Add("RedirectPrinters");
-							strHide.Add("RedirectSmartCards");
+                            strHide.Add("RedirectClipboard");
+                            strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
 							strHide.Add("Resolution");
@@ -1151,7 +1157,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
 							strHide.Add("RedirectPrinters");
-							strHide.Add("RedirectSmartCards");
+                            strHide.Add("RedirectClipboard");
+                            strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
 							strHide.Add("Resolution");
@@ -1197,7 +1204,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
 							strHide.Add("RedirectPrinters");
-							strHide.Add("RedirectSmartCards");
+                            strHide.Add("RedirectClipboard");
+                            strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("Resolution");
 							strHide.Add("AutomaticResize");
@@ -1241,7 +1249,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
 							strHide.Add("RedirectPrinters");
-							strHide.Add("RedirectSmartCards");
+                            strHide.Add("RedirectClipboard");
+                            strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound;Resolution");
 							strHide.Add("AutomaticResize");
 							strHide.Add("UseConsoleSession");
@@ -1281,7 +1290,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
 							strHide.Add("RedirectPrinters");
-							strHide.Add("RedirectSmartCards");
+                            strHide.Add("RedirectClipboard");
+                            strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
 							strHide.Add("AutomaticResize");
@@ -1323,7 +1333,8 @@ namespace mRemoteNG.UI.Window
 							strHide.Add("RedirectKeys");
 							strHide.Add("RedirectPorts");
 							strHide.Add("RedirectPrinters");
-							strHide.Add("RedirectSmartCards");
+                            strHide.Add("RedirectClipboard");
+                            strHide.Add("RedirectSmartCards");
 							strHide.Add("RedirectSound");
 							strHide.Add("RenderingEngine");
 							strHide.Add("Resolution");
@@ -1381,6 +1392,8 @@ namespace mRemoteNG.UI.Window
                             strHide.Add("RedirectPorts");
                         if (conI.Inheritance.RedirectPrinters)
                             strHide.Add("RedirectPrinters");
+                        if (conI.Inheritance.RedirectClipboard)
+                            strHide.Add("RedirectClipboard");
                         if (conI.Inheritance.RedirectSmartCards)
                             strHide.Add("RedirectSmartCards");
                         if (conI.Inheritance.RedirectSound)

--- a/mRemoteV1/app.config
+++ b/mRemoteV1/app.config
@@ -170,6 +170,9 @@
       <setting name="ConDefaultRedirectPrinters" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="ConDefaultRedirectClipboard" serializeAs="String">
+        <value>False</value>
+      </setting>
       <setting name="ConDefaultRedirectPorts" serializeAs="String">
         <value>False</value>
       </setting>
@@ -273,6 +276,9 @@
         <value>False</value>
       </setting>
       <setting name="InhDefaultRedirectPrinters" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="InhDefaultRedirectClipboard" serializeAs="String">
         <value>False</value>
       </setting>
       <setting name="InhDefaultRedirectSmartCards" serializeAs="String">


### PR DESCRIPTION
## Description
Implementation of **clipboard sharing setting for RDP protocol**.

## Motivation and Context
This implementation provides de posibility of enabling or disabling clipboard sharing on RPD connections which can be usefull in multiple scenarios.
It solves the issue #416 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
