### PR TITLE
fix a test case caused by property named "Prop_StartProgram" instead …

### DIFF
--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/MsSql/DataTableSerializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/MsSql/DataTableSerializer.cs
@@ -590,8 +590,8 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.MsSql
             dataRow["RdpVersion"] = connectionInfo.RdpVersion;
             dataRow["Favorite"] = connectionInfo.Favorite;
             dataRow["ICAEncryptionStrength"] = string.Empty;
-            dataRow["Prop_StartProgram"] = connectionInfo.StartProgram;
-            dataRow["Prop_StartProgramWorkDir"] = connectionInfo.StartProgramWorkDir;
+            dataRow["StartProgram"] = connectionInfo.StartProgram;
+            dataRow["StartProgramWorkDir"] = connectionInfo.StartProgramWorkDir;
 
             if (_saveFilter.SaveInheritance)
             {


### PR DESCRIPTION
…of "StartProgram"

this fixes around 10 of the automated test cases. not sure why this is "Prop_StartProgram" ... maybe an automated tool caused this?
