### PR TITLE
Use async HttpClient instead of obsolete WebClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
+- #2086: Replace WebClient with async HttpClient for updater.
 - #1850: Minify config xml
 - #1770: Added missing RDP performance settings
 - #1516: added API to access credential vault (Thycotic Secret Server) by specifying SSAPI:ID as username
@@ -38,7 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - #1720: Show configuration file name in title of password prompt form
 - #1713: Sound redirection does not work if Clipboard redirection is set to No
 - #1632: 1.77.1 breaks RDP drive and sound redirection
-- #1610: Menu bar changes to english when cancelling options form
+- #1610: Menu bar changes to english when canceling options form
 - #1595: Unhandled exception when trying to browse through non existent multi ssh history with keyboard key strokes
 - #1589: Update SQL tables instead of rewriting them
 - #1465: REGRESSION: Smart Cards redirection to Remote Desktop not working

--- a/mRemoteNG/App/Startup.cs
+++ b/mRemoteNG/App/Startup.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.Threading.Tasks;
 using mRemoteNG.App.Info;
 using mRemoteNG.App.Initialization;
 using mRemoteNG.App.Update;
@@ -65,7 +66,7 @@ namespace mRemoteNG.App
             Runtime.ConnectionsService.RemoteConnectionsSyncronizer.Enable();
         }
 
-        public async void CheckForUpdate()
+        public async Task CheckForUpdate()
         {
             if (_appUpdate == null)
             {

--- a/mRemoteNG/App/Startup.cs
+++ b/mRemoteNG/App/Startup.cs
@@ -65,7 +65,7 @@ namespace mRemoteNG.App
             Runtime.ConnectionsService.RemoteConnectionsSyncronizer.Enable();
         }
 
-        public void CheckForUpdate()
+        public async void CheckForUpdate()
         {
             if (_appUpdate == null)
             {
@@ -87,32 +87,9 @@ namespace mRemoteNG.App
                 return;
             }
 
-            _appUpdate.GetUpdateInfoCompletedEvent += GetUpdateInfoCompleted;
-            _appUpdate.GetUpdateInfoAsync();
-        }
-
-        private void GetUpdateInfoCompleted(object sender, AsyncCompletedEventArgs e)
-        {
-            if (_frmMain.InvokeRequired)
-            {
-                _frmMain.Invoke(new AsyncCompletedEventHandler(GetUpdateInfoCompleted), sender, e);
-                return;
-            }
-
             try
             {
-                _appUpdate.GetUpdateInfoCompletedEvent -= GetUpdateInfoCompleted;
-
-                if (e.Cancelled)
-                {
-                    return;
-                }
-
-                if (e.Error != null)
-                {
-                    throw e.Error;
-                }
-
+                await _appUpdate.GetUpdateInfoAsync();
                 if (_appUpdate.IsUpdateAvailable())
                 {
                     Windows.Show(WindowType.Update);
@@ -120,7 +97,7 @@ namespace mRemoteNG.App
             }
             catch (Exception ex)
             {
-                Runtime.MessageCollector.AddExceptionMessage("GetUpdateInfoCompleted() failed.", ex);
+                Runtime.MessageCollector.AddExceptionMessage("CheckForUpdate() failed.", ex);
             }
         }
     }

--- a/mRemoteNG/App/Update/AppUpdater.cs
+++ b/mRemoteNG/App/Update/AppUpdater.cs
@@ -38,7 +38,6 @@ namespace mRemoteNG.App.Update
             get
             {
                 return _getUpdateInfoCancelToken != null;
-
             }
         }
 

--- a/mRemoteNG/App/Update/AppUpdater.cs
+++ b/mRemoteNG/App/Update/AppUpdater.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Net;
-using System.ComponentModel;
 using System.Net.Http;
 using System.Threading;
-using System.Reflection;
 using mRemoteNG.App.Info;
 using mRemoteNG.Security.SymmetricEncryption;
 using System.Security.Cryptography;

--- a/mRemoteNG/UI/Forms/OptionsPages/UpdatesPage.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/UpdatesPage.cs
@@ -159,8 +159,6 @@ namespace mRemoteNG.UI.Forms.OptionsPages
 
         #endregion
 
-        #region Private Methods
-
         #region Event Handlers
 
         private void chkCheckForUpdatesOnStartup_CheckedChanged(object sender, EventArgs e)
@@ -194,7 +192,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             }
         }
 
-        private void btnTestProxy_Click(object sender, EventArgs e)
+        private async void btnTestProxy_Click(object sender, EventArgs e)
         {
             if (_appUpdate != null)
             {
@@ -210,13 +208,27 @@ namespace mRemoteNG.UI.Forms.OptionsPages
                                         (int)numProxyPort.Value, chkUseProxyAuthentication.Checked,
                                         txtProxyUsername.Text,
                                         txtProxyPassword.Text);
+            try
+            {
+                btnTestProxy.Enabled = false;
+                btnTestProxy.Text = Language.OptionsProxyTesting;
 
-            btnTestProxy.Enabled = false;
-            btnTestProxy.Text = Language.OptionsProxyTesting;
+                await _appUpdate.GetUpdateInfoAsync();
 
-            _appUpdate.GetUpdateInfoCompletedEvent += GetUpdateInfoCompleted;
+                btnTestProxy.Enabled = true;
+                btnTestProxy.Text = Language.TestProxy;
+                CTaskDialog.ShowCommandBox(this, Application.ProductName, Language.ProxyTestSucceeded, "",
+                    Language._Ok, false);
+            }
+            catch (Exception ex)
+            {
+                CTaskDialog.ShowCommandBox(this, Application.ProductName, Language.ProxyTestFailed,
+                    MiscTools.GetExceptionMessageRecursive(ex), "", "", "", Language._Ok,
+                    false,
+                    ESysIcons.Error,
+                    0);
+            }
 
-            _appUpdate.GetUpdateInfoAsync();
         }
 
         private void chkUseProxyAuthentication_CheckedChanged(object sender, EventArgs e)
