### PR TITLE
Cannot connect to the database when the password has special characters

### DIFF
--- a/mRemoteNG/Config/DatabaseConnectors/MSSqlDatabaseConnector.cs
+++ b/mRemoteNG/Config/DatabaseConnectors/MSSqlDatabaseConnector.cs
@@ -53,12 +53,23 @@ namespace mRemoteNG.Config.DatabaseConnectors
 
         private void BuildDbConnectionStringWithCustomCredentials()
         {
-            _dbConnectionString = $"Data Source={_dbHost};Initial Catalog={_dbCatalog};User Id={_dbUsername};Password={_dbPassword}";
+            _dbConnectionString = new SqlConnectionStringBuilder
+            {
+                DataSource = _dbHost,
+                InitialCatalog = _dbCatalog,
+                UserID = _dbUsername,
+                Password = _dbPassword,
+            }.ToString();
         }
 
         private void BuildDbConnectionStringWithDefaultCredentials()
         {
-            _dbConnectionString = $"Data Source={_dbHost};Initial Catalog={_dbCatalog};Integrated Security=True";
+            _dbConnectionString = new SqlConnectionStringBuilder
+            {
+                DataSource = _dbHost,
+                InitialCatalog = _dbCatalog,
+                IntegratedSecurity = true
+            }.ToString();
         }
 
         public void Connect()


### PR DESCRIPTION
When the password contains special characters, it will be unable to connect to the database. Using "SqlConnectionStringBuilder" to construct "ConnectionString" can solve the problem


## Description
* Change mRemoteNG.Config.DatabaseConnectors.BuildDbConnectionStringWithCustomCredentials  
* Change mRemoteNG.Config.DatabaseConnectors.BuildDbConnectionStringWithDefaultCredentials



## Motivation and Context
For example, set password as "@;123qweqwe123"
Before  
```
"Data Source=fzyyxx.com;Initial Catalog=mRemoteNG;User Id=mng;Password=@;123qweqwe123"
```
After  
```
"Data Source=fzyyxx.com;Initial Catalog=mRemoteNG;User ID=mng;Password=\"@;123qweqwe123\""
```
The SqlConnectionStringBuilder performs checks for valid key/value pairs.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [X] All Tests within VisualStudio are passing
- [X] This pull request does not target the master branch.
- [X] I have updated the changelog file accordingly, if necessary.
- [X] I have updated the documentation accordingly, if necessary.
