### PR TITLE
Fix and refactor CreateBulkConnections_ConfCons2_6.ps1

### DIFF
--- a/Tools/CreateBulkConnections_ConfCons2_6.ps1
+++ b/Tools/CreateBulkConnections_ConfCons2_6.ps1
@@ -17,6 +17,23 @@ foreach ($Path in 'HKLM:\SOFTWARE\WOW6432Node\mRemoteNG', 'HKLM:\SOFTWARE\mRemot
         continue
     }
 }
+if (!$mRNGPath) {
+    Add-Type -AssemblyName System.Windows.Forms
+    $FolderBrowser = [System.Windows.Forms.FolderBrowserDialog]@{
+        Description = 'Please select the folder which contains mRemoteNG.exe'
+        ShowNewFolderButton = $false
+    }
+    
+    $Response = $FolderBrowser.ShowDialog()
+    
+    if ($Response.value__ -eq 1) {
+        $mRNGPath = $FolderBrowser.SelectedPath
+    }
+    elseif ($Response.value__ -eq 2) {
+        Write-Warning 'A folder containing mRemoteNG.exe has not been selected'
+        return
+    }
+}
 $null = [System.Reflection.Assembly]::LoadFile((Join-Path -Path $mRNGPath -ChildPath "mRemoteNG.exe"))
 Add-Type -Path (Join-Path -Path $mRNGPath -ChildPath "BouncyCastle.Crypto.dll")
 

--- a/Tools/CreateBulkConnections_ConfCons2_6.ps1
+++ b/Tools/CreateBulkConnections_ConfCons2_6.ps1
@@ -8,7 +8,7 @@
 #   Replace or modify the examples that are shown toward the end of the script to create your own connection info objects.
 #####################################
 
