### PR TITLE
Corrected encryption code of LegacyRijndaelCryptographyProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,16 +31,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - #1690: Replaced GeckoFX (Firefox) with CefSharp (Chromium)
 - #1325: Language resource files cleanup
 ### Fixed
+- #2096: Corrected encryption code of LegacyRijndaelCryptographyProvider
 - #2087: Fixed application crash, when the update file is launched from the application
 - #2079: Fixed theme files not being copied to output directory
 - #1884: Allow setting Port when using MSSQL
 - #1783: Added missing inheritance properties to SQL scripts
-- #1773: Connection issue with mysql - Missing fields in 
+- #1773: Connection issue with MySql - Missing fields in
 - #1756: Cannot type any character on MultiSSH toolbar 
 - #1720: Show configuration file name in title of password prompt form
 - #1713: Sound redirection does not work if Clipboard redirection is set to No
 - #1632: 1.77.1 breaks RDP drive and sound redirection
-- #1610: Menu bar changes to english when canceling options form
+- #1610: Menu bar changes to English when canceling options form
 - #1595: Unhandled exception when trying to browse through non existent multi ssh history with keyboard key strokes
 - #1589: Update SQL tables instead of rewriting them
 - #1465: REGRESSION: Smart Cards redirection to Remote Desktop not working


### PR DESCRIPTION
## Description
I apologize, but my improvement PR #2081 has broke a single test in LegacyRijndaelCryptographyProviderTests, and I spent few evenings to understand this.

## Motivation and Context
Because the old PR broke the code.

## How Has This Been Tested?
Tests in LegacyRijndaelCryptographyProviderTests should be green now.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
