### PR TITLE
Fix RDP local desktop scale not taking effect on remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
+- #1427: Fix RDP local desktop scale not taking effect on remote
 - #1770: Added missing RDP performance settings
 - #1332: Added option to hide menu strip container
 - #545: Option to minimize to system tray on closing

--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol6.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol6.cs
@@ -518,7 +518,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
         {
             try
             {
-                var scaleFactor = (uint)_displayProperties.ResolutionScalingFactor.Width * 100;
+                var scaleFactor = (uint)(_displayProperties.ResolutionScalingFactor.Width * 100);
                 SetExtendedProperty("DesktopScaleFactor", scaleFactor);
                 SetExtendedProperty("DeviceScaleFactor", (uint)100);
 


### PR DESCRIPTION
## Description
RDP remote desktop scale was calculated incorrectly, resulting in local 125%/150% translating to remote 100%

## Motivation and Context
When working with a high-DPI display with a scaling factor, the remote machines are set to 100% due to this bug. This results in RDP session where everything is too small.
#1427 RDP doesn't respect desktop scaling

## How Has This Been Tested?
Tested on my 125%-scale setup: laptop monitor of 1920*1080 and + 4K external monitor. My change works great on both monitors.
This change is a one-liner, only in the RDP connection, so I believe it's low-risk.

## Screenshots (if appropriate):

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] My code follows the code style of this project.
- [ x ] All Tests within VisualStudio are passing
- [ ] This pull request does not target the master branch.
- [ x ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