-foreach ($Path in 'HKLM:\SOFTWARE\WOW6432Node\mRemoteNG', 'HKLM:\SOFTWARE\WOW6432Node\mRemoteNG') {
+foreach ($Path in 'HKLM:\SOFTWARE\WOW6432Node\mRemoteNG', 'HKLM:\SOFTWARE\mRemoteNG') {
     Try {
         $mRNGPath = (Get-ItemProperty -Path $Path -Name InstallDir -ErrorAction Stop).InstallDir
         break

--- a/Tools/CreateBulkConnections_ConfCons2_6.ps1
+++ b/Tools/CreateBulkConnections_ConfCons2_6.ps1
@@ -1,60 +1,152 @@
 ﻿#####################################
-# Author: David Sparer
-# Summary: 
+# Authors: David Sparer & Jack Denton
+# Summary:
 #   This is intended to be a template for creating connections in bulk. This uses the serializers directly from the mRemoteNG binaries.
 #   You will still need to create the connection info objects, but the library will handle serialization. It is expected that you
 #   are familiar with PowerShell. If this is not the case, reach out to the mRemoteNG community for help.
 # Usage:
-#   Replace or modify the examples that are shown toward the end of the script to create your own connection info objects. 
+#   Replace or modify the examples that are shown toward the end of the script to create your own connection info objects.
 #####################################
 
-$EncryptionKey = (Get-Credential -Message "Enter the encryption key you would like to use. This must match the encryption key used by the rest of the confCons file." -UserName "DontNeedUsername").Password
-$PathToMrngFolder = ""
-
-if ($PathToMrngFolder -eq "") {
-    Write-Error -Message 'You must set the $PathToMrngFolder variable in this script to the folder which contains mRemoteNG.exe'
+foreach ($Path in 'HKLM:\SOFTWARE\WOW6432Node\mRemoteNG', 'HKLM:\SOFTWARE\WOW6432Node\mRemoteNG') {
+    Try {
+        $mRNGPath = (Get-ItemProperty -Path $Path -Name InstallDir -ErrorAction Stop).InstallDir
+        break
+    }
+    Catch {
+        continue
+    }
 }
+$null = [System.Reflection.Assembly]::LoadFile((Join-Path -Path $mRNGPath -ChildPath "mRemoteNG.exe"))
+Add-Type -Path (Join-Path -Path $mRNGPath -ChildPath "BouncyCastle.Crypto.dll")
 
-$assembly = [System.Reflection.Assembly]::LoadFile((Join-Path -Path $PathToMrngFolder -ChildPath "mRemoteNG.exe"))
-$assembly = [System.Reflection.Assembly]::LoadFile((Join-Path -Path $PathToMrngFolder -ChildPath "BouncyCastle.Crypto.dll"))
 
-function New-mRemoteNGXmlSerializer {
+
+function ConvertTo-mRNGSerializedXml {
     [CmdletBinding()]
-    param (
-        [SecureString]
-        $EncryptionKey
+    Param (
+        [Parameter(Mandatory)]
+        [mRemoteNG.Connection.ConnectionInfo[]]
+        $Xml,
+
+        [Parameter()]
+        [pscredential]
+        $Credential = (Get-Credential -Message 'Enter the encryption key you would like to use. This must match the encryption key used by the rest of the confCons file.' -UserName $ENV:USERNAME)
     )
 
-    PROCESS {
-        $cryptoProvider = New-Object -TypeName mRemoteNG.Security.SymmetricEncryption.AeadCryptographyProvider
-        $saveFilter = New-Object -TypeName mRemoteNG.Security.SaveFilter -ArgumentList @($false)
-        $xmlSerializer = New-Object -TypeName mRemoteNG.Config.Serializers.XmlConnectionNodeSerializer -ArgumentList @($cryptoProvider, $encryptionKey, $saveFilter)
-        Write-Output $xmlSerializer
+    $CryptoProvider = [mRemoteNG.Security.SymmetricEncryption.AeadCryptographyProvider]::new()
+    $SaveFilter = [mRemoteNG.Security.SaveFilter]::new()
+    $ConnectionNodeSerializer = [mRemoteNG.Config.Serializers.Xml.XmlConnectionNodeSerializer26]::new($CryptoProvider, $Credential.Password, $SaveFilter)
+    $XmlSerializer = [mRemoteNG.Config.Serializers.Xml.XmlConnectionsSerializer]::new($CryptoProvider, $ConnectionNodeSerializer)
+
+    $RootNode = [mRemoteNG.Tree.Root.RootNodeInfo]::new('Connection')
+    foreach ($Node in $Xml) {
+        $RootNode.AddChild($Node)
     }
+    $XmlSerializer.Serialize($RootNode)
 }
 
-function New-mRemoteNGConnectionInfo {
+function New-mRNGConnection {
     [CmdletBinding()]
-    param ()
+    Param (
+        [Parameter(Mandatory)]
+        [string]
+        $Name,
 
-    PROCESS {
-        $connectionInfo = New-Object -TypeName mRemoteNG.Connection.ConnectionInfo
-        Write-Output $connectionInfo
+        [Parameter(Mandatory)]
+        [string]
+        $Hostname,
+
+        [Parameter(Mandatory)]
+        [mRemoteNG.Connection.Protocol.ProtocolType]
+        $Protocol,
+
+        [Parameter()]
+        [switch]
+        $InheritCredential,
+
+        [Parameter()]
+        [mRemoteNG.Container.ContainerInfo]
+        $ParentContainer,
+
+        [Parameter()]
+        [switch]
+        $PassThru
+    )
+
+    $Connection = [mRemoteNG.Connection.ConnectionInfo]@{
+        Name     = $Name
+        Hostname = $Hostname
+        Protocol = $Protocol
+    }
+
+    if ($PSBoundParameters.ContainsKey('InheritCredential')) {
+        $Connection.Inheritance.Username = $true
+        $Connection.Inheritance.Domain = $true
+        $Connection.Inheritance.Password = $true
+    }
+
+    if ($ParentContainer) {
+        $ParentContainer.AddChild($Connection)
+
+        if ($PSBoundParameters.ContainsKey('PassThru')) {
+            $Connection
+        }
+    }
+    else {
+        $Connection
     }
 }
 
-function New-mRemoteNGContainerInfo {
+function New-mRNGContainer {
     [CmdletBinding()]
-    param ()
+    Param (
+        [Parameter(Mandatory)]
+        [string]
+        $Name,
 
-    PROCESS {
-        $connectionInfo = New-Object -TypeName mRemoteNG.Container.ContainerInfo
-        Write-Output $connectionInfo
+        [Parameter()]
+        [switch]
+        $InheritCredential,
+
+        [Parameter()]
+        [mRemoteNG.Container.ContainerInfo]
+        $ParentContainer
+    )
+
+    $Container = [mRemoteNG.Container.ContainerInfo]@{
+        Name = $Name
     }
+
+    if ($PSBoundParameters.ContainsKey('InheritCredential')) {
+        $Container.Inheritance.Username = $true
+        $Container.Inheritance.Domain = $true
+        $Container.Inheritance.Password = $true
+    }
+
+    if ($ParentContainer) {
+        $ParentContainer.AddChild($Container)
+    }
+    
+    $Container
 }
 
-# Setup the services needed to do serialization
-$xmlSerializer = New-mRemoteNGXmlSerializer -EncryptionKey $EncryptionKey
+function Export-mRNGXml {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string]
+        $Path,
+
+        [Parameter()]
+        [string]
+        $SerializedXml
+    )
+
+    $FilePathProvider = [mRemoteNG.Config.DataProviders.FileDataProvider]::new($Path)
+    $filePathProvider.Save($SerializedXml)
+}
+
 
 
 
@@ -62,53 +154,84 @@ $xmlSerializer = New-mRemoteNGXmlSerializer -EncryptionKey $EncryptionKey
 # Example 1: serialize many connections, no containers
 # Here you can define the number of connection info objects to create
 # You can also provide a list of desired hostnames and iterate over those
-$xml = ""
-foreach($i in 1..5)
-{
-    $connectionInfo = New-mRemoteNGConnectionInfo
 
-    # Set connection info properties
-    $connectionInfo.Name = "server-$i"
-    $connectionInfo.Hostname = "some-win-server-$i"
-    $connectionInfo.Protocol = [mRemoteNG.Connection.Protocol.ProtocolType]::RDP
-    $connectionInfo.Inheritance.Username = $true
-    $connectionInfo.Inheritance.Domain = $true
-    $connectionInfo.Inheritance.Password = $true
-
-    $serializedConnection = $xmlSerializer.SerializeConnectionInfo($connectionInfo).ToString()
-    $xml += $serializedConnection + [System.Environment]::NewLine
+$Connections = foreach ($i in 1..5) {
+    # Create new connection
+    $Splat = @{
+        Name              = 'Server-{0:D2}' -f $i
+        Hostname          = 'Server-{0:D2}' -f $i
+        Protocol          = 'RDP'
+        InheritCredential = $true
+    }
+    New-mRNGConnection @Splat
 }
 
-Write-Output $xml
+# Serialize the connections
+$SerializedXml = ConvertTo-mRNGSerializedXml -Xml $Connections
+
+# Write the XML to a file ready to import into mRemoteNG
+Export-mRNGXml -Path "$ENV:APPDATA\mRemoteNG\PowerShellGenerated.xml" -SerializedXml $SerializedXml
+
+# Now open up mRemoteNG and press Ctrl+O and open up the exported XML file
 
 
 
 
 #----------------------------------------------------------------
 # Example 2: serialize a container which has connections
-# You can also create containers and add connections to them, which will be nested correctly when serialized
-$xml = ""
-$container = New-mRemoteNGContainerInfo
-$container.Name = "ProductionServers"
-$serializedContainer = $xmlSerializer.SerializeConnectionInfo($container)
+# You can also create containers and add connections and containers to them, which will be nested correctly when serialized
+# If you specify the ParentContainer parameter for new connections then there will be no output unless the PassThru parameter is also used
 
-foreach($i in 1..3)
-{
-    $connectionInfo = New-mRemoteNGConnectionInfo
+$ProdServers = New-mRNGContainer -Name 'ProdServers'
 
-    # Set connection info properties
-    $connectionInfo.Name = "server-$i"
-    $connectionInfo.Hostname = "some-linux-server-$i"
-    $connectionInfo.Protocol = [mRemoteNG.Connection.Protocol.ProtocolType]::SSH2
-    $connectionInfo.Inheritance.Username = $true
-    $connectionInfo.Inheritance.Domain = $true
-    $connectionInfo.Inheritance.Password = $true
-    
-    # serialize the connection
-    $serializedConnection = $xmlSerializer.SerializeConnectionInfo($connectionInfo)
-    # add the connection to the container
-    $serializedContainer.Add($serializedConnection)
+foreach ($i in 1..3) {
+    # Create new connection
+    $Splat = @{
+        Name              = 'Server-{0:D2}' -f $i
+        Hostname          = 'Server-{0:D2}' -f $i
+        Protocol          = 'RDP'
+        InheritCredential = $true
+        ParentContainer   = $ProdServers
+    }
+    New-mRNGConnection @Splat
 }
 
-# Call ToString() on the top-level container to get the XML of it and all its children
-Write-Output $serializedContainer.ToString()
+$ProdWebServers = New-mRNGContainer -Name 'WebServers' -ParentContainer $ProdServers
+
+foreach ($i in 1..3) {
+    # Create new connection
+    $Splat = @{
+        Name              = 'WebServer-{0:D2}' -f $i
+        Hostname          = 'WebServer-{0:D2}' -f $i
+        Protocol          = 'SSH1'
+        InheritCredential = $true
+        ParentContainer   = $ProdWebServers
+    }
+    New-mRNGConnection @Splat
+}
+
+$DevServers = New-mRNGContainer -Name 'DevServers'
+
+foreach ($i in 1..3) {
+    # Create new connection
+    $Splat = @{
+        Name              = 'DevServer-{0:D2}' -f $i
+        Hostname          = 'DevServer-{0:D2}' -f $i
+        Protocol          = 'RDP'
+        InheritCredential = $true
+        ParentContainer   = $DevServers
+        PassThru          = $true
+    }
+
+    # Specified the PassThru parameter in order to catch the connection and change a property
+    $Connection = New-mRNGConnection @Splat
+    $Connection.Resolution = 'FullScreen'
+}
+
+# Serialize the container
+$SerializedXml = ConvertTo-mRNGSerializedXml -Xml $ProdServers, $DevServers
+
+# Write the XML to a file ready to import into mRemoteNG
+Export-mRNGXml -Path "$ENV:APPDATA\mRemoteNG\PowerShellGenerated.xml" -SerializedXml $SerializedXml
+
+# Now open up mRemoteNG and press Ctrl+O and open up the exported XML file


### PR DESCRIPTION
## Description
The bulk connections PowerShell script currently doesn't work as it references non-existent classes (presumably from an old class structure). This PR fixes the issue by using the new classes. A lot of the script has been re-written to adhere to PowerShell best practices and to paramterize a lot of the .Net methods. The changes are:
- Remove trailing whitespaces per the [PowerShell community best practices](https://github.com/PoshCode/PowerShellPracticeAndStyle/blob/master/Style-Guide/Code-Layout-and-Formatting.md#trailing-spaces).
- Query the registry for the install path instead of requiring the end user to edit the script
- Update the syntax for instantiating objects from .Net classes from the old `New-Object` syntax.
- Rename functions using a shorter naming convention
- Add parameters and logic to functions to avoid instantiating .Net classes and calling .Net methods in the examples
- Make use of the FileDataProvider class to export the serialized XML instead of building it manually as a string
- Flesh out Example 2 to provide an example of nested folders and the use of the PassThru parameter to edit connection properties

## Motivation and Context
This fix will enable users to download the bulk connections PowerShell script and run it without having to troubleshoot why it's throwing errors.
Fixes #1149

## How Has This Been Tested?
It's been tested on a Windows 10 1809 PowerShell 5.1 machine and it produces the XML without errors for both examples. 
As this is an example/documentation change it doesn't affect other areas of the code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.