### PR TITLE
fix issue 2075 

### DIFF
--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsDeserializerMremotengFormat.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsDeserializerMremotengFormat.cs
@@ -190,12 +190,12 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Csv
                 ? connectionCsv[headers.IndexOf("RDGatewayHostname")]
                 : "";
 
-            connectionRecord.StartProgram = headers.Contains("StartProgram")
-                ? connectionCsv[headers.IndexOf("StartProgram")]
+            connectionRecord.RDPStartProgram = headers.Contains("RDPStartProgram")
+                ? connectionCsv[headers.IndexOf("RDPStartProgram")]
                 : "";
 
-            connectionRecord.StartProgramWorkDir = headers.Contains("StartProgramWorkDir")
-                ? connectionCsv[headers.IndexOf("StartProgramWorkDir")]
+            connectionRecord.RDPStartProgramWorkDir = headers.Contains("RDPStartProgramWorkDir")
+                ? connectionCsv[headers.IndexOf("RDPStartProgramWorkDir")]
                 : "";
 
             if (headers.Contains("Protocol"))

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsSerializerMremotengFormat.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsSerializerMremotengFormat.cs
@@ -61,12 +61,12 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Csv
                       "CacheBitmaps;RedirectDiskDrives;RedirectPorts;RedirectPrinters;RedirectClipboard;RedirectSmartCards;RedirectSound;RedirectKeys;" +
                       "PreExtApp;PostExtApp;MacAddress;UserField;ExtApp;Favorite;VNCCompression;VNCEncoding;VNCAuthMode;VNCProxyType;VNCProxyIP;" +
                       "VNCProxyPort;VNCProxyUsername;VNCProxyPassword;VNCColors;VNCSmartSizeMode;VNCViewOnly;RDGatewayUsageMethod;RDGatewayHostname;" +