@@ -224,47 +236,6 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             if (chkUseProxyForAutomaticUpdates.Checked)
             {
                 tblProxyAuthentication.Enabled = chkUseProxyAuthentication.Checked;
-            }
-        }
-
-        #endregion
-
-        private void GetUpdateInfoCompleted(object sender, AsyncCompletedEventArgs e)
-        {
-            if (InvokeRequired)
-            {
-                AsyncCompletedEventHandler myDelegate = GetUpdateInfoCompleted;
-                Invoke(myDelegate, sender, e);
-                return;
-            }
-
-            try
-            {
-                _appUpdate.GetUpdateInfoCompletedEvent -= GetUpdateInfoCompleted;
-
-                btnTestProxy.Enabled = true;
-                btnTestProxy.Text = Language.TestProxy;
-
-                if (e.Cancelled)
-                {
-                    return;
-                }
-
-                if (e.Error != null)
-                {
-                    throw e.Error;
-                }
-
-                CTaskDialog.ShowCommandBox(this, Application.ProductName, Language.ProxyTestSucceeded, "",
-                                           Language._Ok, false);
-            }
-            catch (Exception ex)
-            {
-                CTaskDialog.ShowCommandBox(this, Application.ProductName, Language.ProxyTestFailed,
-                                           MiscTools.GetExceptionMessageRecursive(ex), "", "", "", Language._Ok,
-                                           false,
-                                           ESysIcons.Error,
-                                           0);
             }
         }
 

--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -25,6 +25,7 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using mRemoteNG.UI.Panels;
 using WeifenLuo.WinFormsUI.Docking;
@@ -342,7 +343,7 @@ namespace mRemoteNG.UI.Forms
         private async void frmMain_Shown(object sender, EventArgs e)
         {
             PromptForUpdatesPreference();
-            CheckForUpdates();
+            await CheckForUpdates();
         }
 
         private void PromptForUpdatesPreference()
@@ -374,7 +375,7 @@ namespace mRemoteNG.UI.Forms
             }
         }
 
-        private async void CheckForUpdates()
+        private async Task CheckForUpdates()
         {
             if (!Settings.Default.CheckForUpdatesOnStartup) return;
 
@@ -385,7 +386,7 @@ namespace mRemoteNG.UI.Forms
             if (!IsHandleCreated)
                 CreateHandle(); // Make sure the handle is created so that InvokeRequired returns the correct result
 
-            Startup.Instance.CheckForUpdate();
+            await Startup.Instance.CheckForUpdate();
         }
 
         private void frmMain_FormClosing(object sender, FormClosingEventArgs e)

--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -339,7 +339,7 @@ namespace mRemoteNG.UI.Forms
             }
         }
 
-        private void frmMain_Shown(object sender, EventArgs e)
+        private async void frmMain_Shown(object sender, EventArgs e)
         {
             PromptForUpdatesPreference();
             CheckForUpdates();
@@ -374,7 +374,7 @@ namespace mRemoteNG.UI.Forms
             }
         }
 
-        private void CheckForUpdates()
+        private async void CheckForUpdates()
         {
             if (!Settings.Default.CheckForUpdatesOnStartup) return;
 

--- a/mRemoteNG/UI/Window/UpdateWindow.cs
+++ b/mRemoteNG/UI/Window/UpdateWindow.cs
@@ -44,7 +44,7 @@ namespace mRemoteNG.UI.Window
             ApplyTheme();
             ThemeManager.getInstance().ThemeChanged += ApplyTheme;
             ApplyLanguage();
-            CheckForUpdateAsync();
+            await CheckForUpdateAsync();
         }
 
         private new void ApplyTheme()
@@ -73,9 +73,9 @@ namespace mRemoteNG.UI.Window
             lblLatestVersionLabel.Text = $"{Language.AvailableVersion}:";
         }
 
-        private void btnCheckForUpdate_Click(object sender, EventArgs e)
+        private async void btnCheckForUpdate_Click(object sender, EventArgs e)
         {
-            CheckForUpdateAsync();
+            await CheckForUpdateAsync();
         }
 
         private async void btnDownload_Click(object sender, EventArgs e)
@@ -98,7 +98,7 @@ namespace mRemoteNG.UI.Window
 
         #region Private Methods
 
-        private async void CheckForUpdateAsync()
+        private async Task CheckForUpdateAsync()
         {
             if (_appUpdate == null)
             {

--- a/mRemoteNG/UI/Window/UpdateWindow.cs
+++ b/mRemoteNG/UI/Window/UpdateWindow.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
-using System.Net;
 using System.Windows.Forms;
 using mRemoteNG.App;
 using mRemoteNG.App.Update;


### PR DESCRIPTION
## Description

- Corrected the warnings related to **WebClient** by replacing it with **System.Net.Http**.
- Rewritten a lot of code in AppUpdater.cs to support HttpClient and removed legacy or unused code (e.g. Event-based Asynchronous Pattern (EAP)) and replaced it with APM (Asynchronous Programming Model). Unfortunately, there were no unit tests for HTTP layer, so I haven't added mine.
- Several event handlers were converted from "public void" to "public async void", where other used methods return "async Task" or "async string/int".
- I have also removed some region directives, because they are empty now. I can return them back if needed.

## Motivation and Context
Removes obsolete WebClient. Wanted to help the project.

## How Has This Been Tested?
Manually:
1. Change the assembly version to something old;
2. Start the application and either download the new update, or check whether the new update is available.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
