### PR TITLE
added optional but helpful winscp arguments

### DIFF
--- a/mRemoteNG/Documentation/external_tools_cheat_sheet.rst
+++ b/mRemoteNG/Documentation/external_tools_cheat_sheet.rst
@@ -27,7 +27,8 @@ WinSCP is a free GUI Secure Copy program.
 
 - Filename: C:\\Program Files\\WinSCP\\WinSCP.exe (example path)
 - Arguments: scp://%Username%:%Password%@%Hostname%/
-- Can integrate: Unknown
+- Optional Arguments - turn on compression and ignore any host key errors: -rawsetting Compression=1 -hostkey=*
+- Can integrate: No
 
 `FileZilla S/FTP <https://filezilla-project.org/>`_
 ===================================================


### PR DESCRIPTION
## Description
added ssh compression and ignore all hostkey errors 

## Motivation and Context
especially out of mremoteng winscp is often used for a quick fetch of logfiles -> compression speeds that up a lot
the ignore hostkey errors needs to be considered on the security needs, nonetheless its is convenient  

## How Has This Been Tested?
I use it everyday

## Types of changes
- [x] Updated manual for external tools

## Checklist:
- [x] I have updated the documentation accordingly, if necessary.
