### PR TITLE
647 save symbols

### DIFF
--- a/Jenkinsfile_publish.groovy
+++ b/Jenkinsfile_publish.groovy
@@ -36,12 +36,12 @@ node('windows') {
     withCredentials([file(credentialsId: '9b674d57-6792-48e3-984a-4d1bab2abb64', variable: 'CODE_SIGNING_CERT')]) {
         withCredentials([usernamePassword(credentialsId: '05b7449b-05c0-490f-8661-236242526e62', passwordVariable: 'MRNG_CERT_PASSWORD', usernameVariable: 'NO_USERNAME')]) {
             stage ('Build mRemoteNG (Normal - MSI)') {
-                bat "\"msBuild\" /nologo /t:Clean,Build /p:Configuration=\"Release Installer\" /p:Platform=x86 /p:CertPath=\"${env.CODE_SIGNING_CERT}\" /p:CertPassword=${env.MRNG_CERT_PASSWORD} \"${jobDir}\\mRemoteV1.sln\""
+                bat "\"${msBuild}\" /nologo /t:Clean,Build /p:Configuration=\"Release Installer\" /p:Platform=x86 /p:CertPath=\"${env.CODE_SIGNING_CERT}\" /p:CertPassword=${env.MRNG_CERT_PASSWORD} \"${jobDir}\\mRemoteV1.sln\""
                 archiveArtifacts artifacts: "Release\\*.msi", caseSensitive: false, onlyIfSuccessful: true, fingerprint: true
             }
         
             stage ('Build mRemoteNG (Portable)') {
-                bat "\"msBuild\" /nologo /t:Clean,Build /p:Configuration=\"Release Portable\" /p:Platform=x86 /p:CertPath=\"${env.CODE_SIGNING_CERT}\" /p:CertPassword=${env.MRNG_CERT_PASSWORD} \"${jobDir}\\mRemoteV1.sln\""
+                bat "\"${msBuild}\" /nologo /t:Clean,Build /p:Configuration=\"Release Portable\" /p:Platform=x86 /p:CertPath=\"${env.CODE_SIGNING_CERT}\" /p:CertPassword=${env.MRNG_CERT_PASSWORD} \"${jobDir}\\mRemoteV1.sln\""
                 archiveArtifacts artifacts: "Release\\*.zip", caseSensitive: false, onlyIfSuccessful: true, fingerprint: true
             }
         }

--- a/Jenkinsfile_publish.groovy
+++ b/Jenkinsfile_publish.groovy
@@ -48,11 +48,11 @@ node('windows') {
     }
 	
     stage ('Run Unit Tests (Normal - MSI)') {
-        bat "\"${openCoverPath}\" -register:user -target:\"${nunitConsolePath}\" -targetargs:\"\"${jobDir}\\mRemoteNGTests\\bin\\debug\\mRemoteNGTests.dll\" --result=${testResultFileNormal} --x86\" -output:\"${coverageReport}\""
+        bat "\"${nunitConsolePath}\" \"${jobDir}\\mRemoteNGTests\\bin\\release\\mRemoteNGTests.dll\" --result=${testResultFileNormal} --x86"
     }
     
     stage ('Run Unit Tests (Portable)') {
-        bat "\"${nunitConsolePath}\" \"${jobDir}\\mRemoteNGTests\\bin\\debug portable\\mRemoteNGTests.dll\" --result=${testResultFilePortable} --x86"
+        bat "\"${nunitConsolePath}\" \"${jobDir}\\mRemoteNGTests\\bin\\release portable\\mRemoteNGTests.dll\" --result=${testResultFilePortable} --x86"
     }
 
     stage ('Generate UpdateCheck Files') {

--- a/Jenkinsfile_publish.groovy
+++ b/Jenkinsfile_publish.groovy
@@ -1,9 +1,12 @@
 node('windows') {
 	def jobDir = pwd()
 	def solutionFilePath = "\"${jobDir}\\mRemoteV1.sln\""
-	def vsToolsDir = "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools"
-	def vsExtensionsDir = "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\IDE\\CommonExtensions\\Microsoft\\TestWindow"
-	def nunitTestAdapterPath = "C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\VisualStudio\\14.0\\Extensions"
+    def msBuild = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\msbuild.exe"
+    def nunitConsolePath = "${jobDir}\\packages\\NUnit.ConsoleRunner.3.7.0\\tools\\nunit3-console.exe"
+    def openCoverPath = "${jobDir}\\packages\\OpenCover.4.6.519\\tools\\OpenCover.Console.exe"
+    def testResultFileNormal = "${testResultFilePrefix}_UnitTests_normal.xml"
+    def testResultFilePortable = "${testResultFilePrefix}_UnitTests_portable.xml"
+    def coverageReport = "code_coverage_report.xml"
 
 	
 	stage ('Clean output dir') {
@@ -32,24 +35,24 @@ node('windows') {
     withCredentials([file(credentialsId: '9b674d57-6792-48e3-984a-4d1bab2abb64', variable: 'CODE_SIGNING_CERT')]) {
         withCredentials([usernamePassword(credentialsId: '05b7449b-05c0-490f-8661-236242526e62', passwordVariable: 'MRNG_CERT_PASSWORD', usernameVariable: 'NO_USERNAME')]) {
             stage ('Build mRemoteNG (Normal - MSI)') {
-                bat "\"${vsToolsDir}\\VsDevCmd.bat\" && msbuild.exe /nologo /t:Clean,Build /p:Configuration=\"Release Installer\" /p:Platform=x86 /p:CertPath=\"${env.CODE_SIGNING_CERT}\" /p:CertPassword=${env.MRNG_CERT_PASSWORD} \"${jobDir}\\mRemoteV1.sln\""
+                bat "\"msBuild\" /nologo /t:Clean,Build /p:Configuration=\"Release Installer\" /p:Platform=x86 /p:CertPath=\"${env.CODE_SIGNING_CERT}\" /p:CertPassword=${env.MRNG_CERT_PASSWORD} \"${jobDir}\\mRemoteV1.sln\""
                 archiveArtifacts artifacts: "Release\\*.msi", caseSensitive: false, onlyIfSuccessful: true, fingerprint: true
             }
         
             stage ('Build mRemoteNG (Portable)') {
-                bat "\"${vsToolsDir}\\VsDevCmd.bat\" && msbuild.exe /nologo /t:Clean,Build /p:Configuration=\"Release Portable\" /p:Platform=x86 /p:CertPath=\"${env.CODE_SIGNING_CERT}\" /p:CertPassword=${env.MRNG_CERT_PASSWORD} \"${jobDir}\\mRemoteV1.sln\""
+                bat "\"msBuild\" /nologo /t:Clean,Build /p:Configuration=\"Release Portable\" /p:Platform=x86 /p:CertPath=\"${env.CODE_SIGNING_CERT}\" /p:CertPassword=${env.MRNG_CERT_PASSWORD} \"${jobDir}\\mRemoteV1.sln\""
                 archiveArtifacts artifacts: "Release\\*.zip", caseSensitive: false, onlyIfSuccessful: true, fingerprint: true
             }
         }
     }
 	
-	stage ('Run Unit Tests (Normal - MSI)') {
-    	bat "\"${vsToolsDir}\\VsDevCmd.bat\" && VSTest.Console.exe /logger:trx /TestAdapterPath:${nunitTestAdapterPath} \"${jobDir}\\mRemoteNGTests\\bin\\Release\\mRemoteNGTests.dll\""
-	}
-
-	stage ('Run Unit Tests (Portable)') {
-    	bat "\"${vsToolsDir}\\VsDevCmd.bat\" && VSTest.Console.exe /logger:trx /TestAdapterPath:${nunitTestAdapterPath} \"${jobDir}\\mRemoteNGTests\\bin\\Release Portable\\mRemoteNGTests.dll\""
-	}
+    stage ('Run Unit Tests (Normal - MSI)') {
+        bat "\"${openCoverPath}\" -register:user -target:\"${nunitConsolePath}\" -targetargs:\"\"${jobDir}\\mRemoteNGTests\\bin\\debug\\mRemoteNGTests.dll\" --result=${testResultFileNormal} --x86\" -output:\"${coverageReport}\""
+    }
+    
+    stage ('Run Unit Tests (Portable)') {
+        bat "\"${nunitConsolePath}\" \"${jobDir}\\mRemoteNGTests\\bin\\debug portable\\mRemoteNGTests.dll\" --result=${testResultFilePortable} --x86"
+    }
 
     stage ('Generate UpdateCheck Files') {
         bat "powershell -ExecutionPolicy Bypass -File \"${jobDir}\\Tools\\create_upg_chk_files.ps1\" -TagName \"${env.TagName}\" -UpdateChannel \"${env.UpdateChannel}\""

--- a/Jenkinsfile_publish.groovy
+++ b/Jenkinsfile_publish.groovy
@@ -4,6 +4,7 @@ node('windows') {
     def msBuild = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\msbuild.exe"
     def nunitConsolePath = "${jobDir}\\packages\\NUnit.ConsoleRunner.3.7.0\\tools\\nunit3-console.exe"
     def openCoverPath = "${jobDir}\\packages\\OpenCover.4.6.519\\tools\\OpenCover.Console.exe"
+    def testResultFilePrefix = "TestResult"
     def testResultFileNormal = "${testResultFilePrefix}_UnitTests_normal.xml"
     def testResultFilePortable = "${testResultFilePrefix}_UnitTests_portable.xml"
     def coverageReport = "code_coverage_report.xml"

--- a/Tools/github_functions.ps1
+++ b/Tools/github_functions.ps1
@@ -180,6 +180,7 @@ function Upload-GitHubReleaseAsset {
     # Get-Item could produce an array of files if a wildcard is provided. (C:\*.txt)
     # Upload each matching item individually
     foreach ($file in $files) {
+        Write-Output "Uploading asset to GitHub release: '$($file.FullName)'"
         $req_uploadZipAsset = Invoke-WebRequest -Uri "$($UploadUri)?name=$($file.Name)" -Method Post -Headers @{"Authorization"="token $AuthToken"} -ContentType $ContentType -InFile $file.FullName -ErrorAction Stop
     }
 }

--- a/Tools/github_functions.ps1
+++ b/Tools/github_functions.ps1
@@ -175,9 +175,13 @@ function Upload-GitHubReleaseAsset {
     )
 
     $UploadUri = $UploadUri -replace "(\{[\w,\?]*\})$"
-    $file = Get-Item -Path $FilePath
+    $files = Get-Item -Path $FilePath
 
-    $req_uploadZipAsset = Invoke-WebRequest -Uri "$($UploadUri)?name=$($file.Name)" -Method Post -Headers @{"Authorization"="token $AuthToken"} -ContentType $ContentType -InFile $file.FullName -ErrorAction Stop
+    # Get-Item could produce an array of files if a wildcard is provided. (C:\*.txt)
+    # Upload each matching item individually
+    foreach ($file in $files) {
+        $req_uploadZipAsset = Invoke-WebRequest -Uri "$($UploadUri)?name=$($file.Name)" -Method Post -Headers @{"Authorization"="token $AuthToken"} -ContentType $ContentType -InFile $file.FullName -ErrorAction Stop
+    }
 }
 
 

--- a/Tools/postbuild_mremotev1.ps1
+++ b/Tools/postbuild_mremotev1.ps1
@@ -46,4 +46,5 @@ Format-Table -AutoSize -Wrap -InputObject @{
 & "$PSScriptRoot\tidy_files_for_release.ps1" -TargetDir $TargetDir -ConfigurationName $ConfigurationName
 & "$PSScriptRoot\sign_binaries.ps1" -TargetDir $TargetDir -CertificatePath $CertificatePath -CertificatePassword $CertificatePassword -ConfigurationName $ConfigurationName -Exclude $ExcludeFromSigning
 & "$PSScriptRoot\verify_binary_signatures.ps1" -TargetDir $TargetDir -ConfigurationName $ConfigurationName -CertificatePath $CertificatePath
+& "$PSScriptRoot\zip_symbols.ps1" -SolutionDir $SolutionDir -TargetDir $TargetDir -ConfigurationName $ConfigurationName
 & "$PSScriptRoot\zip_portable_files.ps1" -SolutionDir $SolutionDir -TargetDir $TargetDir -ConfigurationName $ConfigurationName

--- a/Tools/tidy_files_for_release.ps1
+++ b/Tools/tidy_files_for_release.ps1
@@ -15,7 +15,6 @@ if ($ConfigurationName -match "Release") {
     Write-Output "Removing unnecessary files from Release versions"
     Remove-Item -Path (Join-Path -Path $TargetDir -ChildPath "app.publish") -Recurse -Force
     $filesToDelete = Get-ChildItem -Path $TargetDir -Recurse -Include @(
-        "*.pdb",
         "*.publish",
         "*.xml",
         "*.backup",

--- a/Tools/zip_portable_files.ps1
+++ b/Tools/zip_portable_files.ps1
@@ -39,19 +39,22 @@ if ($ConfigurationName -eq "Release Portable") {
 
     $PortableZip="$($SolutionDir)Release\mRemoteNG-Portable-$($version).zip"
 
-    Remove-Item -Recurse "$($SolutionDir)mRemoteV1\bin\package" -ErrorAction SilentlyContinue | Out-Null
-    New-Item "$($SolutionDir)mRemoteV1\bin\package" -ItemType  "directory" | Out-Null
+    $tempFolderPath = Join-Path -Path $SolutionDir -ChildPath "mRemoteV1\bin\package"
+    Remove-Item -Recurse $tempFolderPath -ErrorAction SilentlyContinue | Out-Null
+    New-Item $tempFolderPath -ItemType  "directory" | Out-Null
     
-    Copy-Item "$($SolutionDir)mRemoteV1\Resources\PuTTYNG.exe" -Destination "$($SolutionDir)mRemoteV1\bin\package"
+    Copy-Item "$($SolutionDir)mRemoteV1\Resources\PuTTYNG.exe" -Destination $tempFolderPath
 
     #Write-Output "$($SolutionDir)mRemoteV1\bin\$ConfigurationName" 
     #Write-Output "$($SolutionDir)mRemoteV1\bin\package"
-    Copy-Item "$($SolutionDir)mRemoteV1\bin\$ConfigurationName\*" -Destination "$($SolutionDir)mRemoteV1\bin\package" -Recurse  -Force 
-    Copy-Item "$($SolutionDir)*.txt" -Destination "$($SolutionDir)mRemoteV1\bin\package"
+    Copy-Item "$($SolutionDir)mRemoteV1\bin\$ConfigurationName\*" -Destination $tempFolderPath -Recurse  -Force
+    # Delete any PDB files that accidentally get copied into the temp folder
+    Get-ChildItem -Path $tempFolderPath -Filter "*.pdb" | Remove-Item
+    Copy-Item "$($SolutionDir)*.txt" -Destination $tempFolderPath
 
     Write-Output "Creating portable ZIP file $($PortableZip)"
     Remove-Item -Force  $PortableZip -ErrorAction SilentlyContinue
-    & $SEVENZIP a -bt -bd -bb1 -mx=9 -tzip -y -r $PortableZip "$($SolutionDir)mRemoteV1\bin\package\*.*"
+    & $SEVENZIP a -bt -bd -bb1 -mx=9 -tzip -y -r $PortableZip (Join-Path -Path $tempFolderPath -ChildPath "*.*")
     #& $SEVENZIP a -bt -mx=9 -tzip -y $PortableZip "$($SolutionDir)*.TXT"
 }
 else {

--- a/Tools/zip_symbols.ps1
+++ b/Tools/zip_symbols.ps1
@@ -22,7 +22,7 @@ if(-not [string]::IsNullOrEmpty($Env:APPVEYOR_BUILD_FOLDER)) {
 Write-Output "Solution Dir: '$($SolutionDir)'"
 Write-Output "Target Dir: '$($TargetDir)'"
 $ConfigurationName = $ConfigurationName.Trim()
-Write-Output "Config Name (tirmmed): '$($ConfigurationName)'"
+Write-Output "Config Name (trimmed): '$($ConfigurationName)'"
 
 
 # Windows Sysinternals Sigcheck from http://technet.microsoft.com/en-us/sysinternals/bb897441
@@ -37,7 +37,13 @@ if ($ConfigurationName -match "Release") {
 
     Write-Output "Version is $($version)"
 
-    $outputZipPath="$($SolutionDir)Release\mRemoteNG-symbols-$($version).zip"
+    if ($ConfigurationName -match "Portable") {
+        $zipFilePrefix = "mRemoteNG-Portable-symbols"
+    } else {
+        $zipFilePrefix = "mRemoteNG-symbols"
+    }
+
+    $outputZipPath="$($SolutionDir)Release\$zipFilePrefix-$($version).zip"
 
     Write-Output "Creating debug symbols ZIP file $($outputZipPath)"
     Remove-Item -Force  $outputZipPath -ErrorAction SilentlyContinue

--- a/Tools/zip_symbols.ps1
+++ b/Tools/zip_symbols.ps1
@@ -1,0 +1,50 @@
+﻿param (
+    [string]
+    [Parameter(Mandatory=$true)]
+    $SolutionDir,
+
+    [string]
+    [Parameter(Mandatory=$true)]
+    $TargetDir,
+
+    [string]
+    [Parameter(Mandatory=$true)]
+    $ConfigurationName
+)
+
+Write-Output "===== Beginning $($PSCmdlet.MyInvocation.MyCommand) ====="
+
+if(-not [string]::IsNullOrEmpty($Env:APPVEYOR_BUILD_FOLDER)) {
+    Write-Output "Too early to run via Appveyor - artifacts don't get generated properly. Exiting"
+    Exit
+}
+
+Write-Output "Solution Dir: '$($SolutionDir)'"
+Write-Output "Target Dir: '$($TargetDir)'"
+$ConfigurationName = $ConfigurationName.Trim()
+Write-Output "Config Name (tirmmed): '$($ConfigurationName)'"
+
+
+# Windows Sysinternals Sigcheck from http://technet.microsoft.com/en-us/sysinternals/bb897441
+$SIGCHECK="$($SolutionDir)Tools\exes\sigcheck.exe"
+$SEVENZIP="$($SolutionDir)Tools\7zip\7za.exe"
+
+# Package Zip
+if ($ConfigurationName -match "Release") {
+    Write-Output "Packaging debug symbols"
+   
+    $version = & $SIGCHECK /accepteula -q -n "$($SolutionDir)mRemoteV1\bin\$($ConfigurationName)\mRemoteNG.exe"
+
+    Write-Output "Version is $($version)"
+
+    $zipFilePath="$($SolutionDir)Release\mRemoteNG-symbols-$($version).zip"
+
+    Write-Output "Creating debug symbols ZIP file $($zipFilePath)"
+    Remove-Item -Force  $zipFilePath -ErrorAction SilentlyContinue
+    & $SEVENZIP a -bt -bd -bb1 -mx=9 -tzip -y -r $zipFilePath "$($SolutionDir)mRemoteV1\bin\*.dbg"
+}
+else {
+    Write-Output "We will not package debug symbols - this isnt a release build."
+}
+
+Write-Output ""

--- a/Tools/zip_symbols.ps1
+++ b/Tools/zip_symbols.ps1
@@ -37,11 +37,11 @@ if ($ConfigurationName -match "Release") {
 
     Write-Output "Version is $($version)"
 
-    $zipFilePath="$($SolutionDir)Release\mRemoteNG-symbols-$($version).zip"
+    $outputZipPath="$($SolutionDir)Release\mRemoteNG-symbols-$($version).zip"
 
-    Write-Output "Creating debug symbols ZIP file $($zipFilePath)"
-    Remove-Item -Force  $zipFilePath -ErrorAction SilentlyContinue
-    & $SEVENZIP a -bt -bd -bb1 -mx=9 -tzip -y -r $zipFilePath "$($SolutionDir)mRemoteV1\bin\*.dbg"
+    Write-Output "Creating debug symbols ZIP file $($outputZipPath)"
+    Remove-Item -Force  $outputZipPath -ErrorAction SilentlyContinue
+    & $SEVENZIP a -bt -bd -bb1 -mx=9 -tzip -y -r $outputZipPath (Join-Path -Path $TargetDir -ChildPath "*.pdb")
 }
 else {
     Write-Output "We will not package debug symbols - this isnt a release build."

--- a/mRemoteV1/mRemoteV1.csproj
+++ b/mRemoteV1/mRemoteV1.csproj
@@ -1557,16 +1557,18 @@ powershell.exe -ExecutionPolicy Bypass -File "%25psScriptsDir%25\postbuild_mremo
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <DebugSymbols>false</DebugSymbols>
+    <DebugSymbols>true</DebugSymbols>
     <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Release\</OutputPath>
     <NoWarn>1591,660,661</NoWarn>
-    <DebugType>none</DebugType>
+    <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <WarningLevel>1</WarningLevel>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <Prefer32Bit>false</Prefer32Bit>
+    <DefineConstants>
+    </DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release Portable|x86'">
     <DebugSymbols>false</DebugSymbols>

--- a/mRemoteV1/mRemoteV1.csproj
+++ b/mRemoteV1/mRemoteV1.csproj
@@ -1571,12 +1571,12 @@ powershell.exe -ExecutionPolicy Bypass -File "%25psScriptsDir%25\postbuild_mremo
     </DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release Portable|x86'">
-    <DebugSymbols>false</DebugSymbols>
+    <DebugSymbols>true</DebugSymbols>
     <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Release Portable\</OutputPath>
     <DefineConstants>PORTABLE</DefineConstants>
     <NoWarn>1591,660,661</NoWarn>
-    <DebugType>none</DebugType>
+    <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
We now emit and archive debug symbols for released versions of mRemoteNG. This will help with debugging issues from the field.

## Description
3 changes were made in this PR:
1. Release/Release Portable build configurations now create PDB files.
1. The post build process was modified to zip debug symbols
1. The jenkins file for release builds was updated for msbuild 15 (ported over changes from the normal jenkins file which was updated a while ago).

## Motivation and Context
Implements requested build change in #647

## How Has This Been Tested?
Created several draft releases via the `Build mRemoteNG for release` job. All assets were included as expected in the release draft on GitHub.