### PR TITLE
Handle VNC timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixed
-- Making a VNC connection to a host that is either off or does not have VNC causes the application not to respond for 20-30 seconds
 ### Added
 ### Changed
 - #1460: Updated GeckoFX to v60
 ### Fixed
 - #1595: Unhandled exception when trying to browse through non existent multi ssh history with keyboard key strokes
 - #1337: Unhandled exception after closing mRemoteNG
+- #359: Making a VNC connection to an unreachable host causes the application to not respond for 20-30 seconds
 
 ## [1.77.1] - 2019-09-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Making a VNC connection to a host that is either off or does not have VNC causes the application not to respond for 20-30 seconds
 ### Added
 ### Changed
 - #1460: Updated GeckoFX to v60


### PR DESCRIPTION
Added code to report within 150ms a timeout error if no connection can be made on the VNC port for 150ms. 

 

## Description 

When attempting to make a VNC connection to a host that is off or does not have VNC installed will result in that the application will hang for 20-30 seconds, because it attempts to connect to the host for 20-30 seconds before continuing with the program. I have used a call back method with a test connection to test the connection to the host using the user configured VNC port, and if the command runs for more than 150ms it will through a connection timeout error.  

 

## Motivation and Context 

It has been annoying for us when attempting to connect to a host that is off and then the application hangs for 20-30 seconds before we can continue with a next connection. The code with the call back method I have added solves this, making the application more pleasant for us to use.  

 

## How Has This Been Tested? 

In our environment we use mRemoteNG for all our VNC remote connection. mRemoteNG gets used 24 hours a day to make remote VNC connections to various hosts. With the new code applied I tested it with all my colleagues for 3 days with no issue reported.  

 

## Screenshots (if appropriate): 

 

 

## Types of changes 

Bug fix and program improvement

 

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request to be merged. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [x] I have updated the documentation accordingly, if necessary.