### PR TITLE
Fixing NullReferenceException when renaming node

### DIFF
--- a/mRemoteV1/UI/Controls/ConnectionTree/ConnectionTree.cs
+++ b/mRemoteV1/UI/Controls/ConnectionTree/ConnectionTree.cs
@@ -295,8 +295,11 @@ namespace mRemoteNG.UI.Controls
 
         public void RenameSelectedNode()
         {
-            _allowEdit = true;
-            SelectedItem.BeginEdit();
+            if (SelectedItem != null)
+            {
+                _allowEdit = true;
+                SelectedItem.BeginEdit();
+            }
         }
 
         public void DeleteSelectedNode()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added not null condition to method RenameSelectedNode
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When I have no selected node and I press F2 key, NullReferenceException appears in method RenameSelectedNode(). I added not null condition.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Downloaded develop branch, fixed bug and tested in VS2017
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
