### PR TITLE
Fix RDP high dpi desktop scaling not taking effect on remote connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - #319: Override quick connect username when using user@domain
 - #283: Support for native PowerShell remoting as new protocol
 ### Changed
+- #1898: Fixed RDP desktop scaling not taking effect on remote connections
 - #1777: Cleaned up VisualStudio project structure
 - #1767: Turned about window into a simple popup form
 - #1766: Converted components check page into options page

--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol6.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol6.cs
@@ -514,13 +514,46 @@ namespace mRemoteNG.Connection.Protocol.RDP
             }
         }
 
+		private uint GetDesktopScaleFactor()
+        {
+            var scaleFactor = (uint)(_displayProperties.ResolutionScalingFactor.Width * 100);
+            switch (scaleFactor)
+            {
+                case 125:
+                    return 125;
+                case 150:
+                case 175:
+                    return 150;
+                case 200:
+                    return 200;
+            }
+            if (scaleFactor > 200)
+                return 200;
+            return 100;
+        }
+        private uint GetDeviceScaleFactor()
+        {
+            var scaleFactor = (uint)(_displayProperties.ResolutionScalingFactor.Width * 100);
+            switch (scaleFactor)
+            {
+                case 125:
+                case 150:
+                case 175:
+                    return 140;
+                case 200:
+                    return 180;
+            }
+            if (scaleFactor > 200)
+                return 180;
+            return 100;
+        }
+		
         private void SetResolution()
         {
             try
             {
-                var scaleFactor = (uint)_displayProperties.ResolutionScalingFactor.Width * 100;
-                SetExtendedProperty("DesktopScaleFactor", scaleFactor);
-                SetExtendedProperty("DeviceScaleFactor", (uint)100);
+                SetExtendedProperty("DesktopScaleFactor", GetDesktopScaleFactor());
+                SetExtendedProperty("DeviceScaleFactor", GetDeviceScaleFactor());
 
                 if (Force.HasFlag(ConnectionInfo.Force.Fullscreen))
                 {


### PR DESCRIPTION
## Description
fixed incorrect uint cast which made the scale factor always be 100
added two functions to calculate DesktopScaleFactor and DeviceScaleFactor based on this sample code: [link](https://webdevolutions.blob.core.windows.net/blog/pdf/smart-resizing-and-high-dpi-issues-in-remote-desktop-manager.pdf)


## Motivation and Context
https://github.com/mRemoteNG/mRemoteNG/pull/1898
https://github.com/mRemoteNG/mRemoteNG/issues/1582


## How Has This Been Tested?
tested on three different high resolution screens to multiple targets. tested on a standard screen to verify default behaviour is unchanged.


## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [X] All Tests within VisualStudio are passing
- [X] This pull request does not target the master branch.
- [X] I have updated the changelog file accordingly, if necessary.

