### PR TITLE
Increased VNC test connection timeout from 150ms to 500ms

### DIFF
--- a/mRemoteV1/Connection/Protocol/VNC/Connection.Protocol.VNC.cs
+++ b/mRemoteV1/Connection/Protocol/VNC/Connection.Protocol.VNC.cs
@@ -72,7 +72,7 @@ namespace mRemoteNG.Connection.Protocol.VNC
             SetEventHandlers();
             try
             {
-                if (TestConnect(_info.Hostname, _info.Port, 150))
+                if (TestConnect(_info.Hostname, _info.Port, 500))
                     _vnc.Connect(_info.Hostname, _info.VNCViewOnly, _info.VNCSmartSizeMode != SmartSizeMode.SmartSNo);
             }
             catch (Exception ex)


### PR DESCRIPTION
##  Description
It has been found at times that when connecting to a VNC host, the connection times-out even if the host is powered on. This happens mostly when you are connected to the network through WiFi. This means that when executing the code the test connection takes at times more than the current set 150ms to test the connection to the host and as a result gives an timeout error.

The time out value for the VNC test connection has been increased from 150ms to 500ms.

## How Has This Been Tested?
It has been tested making various VNC connections from a PC that is connected to the network through WiFi. No timeout errors accorded when connecting to any of the hosts.

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request to be merged. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [x] I have updated the documentation accordingly, if necessary.