-                      "RDGatewayUseConnectionCredentials;RDGatewayUsername;RDGatewayPassword;RDGatewayDomain;RedirectAudioCapture;RdpVersion;StartProgram;StartProgramWorkDir;");
+                      "RDGatewayUseConnectionCredentials;RDGatewayUsername;RDGatewayPassword;RDGatewayDomain;RedirectAudioCapture;RdpVersion;RDPStartProgram;RDPStartProgramWorkDir;");
 
             if (_saveFilter.SaveInheritance)
                 sb.Append("InheritCacheBitmaps;InheritColors;InheritDescription;InheritDisplayThemes;InheritDisplayWallpaper;" +
                           "InheritEnableFontSmoothing;InheritEnableDesktopComposition;InheritDisableFullWindowDrag;InheritDisableMenuAnimations;InheritDisableCursorShadow;InheritDisableCursorBlinking;InheritDomain;InheritIcon;InheritPanel;InheritPassword;InheritPort;" +
-                          "InheritProtocol;InheritSSHTunnelConnectionName;InheritSSHOptions;InheritPuttySession;InheritRedirectDiskDrives;InheritRedirectKeys;InheritRedirectPorts;InheritRedirectPrinters;" +
+                          "InheritProtocol;InheritSSHTunnelConnectionName;InheritOpeningCommand;InheritSSHOptions;InheritPuttySession;InheritRedirectDiskDrives;InheritRedirectKeys;InheritRedirectPorts;InheritRedirectPrinters;" +
                           "InheritRedirectClipboard;InheritRedirectSmartCards;InheritRedirectSound;InheritResolution;InheritAutomaticResize;" +
                           "InheritUseConsoleSession;InheritUseCredSsp;InheritUseVmId;InheritUseEnhancedMode;InheritVmId;InheritRenderingEngine;InheritUsername;" +
                           "InheritRDPAuthenticationLevel;InheritLoadBalanceInfo;InheritPreExtApp;InheritPostExtApp;InheritMacAddress;InheritUserField;" +
@@ -174,8 +174,8 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Csv
               .Append(FormatForCsv(con.RDGatewayDomain))
               .Append(FormatForCsv(con.RedirectAudioCapture))
               .Append(FormatForCsv(con.RdpVersion))
-              .Append(FormatForCsv(con.StartProgram))
-              .Append(FormatForCsv(con.StartProgramWorkDir));
+              .Append(FormatForCsv(con.RDPStartProgram))
+              .Append(FormatForCsv(con.RDPStartProgramWorkDir));
 
 
             if (!_saveFilter.SaveInheritance)

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/MsSql/DataTableDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/MsSql/DataTableDeserializer.cs
@@ -123,8 +123,8 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.MsSql
             connectionInfo.RedirectSound = (RDPSounds)Enum.Parse(typeof(RDPSounds), (string)dataRow["RedirectSound"]);
             connectionInfo.SoundQuality = (RDPSoundQuality)Enum.Parse(typeof(RDPSoundQuality), (string)dataRow["SoundQuality"]);
             connectionInfo.RedirectAudioCapture = (bool)dataRow["RedirectAudioCapture"];
-            connectionInfo.StartProgram = (string)dataRow["StartProgram"];
-            connectionInfo.StartProgramWorkDir = (string)dataRow["StartProgramWorkDir"];
+            connectionInfo.RDPStartProgram = (string)dataRow["StartProgram"];
+            connectionInfo.RDPStartProgramWorkDir = (string)dataRow["StartProgramWorkDir"];
             connectionInfo.RedirectKeys = (bool)dataRow["RedirectKeys"];
             connectionInfo.OpeningCommand = (string)dataRow["OpeningCommand"];
             connectionInfo.PreExtApp = (string)dataRow["PreExtApp"];

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/MsSql/DataTableSerializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/MsSql/DataTableSerializer.cs
@@ -323,8 +323,8 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.MsSql
              dataRow["SoundQuality"].Equals(connectionInfo.SoundQuality.ToString()) &&
              dataRow["RedirectAudioCapture"].Equals(connectionInfo.RedirectAudioCapture) &&
              dataRow["RedirectKeys"].Equals(connectionInfo.RedirectKeys) &&
-             dataRow["StartProgram"].Equals(connectionInfo.StartProgram) &&
-             dataRow["StartProgramWorkDir"].Equals(connectionInfo.StartProgramWorkDir);
+             dataRow["StartProgram"].Equals(connectionInfo.RDPStartProgram) &&
+             dataRow["StartProgramWorkDir"].Equals(connectionInfo.RDPStartProgramWorkDir);
 
             isFieldNotChange = isFieldNotChange &&
              dataRow["Connected"].Equals(false) && // TODO: this column can eventually be removed. we now save this property locally
@@ -590,8 +590,8 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.MsSql
             dataRow["RdpVersion"] = connectionInfo.RdpVersion;
             dataRow["Favorite"] = connectionInfo.Favorite;
             dataRow["ICAEncryptionStrength"] = string.Empty;
-            dataRow["StartProgram"] = connectionInfo.StartProgram;
-            dataRow["StartProgramWorkDir"] = connectionInfo.StartProgramWorkDir;
+            dataRow["StartProgram"] = connectionInfo.RDPStartProgram;
+            dataRow["StartProgramWorkDir"] = connectionInfo.RDPStartProgramWorkDir;
 
             if (_saveFilter.SaveInheritance)
             {

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer26.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer26.cs
@@ -99,7 +99,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
             element.Add(new XAttribute("MacAddress", connectionInfo.MacAddress));
             element.Add(new XAttribute("UserField", connectionInfo.UserField));
             element.Add(new XAttribute("ExtApp", connectionInfo.ExtApp));
-            element.Add(new XAttribute("StartProgram", connectionInfo.StartProgram));
+            element.Add(new XAttribute("StartProgram", connectionInfo.RDPStartProgram));
             element.Add(new XAttribute("VNCCompression", connectionInfo.VNCCompression));
             element.Add(new XAttribute("VNCEncoding", connectionInfo.VNCEncoding));
             element.Add(new XAttribute("VNCAuthMode", connectionInfo.VNCAuthMode));

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer27.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer27.cs
@@ -115,8 +115,8 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
             element.Add(new XAttribute("UserField", connectionInfo.UserField));
             element.Add(new XAttribute("Favorite", connectionInfo.Favorite));
             element.Add(new XAttribute("ExtApp", connectionInfo.ExtApp));
-            element.Add(new XAttribute("StartProgram", connectionInfo.StartProgram));
-            element.Add(new XAttribute("StartProgramWorkDir", connectionInfo.StartProgramWorkDir));
+            element.Add(new XAttribute("StartProgram", connectionInfo.RDPStartProgram));
+            element.Add(new XAttribute("StartProgramWorkDir", connectionInfo.RDPStartProgramWorkDir));
             element.Add(new XAttribute("VNCCompression", connectionInfo.VNCCompression));
             element.Add(new XAttribute("VNCEncoding", connectionInfo.VNCEncoding));
             element.Add(new XAttribute("VNCAuthMode", connectionInfo.VNCAuthMode));

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
@@ -541,13 +541,14 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
                     connectionInfo.SSHTunnelConnectionName = xmlnode.GetAttributeAsString("SSHTunnelConnectionName");
                     connectionInfo.OpeningCommand = xmlnode.GetAttributeAsString("OpeningCommand");
                     connectionInfo.SSHOptions = xmlnode.GetAttributeAsString("SSHOptions");
-                    connectionInfo.StartProgram = xmlnode.GetAttributeAsString("StartProgram");
+                    connectionInfo.RDPStartProgram = xmlnode.GetAttributeAsString("StartProgram");
+                    connectionInfo.RDPStartProgramWorkDir = xmlnode.GetAttributeAsString("StartProgramWorkDir");
                     connectionInfo.DisableFullWindowDrag = xmlnode.GetAttributeAsBool("DisableFullWindowDrag");
                     connectionInfo.DisableMenuAnimations = xmlnode.GetAttributeAsBool("DisableMenuAnimations");
                     connectionInfo.DisableCursorShadow = xmlnode.GetAttributeAsBool("DisableCursorShadow");
                     connectionInfo.DisableCursorBlinking = xmlnode.GetAttributeAsBool("DisableCursorBlinking");
-                    connectionInfo.StartProgram = xmlnode.GetAttributeAsString("StartProgram");
-                    connectionInfo.StartProgramWorkDir = xmlnode.GetAttributeAsString("StartProgramWorkDir");
+                    connectionInfo.RDPStartProgram = xmlnode.GetAttributeAsString("StartProgram");
+                    connectionInfo.RDPStartProgramWorkDir = xmlnode.GetAttributeAsString("StartProgramWorkDir");
                     connectionInfo.Inheritance.RedirectClipboard = xmlnode.GetAttributeAsBool("InheritRedirectClipboard");
                     connectionInfo.Inheritance.Favorite = xmlnode.GetAttributeAsBool("InheritFavorite");
                     connectionInfo.Inheritance.RdpVersion = xmlnode.GetAttributeAsBool("InheritRdpVersion");

--- a/mRemoteNG/Config/Serializers/MiscSerializers/RemoteDesktopConnectionDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/MiscSerializers/RemoteDesktopConnectionDeserializer.cs
@@ -152,7 +152,7 @@ namespace mRemoteNG.Config.Serializers.MiscSerializers
                     connectionInfo.RDGatewayHostname = value;
                     break;
                 case "alternate shell":
-                    connectionInfo.StartProgram = value;
+                    connectionInfo.RDPStartProgram = value;
                     break;
             }
         }

