### PR TITLE
Feature/serial UI integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
+- Added support for Serial connections in the Connection Drop-Down menu
 - #545: Option to minimize to system tray on closing
 - #283: Support for native PowerShell remoting as new protocol
 ### Changed

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -25,9 +25,9 @@ Vladimir Semenov (http://github.com/sli-pro)
 Stephan (http://github.com/st-schuler)  
 Aleksey Reytsman (http://github.com/areytsman)  
 Cristian Abelleira (http://github.com/CrAbelleira)  
-http://github.com/MitchellBot
-Filippo Ferrazini (http://github.com/Filippo125)
-Aaron Zauner (https://github.com/azet)
+http://github.com/MitchellBot   
+Filippo Ferrazini (http://github.com/Filippo125)    
+Aaron Zauner (https://github.com/azet)    
 
 ## Past Contributors
 Felix Deimel - mRemote original developer  

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -27,6 +27,7 @@ Aleksey Reytsman (http://github.com/areytsman)
 Cristian Abelleira (http://github.com/CrAbelleira)  
 http://github.com/MitchellBot
 Filippo Ferrazini (http://github.com/Filippo125)
+Aaron Zauner (https://github.com/azet)
 
 ## Past Contributors
 Felix Deimel - mRemote original developer  

--- a/mRemoteV1/Connection/Protocol/ProtocolFactory.cs
+++ b/mRemoteV1/Connection/Protocol/ProtocolFactory.cs
@@ -4,6 +4,7 @@ using mRemoteNG.Connection.Protocol.RAW;
 using mRemoteNG.Connection.Protocol.RDP;
 using mRemoteNG.Connection.Protocol.Rlogin;
 using mRemoteNG.Connection.Protocol.SSH;
+using mRemoteNG.Connection.Protocol.Serial;
 using mRemoteNG.Connection.Protocol.Telnet;
 using mRemoteNG.Connection.Protocol.VNC;
 using System;
@@ -30,6 +31,8 @@ namespace mRemoteNG.Connection.Protocol
                     return new ProtocolSSH1();
                 case ProtocolType.SSH2:
                     return new ProtocolSSH2();
+                case ProtocolType.Serial:
+					returm new ProtocolSerial();
                 case ProtocolType.Telnet:
                     return new ProtocolTelnet();
                 case ProtocolType.Rlogin:

--- a/mRemoteV1/Connection/Protocol/ProtocolFactory.cs
+++ b/mRemoteV1/Connection/Protocol/ProtocolFactory.cs
@@ -32,7 +32,7 @@ namespace mRemoteNG.Connection.Protocol
                 case ProtocolType.SSH2:
                     return new ProtocolSSH2();
                 case ProtocolType.Serial:
-					returm new ProtocolSerial();
+					return new ProtocolSerial();
                 case ProtocolType.Telnet:
                     return new ProtocolTelnet();
                 case ProtocolType.Rlogin:

--- a/mRemoteV1/Connection/Protocol/ProtocolType.cs
+++ b/mRemoteV1/Connection/Protocol/ProtocolType.cs
@@ -36,6 +36,9 @@ namespace mRemoteNG.Connection.Protocol
 
         [LocalizedAttributes.LocalizedDescription(nameof(Language.strPowerShell))]
         PowerShell = 10,
+        
+        [LocalizedAttributes.LocalizedDescription(nameof(Language.strSerial))]
+        Serial = 11,
 
         [LocalizedAttributes.LocalizedDescription(nameof(Language.strExtApp))]
         IntApp = 20

--- a/mRemoteV1/Resources/Language/Language.resx
+++ b/mRemoteV1/Resources/Language/Language.resx
@@ -822,6 +822,9 @@ See the Microsoft Support article at http://support.microsoft.com/kb/811833 for 
   <data name="strIcaSetResolutionFailed" xml:space="preserve">
     <value>ICA Set Resolution Failed!</value>
   </data>
+  <data name="strSerial" xml:space="preserve">
+    <value>Serial</value>
+  </data>
   <data name="strIdentifyQuickConnectTabs" xml:space="preserve">
     <value>Identify quick connect tabs by adding the prefix "Quick:"</value>
   </data>


### PR DESCRIPTION
Add Quick Integration to use Serial Connections (e.g. for USB Serial/COM devices on Windows) within mRemoteNG for example to Debug Network devices via Serial Ports or other Serial Protocol connected devices.

## How Has This Been Tested?

Was been tested in Visual Studio 2019 with the newest available .NET Framework

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/855369/76440306-f0e91f80-63bd-11ea-96e7-ad5bf3e6c8e0.png)

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request to be merged. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [x] I have updated the documentation accordingly, if necessary.
