### PR TITLE
Set focus to textbox instead of connecting, 

### DIFF
--- a/mRemoteV1/UI/Controls/QuickConnectToolStrip.cs
+++ b/mRemoteV1/UI/Controls/QuickConnectToolStrip.cs
@@ -203,7 +203,7 @@ namespace mRemoteNG.UI.Controls
         private void btnQuickConnect_DropDownItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
             SetQuickConnectProtocol(e.ClickedItem.Text);
-            btnQuickConnect_ButtonClick(this, e);
+            _cmbQuickConnect.Focus();
         }
 
         private void SetQuickConnectProtocol(string protocol)

--- a/mRemoteV1/UI/Controls/QuickConnectToolStrip.cs
+++ b/mRemoteV1/UI/Controls/QuickConnectToolStrip.cs
@@ -203,7 +203,10 @@ namespace mRemoteNG.UI.Controls
         private void btnQuickConnect_DropDownItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
             SetQuickConnectProtocol(e.ClickedItem.Text);
-            _cmbQuickConnect.Focus();
+            if (string.IsNullOrEmpty(_cmbQuickConnect.Text))
+                _cmbQuickConnect.Focus();
+            else
+                btnQuickConnect_ButtonClick(this, e);
         }
 
         private void SetQuickConnectProtocol(string protocol)


### PR DESCRIPTION
This fixes #1271.
Changing the protocol in the quick connect toolstrip sets the focus to the textbox instead of directly connecting.
Users that use the keyboard can still initiate a connection when hitting `ENTER` afterwards.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