--- a/mRemoteNG/Config/Serializers/MiscSerializers/RemoteDesktopConnectionManagerDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/MiscSerializers/RemoteDesktopConnectionManagerDeserializer.cs
@@ -183,8 +183,8 @@ namespace mRemoteNG.Config.Serializers.MiscSerializers
             {
 				if (bool.TryParse(connectionSettingsNode.SelectSingleNode("./connectToConsole")?.InnerText, out var useConsole))
 					connectionInfo.UseConsoleSession = useConsole;
-                connectionInfo.StartProgram = connectionSettingsNode.SelectSingleNode("./startProgram")?.InnerText;
-                connectionInfo.StartProgramWorkDir = connectionSettingsNode.SelectSingleNode("./startProgramWorkDir")?.InnerText;
+                connectionInfo.RDPStartProgram = connectionSettingsNode.SelectSingleNode("./startProgram")?.InnerText;
+                connectionInfo.RDPStartProgramWorkDir = connectionSettingsNode.SelectSingleNode("./startProgramWorkDir")?.InnerText;
                 if (int.TryParse(connectionSettingsNode.SelectSingleNode("./port")?.InnerText, out var port))
 					connectionInfo.Port = port;
             }

--- a/mRemoteNG/Connection/AbstractConnectionRecord.cs
+++ b/mRemoteNG/Connection/AbstractConnectionRecord.cs
@@ -79,8 +79,8 @@ namespace mRemoteNG.Connection
         private string _macAddress;
         private string _openingCommand;
         private string _userField;
