### PR TITLE
Corrected how clipboard redirection is done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - #1589: Update SQL tables instead of rewriting them
 - #1337: Unhandled exception after closing mRemoteNG
 - #359: Making a VNC connection to an unreachable host causes the application to not respond for 20-30 seconds
+- #1465: REGRESSION: Smart Cards redirection to Remote Desktop not working
+- #1632: 1.77.1 breaks RDP drive and sound redirection
+- #1713: Sound redirection does not work if Clipboard redirection is set to No
 
 ## [1.77.1] - 2019-09-02
 ### Added

--- a/mRemoteV1/Connection/Protocol/RDP/RdpProtocol6.cs
+++ b/mRemoteV1/Connection/Protocol/RDP/RdpProtocol6.cs
@@ -589,7 +589,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
                 _rdpClient.AdvancedSettings2.RedirectPrinters = connectionInfo.RedirectPrinters;
                 _rdpClient.AdvancedSettings2.RedirectSmartCards = connectionInfo.RedirectSmartCards;
                 _rdpClient.SecuredSettings2.AudioRedirectionMode = (int)connectionInfo.RedirectSound;
-                _rdpClient.AdvancedSettings.DisableRdpdr = connectionInfo.RedirectClipboard ? 0 : 1;
+                _rdpClient.AdvancedSettings6.RedirectClipboard = connectionInfo.RedirectClipboard;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously DisableRdpdr was used, which broke smartcard and sound redirection.
By changing it to use AdvancedSettings6.RedirectClipboard, it works without breaking other stuff.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The problem was introduced in this PR: #951
This change fixes the following issues: #1465, #1632, #1713

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested with the 1.77.1 build without the change, and if clipboard redirection is set to No, drives and sound is broken - setting it to Yes and they work.
With this change they work with the Clipboard setting set to both Yes and No.
I have also tested that the clipboard setting is working, setting it to No results in the clipboard not being carried across, setting it to Yes, and it does.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Uncomment the line(s) that apply(s) to you pull request -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Updated translation -->
Bug fix

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request to be merged. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [X] All Tests within VisualStudio are passing
- [X] This pull request does not target the master branch.
- [X] I have updated the changelog file accordingly, if necessary.
- [X] I have updated the documentation accordingly, if necessary.
