### PR TITLE
Fix failed BinaryFileTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - #1690: Replaced GeckoFX (Firefox) with CefSharp (Chromium)
 - #1325: Language resource files cleanup
 ### Fixed
+- #2098: Fix failed BinaryFileTest
 - #2096: Corrected encryption code of LegacyRijndaelCryptographyProvider
 - #2089: Fixed the exception thrown by menu buttons "Documentation" and "Website"
 - #2087: Fixed application crash, when the update file is launched from the application

--- a/mRemoteNGTests/BinaryFileTests.cs
+++ b/mRemoteNGTests/BinaryFileTests.cs
@@ -17,14 +17,14 @@ namespace mRemoteNGTests
         public string GetTargetPath([CallerFilePath] string sourceFilePath = "")
         {
             const string debugOrRelease =
-            #if DEBUG
+            #if DEBUG || DEBUG_PORTABLE
 				"Debug";
             #else
 				"Release";
             #endif
 
             const string normalOrPortable =
-            #if PORTABLE
+            #if PORTABLE || DEBUG_PORTABLE
                 " Portable";
             #else
             "";


### PR DESCRIPTION
## Description
mRemoteNGTests doesn't define "DEBUG" and "PORTABLE", but defines "DEBUG_PORTABLE" macro.
The change is to add the mentioned macro as well.

## Motivation and Context
Fix failed tests

## How Has This Been Tested?
VS 2022

## Screenshots (if appropriate):
![Previously, it though that we use Release build](https://user-images.githubusercontent.com/1671049/147158177-16bfd9ee-3e49-4e6a-8e36-ae0471eea653.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