-        private string _startProgram;
-        private string _startProgramWorkDir;
+        private string _RDPStartProgram;
+        private string _RDPStartProgramWorkDir;
         private bool _favorite;
 
         private ProtocolVNC.Compression _vncCompression;
@@ -744,23 +744,23 @@ namespace mRemoteNG.Connection
         }
 
         [LocalizedAttributes.LocalizedCategory(nameof(Language.Miscellaneous), 7),
-         LocalizedAttributes.LocalizedDisplayName(nameof(Language.StartProgram)),
-         LocalizedAttributes.LocalizedDescription(nameof(Language.PropertyDescriptionStartProgram)),
+         LocalizedAttributes.LocalizedDisplayName(nameof(Language.RDPStartProgram)),
+         LocalizedAttributes.LocalizedDescription(nameof(Language.PropertyDescriptionRDPStartProgram)),
          AttributeUsedInProtocol(ProtocolType.RDP)]
-        public virtual string StartProgram
+        public virtual string RDPStartProgram
         {
-            get => GetPropertyValue("StartProgram", _startProgram);
-            set => SetField(ref _startProgram, value, "StartProgram");
+            get => GetPropertyValue("RDPStartProgram", _RDPStartProgram);
+            set => SetField(ref _RDPStartProgram, value, "RDPStartProgram");
         }
 
         [LocalizedAttributes.LocalizedCategory(nameof(Language.Miscellaneous), 7),
          LocalizedAttributes.LocalizedDisplayName(nameof(Language.RDPStartProgramWorkDir)),
          LocalizedAttributes.LocalizedDescription(nameof(Language.PropertyDescriptionRDPStartProgramWorkDir)),
          AttributeUsedInProtocol(ProtocolType.RDP)]
-        public virtual string StartProgramWorkDir
+        public virtual string RDPStartProgramWorkDir
         {
-            get => GetPropertyValue("StartProgramWorkDir", _startProgramWorkDir);
-            set => SetField(ref _startProgramWorkDir, value, "StartProgramWorkDir");
+            get => GetPropertyValue("RDPStartProgramWorkDir", _RDPStartProgramWorkDir);
+            set => SetField(ref _RDPStartProgramWorkDir, value, "RDPStartProgramWorkDir");
         }
 
         #endregion

--- a/mRemoteNG/Connection/ConnectionInfo.cs
+++ b/mRemoteNG/Connection/ConnectionInfo.cs
@@ -317,8 +317,8 @@ namespace mRemoteNG.Connection
 
         private void SetRemoteDesktopServicesDefaults()
         {
-            StartProgram = string.Empty;
-            StartProgramWorkDir = string.Empty;
+            RDPStartProgram = string.Empty;
+            RDPStartProgramWorkDir = string.Empty;
         }
 
         private void SetRdGatewayDefaults()
