### PR TITLE
Fixing "Reconnect to previously opened sessions on startup"

### DIFF
--- a/mRemoteV1/Config/Connections/SaveConnectionsOnEdit.cs
+++ b/mRemoteV1/Config/Connections/SaveConnectionsOnEdit.cs
@@ -2,6 +2,7 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 using mRemoteNG.Connection;
+using mRemoteNG.UI.Forms;
 
 namespace mRemoteNG.Config.Connections
 {
@@ -43,6 +44,8 @@ namespace mRemoteNG.Config.Connections
         private void SaveConnectionOnEdit()
         {
             if (!mRemoteNG.Settings.Default.SaveConnectionsAfterEveryEdit)
+                return;
+            if (FrmMain.Default.IsClosing)
                 return;
 
             _connectionsService.SaveConnectionsAsync();


### PR DESCRIPTION
Fixes #1139

## Description
The method SaveConnectionOnEdit now queries the IsClosing property of FrmMain and thereby a saving is prevented. When opening a connection, the SaveConnectionOnEdit method now saves the status and does not overwrite it when closing mRemoteNG.

## Motivation and Context
The Option "Reconnect to previously opened sessions on startup" is not working if "Save connections after every edit" is enabled. This is because the connection settings are saved again after the connection is closed and thereby the connection is saved as "not connected".

## How Has This Been Tested?
Running the portable version.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
