### PR TITLE
Fix failed tests related to mRemoteNGTests.UI.Window.ConfigWindowTests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - #1690: Replaced GeckoFX (Firefox) with CefSharp (Chromium)
 - #1325: Language resource files cleanup
 ### Fixed
+- #2097: Fix failed tests related to mRemoteNGTests.UI.Window.ConfigWindowTests
 - #2096: Corrected encryption code of LegacyRijndaelCryptographyProvider
 - #2089: Fixed the exception thrown by menu buttons "Documentation" and "Website"
 - #2087: Fixed application crash, when the update file is launched from the application

--- a/mRemoteNGTests/UI/Window/ConfigWindowTests/ConfigWindowGeneralTests.cs
+++ b/mRemoteNGTests/UI/Window/ConfigWindowTests/ConfigWindowGeneralTests.cs
@@ -212,8 +212,7 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                 nameof(ConnectionInfo.MacAddress),
                 nameof(ConnectionInfo.UserField),
                 nameof(ConnectionInfo.Favorite),
-                nameof(ConnectionInfo.SSHTunnelConnectionName),
-                nameof(ConnectionInfo.OpeningCommand),
+                nameof(ConnectionInfo.SSHTunnelConnectionName)
             };
 
             if (!isContainer)
@@ -260,7 +259,6 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                         nameof(ConnectionInfo.RedirectSound),
                         nameof(ConnectionInfo.RedirectAudioCapture),
 						nameof(ConnectionInfo.RdpVersion),
-                        nameof(ConnectionInfo.OpeningCommand),
                         nameof(ConnectionInfo.RDPStartProgram),
                         nameof(ConnectionInfo.RDPStartProgramWorkDir)
                     });
@@ -282,7 +280,8 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                         nameof(ConnectionInfo.Password),
                         nameof(ConnectionInfo.Port),
                         nameof(ConnectionInfo.SSHOptions),
-                        nameof(ConnectionInfo.PuttySession)
+                        nameof(ConnectionInfo.PuttySession),
+                        nameof(ConnectionInfo.OpeningCommand)
                     });
                     break;
                 case ProtocolType.Telnet:


### PR DESCRIPTION
## Description
The menu item OpeningCommand is related to SSH1/SSH2. Previously it was tested for RDP.
Practically, this command was removed from the single file (see the commit), and added for SSH1/2 only.

## Motivation and Context
Fix failed tests

## How Has This Been Tested?
VS 2022

## Screenshots (if appropriate):
![everything is green](https://user-images.githubusercontent.com/1671049/147157610-363efa89-969e-4021-9d27-463d0a2a3c23.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
