### PR TITLE
Fix a break in the Windows Clipboard Chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - #1465: REGRESSION: Smart Cards redirection to Remote Desktop not working
 - #1337: Unhandled exception after closing mRemoteNG
 - #359: Making a VNC connection to an unreachable host causes the application to not respond for 20-30 seconds
+- #618: Do not break the Windows Clipboard Chain when exiting.
 
 ## [1.77.1] - 2019-09-02
 ### Added

--- a/mRemoteNG/App/NativeMethods.cs
+++ b/mRemoteNG/App/NativeMethods.cs
@@ -71,6 +71,12 @@ namespace mRemoteNG.App
         [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern IntPtr SetClipboardViewer(IntPtr hWndNewViewer);
 
+        [DllImport("User32.dll", CharSet = CharSet.Auto)]
+        internal static extern bool ChangeClipboardChain(
+            IntPtr hWndRemove,  // handle to window to remove
+            IntPtr hWndNewNext  // handle to next window
+        );
+
         [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern bool SetForegroundWindow(IntPtr hWnd);
 

--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -454,6 +454,7 @@ namespace mRemoteNG.UI.Forms
                 }
             }
 
+            NativeMethods.ChangeClipboardChain(Handle, _fpChainedWindowHandle);
             Shutdown.Cleanup(_quickConnectToolStrip, _externalToolsToolStrip, _multiSshToolStrip, this);
 
             Shutdown.StartUpdate();
@@ -583,9 +584,25 @@ namespace mRemoteNG.UI.Forms
                         _clipboardChangedEvent?.Invoke();
                         break;
                     case NativeMethods.WM_CHANGECBCHAIN:
-                        //Send to the next window
-                        NativeMethods.SendMessage(_fpChainedWindowHandle, m.Msg, m.LParam, m.WParam);
-                        _fpChainedWindowHandle = m.LParam;
+                        // When a clipboard viewer window receives the WM_CHANGECBCHAIN message, 
+                        // it should call the SendMessage function to pass the message to the 
+                        // next window in the chain, unless the next window is the window 
+                        // being removed. In this case, the clipboard viewer should save 
+                        // the handle specified by the lParam parameter as the next window in the chain. 
+                        //
+                        // wParam is the Handle to the window being removed from 
+                        // the clipboard viewer chain 
+                        // lParam is the Handle to the next window in the chain 
+                        // following the window being removed. 
+                        if (m.WParam == _fpChainedWindowHandle) {
+                            // If wParam is the next clipboard viewer then it
+                            // is being removed so update pointer to the next
+                            // window in the clipboard chain
+                            _fpChainedWindowHandle = m.LParam;
+                        } else {
+                            //Send to the next window
+                            NativeMethods.SendMessage(_fpChainedWindowHandle, m.Msg, m.LParam, m.WParam);
+                        }
                         break;
                 }
             }


### PR DESCRIPTION
## Description
This change fixes an issue where the application breaks the clipboard chain for other applications.  The way the windows clipboard works is that an application that adds itself to the chain must maintain the chain and appropriately remove itself from the chain when closing (otherwise the chain is broken).  

## Motivation and Context
This change is required because other applications that are also apart of the chain behind where mRemoteNG is inserted will suddenly stop receiving clipboard events.  This is most notable when one has a Clipboard Manager and those suddenly stop receiving clipboard events due to this application's use.
<!--- If it fixes an open issue, please link to the issue here. -->
The nearest issue I could find that somewhat relates to this is https://github.com/mRemoteNG/mRemoteNG/issues/618.  The reason this is a difficult issue to find is because of the nature of the clipboard chain and that one application can break another, and the tendency is to blame that other application.  I was able to narrow down the specific app to this one as the reason clipboard events suddenly stop.

## How Has This Been Tested?
Tested on Windows 7 and Windows 10.  Can be tested with any clipboard monitor, I also wrote my own clipboard listener to be sure.  Simply start a clipboard monitor and copy something to the clipboard to verify that app receives the text.  Then start mRemoteNG the clipboard will still continue to work (as this was handled correctly).  Then close mRemoteNG, now the clipboard doesn't work for the other application without resetting it.  This is because mRemoteNG is still registered as a clipboard listener on the chain but because it is closed it isn't passing on the message down the chain.  Additional issues occur when other applications send a removal message to mRemoteNG which didn't remove the message appropriately.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [x] I have updated the documentation accordingly, if necessary.