@@ -367,8 +367,8 @@ namespace mRemoteNG.Connection
             MacAddress = Settings.Default.ConDefaultMacAddress;
             UserField = Settings.Default.ConDefaultUserField;
             Favorite = Settings.Default.ConDefaultFavorite;
-            StartProgram = Settings.Default.ConDefaultStartProgram;
-            StartProgramWorkDir = Settings.Default.ConDefaultStartProgram;
+            RDPStartProgram = Settings.Default.ConDefaultRDPStartProgram;
+            RDPStartProgramWorkDir = Settings.Default.ConDefaultRDPStartProgram;
             OpeningCommand = Settings.Default.OpeningCommand;
         }
 

--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol6.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol6.cs
@@ -288,8 +288,8 @@ namespace mRemoteNG.Connection.Protocol.RDP
             _rdpClient.AdvancedSettings2.MinutesToIdleTimeout = connectionInfo.RDPMinutesToIdleTimeout;
 
             #region Remote Desktop Services
-            _rdpClient.SecuredSettings2.StartProgram = connectionInfo.StartProgram;
-            _rdpClient.SecuredSettings2.WorkDir = connectionInfo.StartProgramWorkDir;
+            _rdpClient.SecuredSettings2.StartProgram = connectionInfo.RDPStartProgram;
+            _rdpClient.SecuredSettings2.WorkDir = connectionInfo.RDPStartProgramWorkDir;
             #endregion
 
             //not user changeable

