### PR TITLE
Feature/make ica protocol optional for devs

### DIFF
--- a/mRemoteV1/Connection/Protocol/ICA/DummyICAClient.cs
+++ b/mRemoteV1/Connection/Protocol/ICA/DummyICAClient.cs
@@ -1,0 +1,89 @@
+﻿#if DEBUG
+using mRemoteNG.UI.Window;
+using System;
+using System.Windows.Forms;
+
+namespace mRemoteNG.Connection.Protocol.ICA
+{
+    public class DummyICAClient : IICAClient
+    {
+        public DummyICAClient()
+        {
+            throw new NotImplementedException("This version has been build with ICA Protocol disabled via compile constant 'DISABLE_ICA_PROTOCOL' this should not have happened in a release version!");
+        }
+
+        public event EventHandler<EventArgs> OnConnect;
+
+        public event EventHandler<EventArgs> OnConnectFailed;
+
+        public event EventHandler<EventArgs> OnConnecting;
+
+        public event EventHandler<EventArgs> OnDisconnect;
+
+        public string Address { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public Control Control => throw new NotImplementedException();
+
+        public bool Created => throw new NotImplementedException();
+        public string Domain { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public bool Encrypt { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string EncryptionLevelSession { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey10Char { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey10Shift { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey11Char { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey11Shift { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey1Char { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey1Shift { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey2Char { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey2Shift { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey3Char { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey3Shift { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey4Char { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey4Shift { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey5Char { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey5Shift { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey6Char { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey6Shift { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey7Char { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey7Shift { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey8Char { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey8Shift { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey9Char { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Hotkey9Shift { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public ComponentsCheckWindow Parent { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public bool PersistentCacheEnabled { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string Title { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string Username { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public object Version => throw new NotImplementedException();
+
+        public void Connect()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Control CreateControl()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void FullScreenWindow()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetProp(string v1, string v2)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetWindowSize(int width, int height)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+#endif

--- a/mRemoteV1/Connection/Protocol/ICA/ICAClient.cs
+++ b/mRemoteV1/Connection/Protocol/ICA/ICAClient.cs
@@ -1,0 +1,101 @@
+﻿#if DEBUG && !DISABLE_ICA_PROTOCOL
+
+using mRemoteNG.UI.Window;
+using System;
+using System.Windows.Forms;
+
+namespace mRemoteNG.Connection.Protocol.ICA
+{
+    public class ICAClient : IICAClient
+    {
+        private AxICAClient _icaClient;
+
+        public ICAClient()
+        {
+            _icaClient = new AxICAClient();
+
+            OnConnect += _icaClient.OnConnect;
+            OnConnectFailed += _icaClient.OnConnectFailed;
+            OnConnecting += _icaClient.OnConnecting;
+            OnDisconnect += _icaClient.OnDisconnect;
+        }
+
+        public Control Control => _icaClient;
+
+        public bool Created => _icaClient.Created;
+
+        public string Address { get => _icaClient.Address; set => _icaClient.Address = value; }
+        public string Username { get => _icaClient.Username; set => _icaClient.Username = value; }
+        public string Domain { get => _icaClient.Domain; set => _icaClient.Domain = value; }
+        public bool Encrypt { get => _icaClient.Encrypt; set => _icaClient.Encrypt = value; }
+        public string EncryptionLevelSession { get => _icaClient.EncryptionLevelSession; set => _icaClient.EncryptionLevelSession = value; }
+        public object Hotkey1Shift { get => _icaClient.Hotkey1Shift; set => _icaClient.Hotkey1Shift = value; }
+        public object Hotkey1Char { get => _icaClient.Hotkey1Char; set => _icaClient.Hotkey1Char = value; }
+        public object Hotkey2Shift { get => _icaClient.Hotkey2Shift; set => _icaClient.Hotkey2Shift = value; }
+        public object Hotkey2Char { get => _icaClient.Hotkey2Char; set => _icaClient.Hotkey2Char = value; }
+        public object Hotkey3Shift { get => _icaClient.Hotkey3Shift; set => _icaClient.Hotkey3Shift = value; }
+        public object Hotkey3Char { get => _icaClient.Hotkey3Char; set => _icaClient.Hotkey3Char = value; }
+        public object Hotkey4Shift { get => _icaClient.Hotkey4Shift; set => _icaClient.Hotkey4Shift = value; }
+        public object Hotkey4Char { get => _icaClient.Hotkey4Char; set => _icaClient.Hotkey4Char = value; }
+        public object Hotkey5Shift { get => _icaClient.Hotkey5Shift; set => _icaClient.Hotkey5Shift = value; }
+        public object Hotkey5Char { get => _icaClient.Hotkey5Char; set => _icaClient.Hotkey5Char = value; }
+        public object Hotkey6Shift { get => _icaClient.Hotkey6Shift; set => _icaClient.Hotkey6Shift = value; }
+        public object Hotkey6Char { get => _icaClient.Hotkey6Char; set => _icaClient.Hotkey6Char = value; }
+        public object Hotkey7Shift { get => _icaClient.Hotkey7Shift; set => _icaClient.Hotkey7Shift = value; }
+        public object Hotkey7Char { get => _icaClient.Hotkey7Char; set => _icaClient.Hotkey7Char = value; }
+        public object Hotkey8Shift { get => _icaClient.Hotkey8Shift; set => _icaClient.Hotkey8Shift = value; }
+        public object Hotkey8Char { get => _icaClient.Hotkey8Char; set => _icaClient.Hotkey8Char = value; }
+        public object Hotkey9Shift { get => _icaClient.Hotkey9Shift; set => _icaClient.Hotkey9Shift = value; }
+        public object Hotkey9Char { get => _icaClient.Hotkey9Char; set => _icaClient.Hotkey9Char = value; }
+        public object Hotkey10Shift { get => _icaClient.Hotkey10Shift; set => _icaClient.Hotkey10Shift = value; }
+        public object Hotkey10Char { get => _icaClient.Hotkey10Char; set => _icaClient.Hotkey10Char = value; }
+        public object Hotkey11Shift { get => _icaClient.Hotkey11Shift; set => _icaClient.Hotkey11Shift = value; }
+        public object Hotkey11Char { get => _icaClient.Hotkey11Char; set => _icaClient.Hotkey11Char = value; }
+        public bool PersistentCacheEnabled { get => _icaClient.PersistentCacheEnabled; set => _icaClient.PersistentCacheEnabled = value; }
+        public string Title { get => _icaClient.Title; set => _icaClient.Title = value; }
+        public ComponentsCheckWindow Parent { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public object Version => throw new NotImplementedException();
+
+        public event EventHandler<EventArgs> OnConnecting;
+
+        public event EventHandler<EventArgs> OnConnectFailed;
+
+        public event EventHandler<EventArgs> OnDisconnect;
+
+        public event EventHandler<EventArgs> OnConnect;
+
+        public void Connect()
+        {
+            _icaClient.Connect();
+        }
+
+        public Control CreateControl()
+        {
+            _icaClient.CreateControl();
+            return _icaClient;
+        }
+
+        public void Dispose()
+        {
+            _icaClient.Dispose();
+        }
+
+        public void FullScreenWindow()
+        {
+            _icaClient.FullScreenWindow();
+        }
+
+        public void SetProp(string name, string value)
+        {
+            _icaClient.SetProp(name, value);
+        }
+
+        public void SetWindowSize(int width, int height)
+        {
+            _icaClient.SetWindowSize(WFICALib.ICAWindowType.WindowTypeClient, width, height, 0);
+        }
+    }
+}
+
+#endif

--- a/mRemoteV1/Connection/Protocol/ICA/ICAClient.cs
+++ b/mRemoteV1/Connection/Protocol/ICA/ICAClient.cs
@@ -1,4 +1,4 @@
-﻿#if DEBUG && !DISABLE_ICA_PROTOCOL
+﻿#if (DEBUG && !DISABLE_ICA_PROTOCOL) || !DEBUG
 
 using mRemoteNG.UI.Window;
 using System;

--- a/mRemoteV1/Connection/Protocol/ICA/ICAClient.cs
+++ b/mRemoteV1/Connection/Protocol/ICA/ICAClient.cs
@@ -3,6 +3,7 @@
 using mRemoteNG.UI.Window;
 using System;
 using System.Windows.Forms;
+using AxWFICALib;
 
 namespace mRemoteNG.Connection.Protocol.ICA
 {

--- a/mRemoteV1/Connection/Protocol/ICA/ICAClientFactory.cs
+++ b/mRemoteV1/Connection/Protocol/ICA/ICAClientFactory.cs
@@ -11,11 +11,12 @@ namespace mRemoteNG.Connection.Protocol.ICA
 
         public static IICAClient CreateClientInstance()
         {
-#if DEBUG && !DISABLE_ICA_PROTOCOL
+#if (DEBUG && !DISABLE_ICA_PROTOCOL) || !DEBUG
             return new ICAClient();
 #else
             return new DummyICAClient();
 #endif
+
         }
     }
 }

--- a/mRemoteV1/Connection/Protocol/ICA/ICAClientFactory.cs
+++ b/mRemoteV1/Connection/Protocol/ICA/ICAClientFactory.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace mRemoteNG.Connection.Protocol.ICA
+{
+    public static class ICAClientFactory
+    {
+
+        public static IICAClient CreateClientInstance()
+        {
+#if DEBUG && !DISABLE_ICA_PROTOCOL
+            return new ICAClient();
+#else
+            return new DummyICAClient();
+#endif
+        }
+    }
+}

--- a/mRemoteV1/Connection/Protocol/ICA/IICAClient.cs
+++ b/mRemoteV1/Connection/Protocol/ICA/IICAClient.cs
@@ -1,0 +1,61 @@
+﻿using mRemoteNG.UI.Window;
+using System;
+using System.Windows.Forms;
+
+namespace mRemoteNG.Connection.Protocol.ICA
+{
+    public interface IICAClient : IDisposable
+    {
+        event EventHandler<EventArgs> OnConnect;
+
+        event EventHandler<EventArgs> OnConnectFailed;
+
+        event EventHandler<EventArgs> OnConnecting;
+
+        event EventHandler<EventArgs> OnDisconnect;
+
+        string Address { get; set; }
+        Control Control { get; }
+        bool Created { get; }
+        string Domain { get; set; }
+        bool Encrypt { get; set; }
+        string EncryptionLevelSession { get; set; }
+        object Hotkey10Char { get; set; }
+        object Hotkey10Shift { get; set; }
+        object Hotkey11Char { get; set; }
+        object Hotkey11Shift { get; set; }
+        object Hotkey1Char { get; set; }
+        object Hotkey1Shift { get; set; }
+        object Hotkey2Char { get; set; }
+        object Hotkey2Shift { get; set; }
+        object Hotkey3Char { get; set; }
+        object Hotkey3Shift { get; set; }
+        object Hotkey4Char { get; set; }
+        object Hotkey4Shift { get; set; }
+        object Hotkey5Char { get; set; }
+        object Hotkey5Shift { get; set; }
+        object Hotkey6Char { get; set; }
+        object Hotkey6Shift { get; set; }
+        object Hotkey7Char { get; set; }
+        object Hotkey7Shift { get; set; }
+        object Hotkey8Char { get; set; }
+        object Hotkey8Shift { get; set; }
+        object Hotkey9Char { get; set; }
+        object Hotkey9Shift { get; set; }
+        ComponentsCheckWindow Parent { get; set; }
+        bool PersistentCacheEnabled { get; set; }
+        string Title { get; set; }
+        string Username { get; set; }
+        object Version { get; }
+
+        void Connect();
+
+        Control CreateControl();
+
+        void FullScreenWindow();
+
+        void SetProp(string name, string value);
+
+        void SetWindowSize(int width, int height);
+    }
+}

--- a/mRemoteV1/Connection/Protocol/ICA/IcaProtocol.cs
+++ b/mRemoteV1/Connection/Protocol/ICA/IcaProtocol.cs
@@ -1,5 +1,4 @@
-﻿using AxWFICALib;
-using mRemoteNG.App;
+﻿using mRemoteNG.App;
 using mRemoteNG.Connection.Protocol.RDP;
 using mRemoteNG.Messages;
 using mRemoteNG.Security.SymmetricEncryption;
@@ -10,12 +9,11 @@ using System.Threading;
 using System.Timers;
 using System.Windows.Forms;
 
-
 namespace mRemoteNG.Connection.Protocol.ICA
 {
     public class IcaProtocol : ProtocolBase
     {
-        private AxICAClient _icaClient;
+        private IICAClient _icaClient;
         private ConnectionInfo _info;
         private readonly FrmMain _frmMain = FrmMain.Default;
 
@@ -25,7 +23,7 @@ namespace mRemoteNG.Connection.Protocol.ICA
         {
             try
             {
-                Control = new AxICAClient();
+                _icaClient = ICAClientFactory.CreateClientInstance();
             }
             catch (Exception ex)
             {
@@ -41,9 +39,8 @@ namespace mRemoteNG.Connection.Protocol.ICA
 
             try
             {
-                _icaClient = (AxICAClient)Control;
                 _info = InterfaceControl.Info;
-                _icaClient.CreateControl();
+                Control = _icaClient.CreateControl();
 
                 while (!_icaClient.Created)
                 {
@@ -112,7 +109,7 @@ namespace mRemoteNG.Connection.Protocol.ICA
             }
         }
 
-        #endregion
+        #endregion Public Methods
 
         #region Private Methods
 
@@ -193,9 +190,7 @@ namespace mRemoteNG.Connection.Protocol.ICA
             {
                 if (Force.HasFlag(ConnectionInfo.Force.Fullscreen))
                 {
-                    _icaClient.SetWindowSize(WFICALib.ICAWindowType.WindowTypeClient,
-                                             Screen.FromControl(_frmMain).Bounds.Width,
-                                             Screen.FromControl(_frmMain).Bounds.Height, 0);
+                    _icaClient.SetWindowSize(Screen.FromControl(_frmMain).Bounds.Width, Screen.FromControl(_frmMain).Bounds.Height);
                     _icaClient.FullScreenWindow();
 
                     return;
@@ -203,26 +198,21 @@ namespace mRemoteNG.Connection.Protocol.ICA
 
                 if (InterfaceControl.Info.Resolution == RDPResolutions.FitToWindow)
                 {
-                    _icaClient.SetWindowSize(WFICALib.ICAWindowType.WindowTypeClient, InterfaceControl.Size.Width,
-                                             InterfaceControl.Size.Height, 0);
+                    _icaClient.SetWindowSize(InterfaceControl.Size.Width, InterfaceControl.Size.Height);
                 }
                 else if (InterfaceControl.Info.Resolution == RDPResolutions.SmartSize)
                 {
-                    _icaClient.SetWindowSize(WFICALib.ICAWindowType.WindowTypeClient, InterfaceControl.Size.Width,
-                                             InterfaceControl.Size.Height, 0);
+                    _icaClient.SetWindowSize(InterfaceControl.Size.Width, InterfaceControl.Size.Height);
                 }
                 else if (InterfaceControl.Info.Resolution == RDPResolutions.Fullscreen)
                 {
-                    _icaClient.SetWindowSize(WFICALib.ICAWindowType.WindowTypeClient,
-                                             Screen.FromControl(_frmMain).Bounds.Width,
-                                             Screen.FromControl(_frmMain).Bounds.Height, 0);
+                    _icaClient.SetWindowSize(Screen.FromControl(_frmMain).Bounds.Width, Screen.FromControl(_frmMain).Bounds.Height);
                     _icaClient.FullScreenWindow();
                 }
                 else
                 {
                     var resolution = _info.Resolution.GetResolutionRectangle();
-                    _icaClient.SetWindowSize(WFICALib.ICAWindowType.WindowTypeClient, resolution.Width,
-                                             resolution.Height, 0);
+                    _icaClient.SetWindowSize(resolution.Width, resolution.Height);
                 }
             }
             catch (Exception ex)
@@ -241,12 +231,15 @@ namespace mRemoteNG.Connection.Protocol.ICA
                 case RDPColors.Colors256:
                     _icaClient.SetProp("DesiredColor", "2");
                     break;
+
                 case RDPColors.Colors15Bit:
                     _icaClient.SetProp("DesiredColor", "4");
                     break;
+
                 case RDPColors.Colors16Bit:
                     _icaClient.SetProp("DesiredColor", "4");
                     break;
+
                 default:
                     _icaClient.SetProp("DesiredColor", "8");
                     break;
@@ -262,14 +255,17 @@ namespace mRemoteNG.Connection.Protocol.ICA
                     _icaClient.Encrypt = true;
                     _icaClient.EncryptionLevelSession = "EncRC5-0";
                     break;
+
                 case EncryptionStrength.Encr40Bit:
                     _icaClient.Encrypt = true;
                     _icaClient.EncryptionLevelSession = "EncRC5-40";
                     break;
+
                 case EncryptionStrength.Encr56Bit:
                     _icaClient.Encrypt = true;
                     _icaClient.EncryptionLevelSession = "EncRC5-56";
                     break;
+
                 case EncryptionStrength.Encr128Bit:
                     _icaClient.Encrypt = true;
                     _icaClient.EncryptionLevelSession = "EncRC5-128";
@@ -294,7 +290,7 @@ namespace mRemoteNG.Connection.Protocol.ICA
             }
         }
 
-        #endregion
+        #endregion Private Methods
 
         #region Private Events & Handlers
 
@@ -333,7 +329,7 @@ namespace mRemoteNG.Connection.Protocol.ICA
             }
         }
 
-        #endregion
+        #endregion Private Events & Handlers
 
         #region Reconnect Stuff
 
@@ -349,7 +345,7 @@ namespace mRemoteNG.Connection.Protocol.ICA
             _icaClient.Connect();
         }
 
-        #endregion
+        #endregion Reconnect Stuff
 
         #region Enums
 
@@ -377,6 +373,6 @@ namespace mRemoteNG.Connection.Protocol.ICA
             Encr128Bit = 128
         }
 
-        #endregion
+        #endregion Enums
     }
 }

--- a/mRemoteV1/UI/Window/ComponentsCheckWindow.cs
+++ b/mRemoteV1/UI/Window/ComponentsCheckWindow.cs
@@ -4,10 +4,10 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using AxWFICALib;
 using Gecko;
 using mRemoteNG.App;
 using mRemoteNG.App.Info;
+using mRemoteNG.Connection.Protocol.ICA;
 using mRemoteNG.Connection.Protocol.RDP;
 using mRemoteNG.Messages;
 using mRemoteNG.Themes;
@@ -652,7 +652,7 @@ namespace mRemoteNG.UI.Window
 
             try
             {
-                using (var ica = new AxICAClient())
+                using (var ica = ICAClientFactory.CreateClientInstance())
                 {
                     ica.Parent = this;
 

--- a/mRemoteV1/mRemoteV1.csproj
+++ b/mRemoteV1/mRemoteV1.csproj
@@ -263,6 +263,10 @@
     <Compile Include="Connection\IInheritable.cs" />
     <Compile Include="Connection\IHasParent.cs" />
     <Compile Include="Connection\Protocol\Http\Connection.Protocol.HTTPS.CertEvent.cs" />
+    <Compile Include="Connection\Protocol\ICA\DummyICAClient.cs" />
+    <Compile Include="Connection\Protocol\ICA\ICAClient.cs" />
+    <Compile Include="Connection\Protocol\ICA\ICAClientFactory.cs" />
+    <Compile Include="Connection\Protocol\ICA\IICAClient.cs" />
     <Compile Include="Connection\Protocol\ProtocolFactory.cs" />
     <Compile Include="Connection\Protocol\RDP\AuthenticationLevel.cs" />
     <Compile Include="Connection\Protocol\RDP\AzureLoadBalanceInfoEncoder.cs" />


### PR DESCRIPTION
Make the Citrix Client Dependency optional for developers (in DEBUG builds only)

## Description
The changes only take effect when a developer explicitly defines a compile constant called 'DISABLE_ICA_PROTOCOL' on the main project.
When this constant is set the ICA Client is no longer compiled hence removing the requirement to have the Citrix Client component installed and registered on your machine.
Of course that also removes the ICA Protocol support of the application.


## Motivation and Context
As a developer who wants to support the project I did not want to install the Citrix Client on my developer machine therefore I made the component optional for developers (in Debug Builds only and by defining a optional compile constant) 

## How Has This Been Tested?
Since I do not have an Citrix Endpoint I could test against the changes are effectively untested
therefore I hope that someone can test the changes for me.



## Checklist:
- [X ] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [X] This pull request does not target the master branch. (develop branch was used as base)
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