--- a/mRemoteNG/Language/Language.Designer.cs
+++ b/mRemoteNG/Language/Language.Designer.cs
@@ -4000,15 +4000,6 @@ namespace mRemoteNG.Resources.Language {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Start Program/alternate shell.
-        /// </summary>
-        internal static string PropertyDescriptionStartProgram {
-            get {
-                return ResourceManager.GetString("PropertyDescriptionStartProgram", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Connect to the console session of the remote host..
         /// </summary>
         internal static string PropertyDescriptionUseConsoleSession {
@@ -5610,15 +5601,6 @@ namespace mRemoteNG.Resources.Language {
         internal static string StartMinimized {
             get {
                 return ResourceManager.GetString("StartMinimized", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Start Program.
-        /// </summary>
-        internal static string StartProgram {
-            get {
-                return ResourceManager.GetString("StartProgram", resourceCulture);
             }
         }
         

--- a/mRemoteNG/Language/Language.fr.resx
+++ b/mRemoteNG/Language/Language.fr.resx
@@ -1687,10 +1687,10 @@ mRemoteNG va se fermer et l'installation va commencer.</value>
   <data name="TestConnection" xml:space="preserve">
     <value>Tester la connexion</value>
   </data>
-  <data name="PropertyDescriptionStartProgram" xml:space="preserve">
+  <data name="PropertyDescriptionRDPStartProgram" xml:space="preserve">
     <value>Démarrer un programme / un shell alternatif</value>
   </data>
-  <data name="StartProgram" xml:space="preserve">
+  <data name="RDPStartProgram" xml:space="preserve">
     <value>Démarrer un programme</value>
   </data>
   <data name="StackTrace" xml:space="preserve">

--- a/mRemoteNG/Language/Language.resx
+++ b/mRemoteNG/Language/Language.resx
@@ -2181,6 +2181,14 @@ Nightly Channel includes Alphas, Betas &amp; Release Candidates.</value>
     <value>Alternate shell working directory</value>
     <comment>https://docs.microsoft.com/en-us/windows/win32/termserv/imstscsecuredsettings-workdir</comment>
   </data>
+  <data name="OpeningCommand" xml:space="preserve">
+    <value>TODO</value>
+    <comment></comment>
+  </data>
+  <data name="PropertyDescriptionOpeningCommand" xml:space="preserve">
+    <value>TODO</value>
+  </data>
+
   <data name="RedirectDrives" xml:space="preserve">
     <value>Disk Drives</value>
   </data>

--- a/mRemoteNG/Properties/Settings.Designer.cs
+++ b/mRemoteNG/Properties/Settings.Designer.cs
@@ -3098,24 +3098,24 @@ namespace mRemoteNG.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string ConDefaultStartProgram {
+        public string ConDefaultRDPStartProgram {
             get {
-                return ((string)(this["ConDefaultStartProgram"]));
+                return ((string)(this["ConDefaultRDPStartProgram"]));
             }
             set {
-                this["ConDefaultStartProgram"] = value;
+                this["ConDefaultRDPStartProgram"] = value;
             }
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string ConDefaultStartProgramWorkDir {
+        public string ConDefaultRDPStartProgramWorkDir {
             get {
-                return ((string)(this["ConDefaultStartProgramWorkDir"]));
+                return ((string)(this["ConDefaultRDPStartProgramWorkDir"]));
             }
             set {
-                this["ConDefaultStartProgramWorkDir"] = value;
+                this["ConDefaultRDPStartProgramWorkDir"] = value;
             }
         }
         

--- a/mRemoteNG/Schemas/mremoteng_confcons_v2_7.xsd
+++ b/mRemoteNG/Schemas/mremoteng_confcons_v2_7.xsd
@@ -171,5 +171,6 @@
     <xs:attribute name="InheritRDGatewayDomain" type="xs:boolean" use="optional" />
     <xs:attribute name="StartProgram" type="xs:string" use="optional" />
     <xs:attribute name="StartProgramWorkDir" type="xs:string" use="optional" />
+    <xs:attribute name="OpeningCommand" type="xs:string" use="optional" />
   </xs:complexType>
 </xs:schema>

--- a/mRemoteNG/app.config
+++ b/mRemoteNG/app.config
@@ -791,10 +791,13 @@
       <setting name="ConDefaultDisableCursorBlinking" serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="ConDefaultStartProgram" serializeAs="String">
+      <setting name="ConDefaultRDPStartProgram" serializeAs="String">
         <value />
       </setting>
-      <setting name="ConDefaultStartProgramWorkDir" serializeAs="String">
+      <setting name="ConDefaultRDPStartProgramWorkDir" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="ConDefaultOpeningCommand" serializeAs="String">
         <value />
       </setting>
       <setting name="ConDefaultICAEncryptionStrength" serializeAs="String">

--- a/mRemoteNGTests/Config/Serializers/MiscSerializers/RemoteDesktopConnectionDeserializerTests.cs
+++ b/mRemoteNGTests/Config/Serializers/MiscSerializers/RemoteDesktopConnectionDeserializerTests.cs
@@ -178,7 +178,7 @@ namespace mRemoteNGTests.Config.Serializers.MiscSerializers
         public void StartProgramImportedCorrectly()
         {
             var connectionInfo = _connectionTreeModel.RootNodes.First().Children.First();
-            Assert.That(connectionInfo.StartProgram, Is.EqualTo(ExpectedStartProgram));
+            Assert.That(connectionInfo.RDPStartProgram, Is.EqualTo(ExpectedStartProgram));
         }
 
         //[Test]

--- a/mRemoteNGTests/Config/Serializers/MiscSerializers/RemoteDesktopConnectionManager27DeserializerTests.cs
+++ b/mRemoteNGTests/Config/Serializers/MiscSerializers/RemoteDesktopConnectionManager27DeserializerTests.cs
@@ -164,7 +164,7 @@ namespace mRemoteNGTests.Config.Serializers.MiscSerializers
 		        new TestCaseData((Func<ConnectionInfo,object>)(con => con.RedirectPrinters), ExpectedPrinterRedirection).SetName(nameof(ConnectionInfo.RedirectPrinters)),
 		        new TestCaseData((Func<ConnectionInfo,object>)(con => con.RedirectPorts), ExpectedPortRedirection).SetName(nameof(ConnectionInfo.RedirectPorts)),
 		        new TestCaseData((Func<ConnectionInfo,object>)(con => con.RedirectDiskDrives), ExpectedDriveRedirection).SetName(nameof(ConnectionInfo.RedirectDiskDrives)),
-		        new TestCaseData((Func<ConnectionInfo,object>)(con => con.StartProgram), ExpectedStartProgram).SetName(nameof(ConnectionInfo.StartProgram)),
+		        new TestCaseData((Func<ConnectionInfo,object>)(con => con.RDPStartProgram), ExpectedStartProgram).SetName(nameof(ConnectionInfo.RDPStartProgram)),
 			};
         }
 

--- a/mRemoteNGTests/Config/Serializers/MiscSerializers/RemoteDesktopConnectionManagerDeserializerTests.cs
+++ b/mRemoteNGTests/Config/Serializers/MiscSerializers/RemoteDesktopConnectionManagerDeserializerTests.cs
@@ -330,7 +330,7 @@ namespace mRemoteNGTests.Config.Serializers.MiscSerializers
             var importedRdcmanRootNode = rootNode.Children.OfType<ContainerInfo>().First();
             var group1 = importedRdcmanRootNode.Children.OfType<ContainerInfo>().First(node => node.Name == "Group1");
             var connection = group1.Children.First();
-            Assert.That(connection.StartProgram, Is.EqualTo(ExpectedStartProgram));
+            Assert.That(connection.RDPStartProgram, Is.EqualTo(ExpectedStartProgram));
         }
     }
 }

--- a/mRemoteNGTests/TestHelpers/SerializableConnectionInfoAllPropertiesOfType.cs
+++ b/mRemoteNGTests/TestHelpers/SerializableConnectionInfoAllPropertiesOfType.cs
@@ -72,8 +72,8 @@
         public TType UseEnhancedMode { get; set; }
         public TType SSHOptions { get; set; }
         public TType SSHTunnelConnectionName { get; set; }
-        public TType StartProgram { get; set; }
-        public TType StartProgramWorkDir { get; set; }
+        public TType RDPStartProgram { get; set; }
+        public TType RDPStartProgramWorkDir { get; set; }
 		public TType OpeningCommand { get; set; }
 	}
 }

--- a/mRemoteNGTests/UI/Window/ConfigWindowTests/ConfigWindowGeneralTests.cs
+++ b/mRemoteNGTests/UI/Window/ConfigWindowTests/ConfigWindowGeneralTests.cs
@@ -261,8 +261,8 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                         nameof(ConnectionInfo.RedirectAudioCapture),
 						nameof(ConnectionInfo.RdpVersion),
                         nameof(ConnectionInfo.OpeningCommand),
-                        nameof(ConnectionInfo.StartProgram),
-                        nameof(ConnectionInfo.StartProgramWorkDir)
+                        nameof(ConnectionInfo.RDPStartProgram),
+                        nameof(ConnectionInfo.RDPStartProgramWorkDir)
                     });
                     break;
                 case ProtocolType.VNC:


### PR DESCRIPTION
by standardizing "StartProgram" Property to "RDPStartProgram" and "StartProgramWorkDir" to "RDPStartProgramWorkDir"

## Description
seems there was an inconsistency between properties and language files, "StartProgram" and "RDPStartProgram" both existed. this change removes "StartProgram" entirely. i hope this was the intention in the first place?

## Motivation and Context
fix issue https://github.com/mRemoteNG/mRemoteNG/issues/2075

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [X] Changed feature (**breaking** change which changes functionality)  <- need to check, how to handle schemas and data tables in the future. new xml version required? right now i tried not to touch the row/column names or the xml schema, only the code internal properties are renamed to fix the ui crashes.
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation
