### PR TITLE
external connectors update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - #327: Added Alternative Shell for RDP settings
 - #319: Override quick connect username when using user@domain
 - #283: Support for native PowerShell remoting as new protocol
+- #xxx: Add external connector to retrieve ip address from Amazon EC2 Instance IDs
 ### Changed
 - #2022: Replaced CefSharp with WebView2
 - #2014: Revised icons
@@ -30,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - #1767: Turned about window into a simple popup form
 - #1690: Replaced GeckoFX (Firefox) with CefSharp (Chromium)
 - #1325: Language resource files cleanup
+- #xxxx: Secret Server connector via new field "API User ID" instead of SSAPI: prefix
 ### Fixed
 - #2097: Fix failed tests related to mRemoteNGTests.UI.Window.ConfigWindowTests
 - #2096: Corrected encryption code of LegacyRijndaelCryptographyProvider

--- a/ExternalConnectors/AWS/AWSConnectionForm.Designer.cs
+++ b/ExternalConnectors/AWS/AWSConnectionForm.Designer.cs
@@ -33,8 +33,6 @@
             this.btnOK = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.tbRegion = new System.Windows.Forms.TextBox();
-            this.label3 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
@@ -45,29 +43,29 @@
             // tbAccesKeyID
             // 
             this.tbAccesKeyID.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tbAccesKeyID.Location = new System.Drawing.Point(260, 7);
-            this.tbAccesKeyID.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
+            this.tbAccesKeyID.Location = new System.Drawing.Point(152, 4);
+            this.tbAccesKeyID.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tbAccesKeyID.Name = "tbAccesKeyID";
-            this.tbAccesKeyID.Size = new System.Drawing.Size(842, 35);
+            this.tbAccesKeyID.Size = new System.Drawing.Size(490, 23);
             this.tbAccesKeyID.TabIndex = 0;
             // 
             // tbAccesKey
             // 
             this.tbAccesKey.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tbAccesKey.Location = new System.Drawing.Point(260, 86);
-            this.tbAccesKey.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
+            this.tbAccesKey.Location = new System.Drawing.Point(152, 43);
+            this.tbAccesKey.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tbAccesKey.Name = "tbAccesKey";
-            this.tbAccesKey.Size = new System.Drawing.Size(842, 35);
+            this.tbAccesKey.Size = new System.Drawing.Size(490, 23);
             this.tbAccesKey.TabIndex = 2;
             // 
             // btnOK
             // 
             this.btnOK.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btnOK.Location = new System.Drawing.Point(378, 23);
-            this.btnOK.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
+            this.btnOK.Location = new System.Drawing.Point(219, 12);
+            this.btnOK.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnOK.Name = "btnOK";
-            this.btnOK.Size = new System.Drawing.Size(150, 53);
+            this.btnOK.Size = new System.Drawing.Size(88, 26);
             this.btnOK.TabIndex = 10;
             this.btnOK.Text = "OK";
             this.btnOK.UseVisualStyleBackColor = true;
@@ -76,10 +74,10 @@
             // 
             this.btnCancel.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(580, 23);
-            this.btnCancel.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
+            this.btnCancel.Location = new System.Drawing.Point(338, 12);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(150, 53);
+            this.btnCancel.Size = new System.Drawing.Size(88, 26);
             this.btnCancel.TabIndex = 11;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
@@ -89,54 +87,31 @@
             this.tableLayoutPanel1.ColumnCount = 2;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 22.92994F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 77.07006F));
-            this.tableLayoutPanel1.Controls.Add(this.tbRegion, 1, 2);
-            this.tableLayoutPanel1.Controls.Add(this.label3, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.label2, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.tbAccesKeyID, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.tbAccesKey, 1, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Top;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 3;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 46F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 46F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 46F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1108, 205);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 23F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 23F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 23F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(646, 102);
             this.tableLayoutPanel1.TabIndex = 12;
-            // 
-            // tbRegion
-            // 
-            this.tbRegion.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tbRegion.Location = new System.Drawing.Point(260, 165);
-            this.tbRegion.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
-            this.tbRegion.Name = "tbRegion";
-            this.tbRegion.Size = new System.Drawing.Size(842, 35);
-            this.tbRegion.TabIndex = 6;
-            // 
-            // label3
-            // 
-            this.label3.AutoSize = true;
-            this.label3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label3.Location = new System.Drawing.Point(6, 158);
-            this.label3.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(242, 47);
-            this.label3.TabIndex = 5;
-            this.label3.Text = "Region";
-            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
             this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label1.Location = new System.Drawing.Point(6, 0);
-            this.label1.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.label1.Location = new System.Drawing.Point(4, 0);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(242, 79);
+            this.label1.Size = new System.Drawing.Size(140, 39);
             this.label1.TabIndex = 2;
             this.label1.Text = "Access Key ID";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -145,10 +120,10 @@
             // 
             this.label2.AutoSize = true;
             this.label2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label2.Location = new System.Drawing.Point(6, 79);
-            this.label2.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.label2.Location = new System.Drawing.Point(4, 39);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(242, 79);
+            this.label2.Size = new System.Drawing.Size(140, 39);
             this.label2.TabIndex = 4;
             this.label2.Text = "Access Key";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -156,31 +131,31 @@
             // tableLayoutPanel2
             // 
             this.tableLayoutPanel2.ColumnCount = 5;
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 160F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 93F));
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 23F));
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 160F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 93F));
             this.tableLayoutPanel2.Controls.Add(this.btnOK, 1, 0);
             this.tableLayoutPanel2.Controls.Add(this.btnCancel, 3, 0);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 344);
-            this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 112);
+            this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 1;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(1108, 99);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(646, 50);
             this.tableLayoutPanel2.TabIndex = 13;
             // 
             // AWSConnectionForm
             // 
             this.AcceptButton = this.btnOK;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 30F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1108, 443);
+            this.ClientSize = new System.Drawing.Size(646, 162);
             this.Controls.Add(this.tableLayoutPanel2);
             this.Controls.Add(this.tableLayoutPanel1);
-            this.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "AWSConnectionForm";
             this.Text = "AWS EC2 API Login Data";
             this.Activated += new System.EventHandler(this.AWSConnectionForm_Activated);
@@ -201,7 +176,5 @@
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
-        public System.Windows.Forms.TextBox tbRegion;
-        private System.Windows.Forms.Label label3;
     }
 }

--- a/ExternalConnectors/AWS/EC2FetchDataService.cs
+++ b/ExternalConnectors/AWS/EC2FetchDataService.cs
@@ -11,7 +11,7 @@ namespace ExternalConnectors.AWS
         private static List<InstanceInfo>? lastData;
 
         // input must be in format "AWSAPI:instanceid" where instanceid is the ec2 instance id, e.g. i-066f750a76c97583d
-        public static async Task<string> GetEC2InstanceDataAsync(string input)
+        public static async Task<string> GetEC2InstanceDataAsync(string input, string region)
         {
             // get secret id
             if (!input.StartsWith("AWSAPI:"))
@@ -20,19 +20,20 @@ namespace ExternalConnectors.AWS
 
             // init connection credentials, display popup if necessary
             AWSConnectionData.Init();
-            var alldata = await GetEC2IPDataAsync();
+            var alldata = await GetEC2IPDataAsync(region);
             var found = alldata.Where(x => x.InstanceId == InstanceID).SingleOrDefault();
             return (found == null) ? "" : found.PublicIP;
         }
 
-        private static async Task<List<InstanceInfo>> GetEC2IPDataAsync()
+        private static async Task<List<InstanceInfo>> GetEC2IPDataAsync(string region)
         {
             // caching
             TimeSpan timeSpan = DateTime.Now - lastFetch;
             if (timeSpan.TotalMinutes < 1 && lastData != null)
                 return lastData;
 
-            AWSConfigs.AWSRegion = AWSConnectionData.region;
+            //AWSConfigs.AWSRegion = AWSConnectionData.region;
+            AWSConfigs.AWSRegion = region;
             string awsAccessKeyId = AWSConnectionData.awsKeyID;
             string awsSecretAccessKey = AWSConnectionData.awsKey;
 
@@ -82,20 +83,19 @@ namespace ExternalConnectors.AWS
 
             public static string awsKeyID = "";
             public static string awsKey = "";
-            public static string region = "eu-central-1";
+            //public static string _region = "eu-central-1";
 
             public static void Init()
             {
                 if (awsKey != "")
                     return;
-
                 // display gui and ask for data
                 AWSConnectionForm f = new();
                 f.tbAccesKeyID.Text = "" + key.GetValue("KeyID");
                 f.tbAccesKey.Text = "" + key.GetValue("Key");
-                f.tbRegion.Text = "" + key.GetValue("Region");
-                if (f.tbRegion.Text == null || f.tbRegion.Text.Length < 2)
-                    f.tbRegion.Text = region;
+                //f.tbRegion.Text = "" + key.GetValue("Region");
+                //if (f.tbRegion.Text == null || f.tbRegion.Text.Length < 2)
+                //    f.tbRegion.Text = region;
                 _ = f.ShowDialog();
 
                 if (f.DialogResult != DialogResult.OK)
@@ -104,13 +104,13 @@ namespace ExternalConnectors.AWS
                 // store values to memory
                 awsKeyID = f.tbAccesKeyID.Text;
                 awsKey = f.tbAccesKey.Text;
-                region = f.tbRegion.Text;
+                //region = f.tbRegion.Text;
 
 
                 // write values to registry
                 key.SetValue("KeyID", awsKeyID);
                 key.SetValue("Key", awsKey);
-                key.SetValue("Region", region);
+                //key.SetValue("Region", region);
                 key.Close();
             }
         }

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer27.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer27.cs
@@ -150,6 +150,10 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
             element.Add(_saveFilter.SaveDomain
                 ? new XAttribute("RDGatewayDomain", connectionInfo.RDGatewayDomain)
                 : new XAttribute("RDGatewayDomain", ""));
+
+            element.Add(new XAttribute("UserViaAPI", connectionInfo.UserViaAPI));
+            element.Add(new XAttribute("EC2InstanceId", connectionInfo.EC2InstanceId));
+            element.Add(new XAttribute("EC2Region", connectionInfo.EC2Region));
         }
 
         private void SetInheritanceAttributes(XContainer element, IInheritable connectionInfo)
@@ -292,6 +296,8 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
                     element.Add(new XAttribute("InheritUseVmId", inheritance.UseVmId.ToString().ToLowerInvariant()));
                 if (inheritance.UseEnhancedMode)
                     element.Add(new XAttribute("InheritUseEnhancedMode", inheritance.UseEnhancedMode.ToString().ToLowerInvariant()));
+                if (inheritance.UserViaAPI)
+                    element.Add(new XAttribute("InheritUserViaAPI", inheritance.UserViaAPI.ToString().ToLowerInvariant()));
             }
         }
     }

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
@@ -562,8 +562,11 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
                     connectionInfo.Inheritance.DisableMenuAnimations = xmlnode.GetAttributeAsBool("InheritDisableMenuAnimations");
                     connectionInfo.Inheritance.DisableCursorShadow = xmlnode.GetAttributeAsBool("InheritDisableCursorShadow");
                     connectionInfo.Inheritance.DisableCursorBlinking = xmlnode.GetAttributeAsBool("InheritDisableCursorBlinking");
+                    connectionInfo.UserViaAPI = xmlnode.GetAttributeAsString("UserViaAPI");
+                    connectionInfo.Inheritance.UserViaAPI = xmlnode.GetAttributeAsBool("InheritUserViaAPI");
+                    connectionInfo.EC2InstanceId = xmlnode.GetAttributeAsString("EC2InstanceId");
+                    connectionInfo.EC2Region = xmlnode.GetAttributeAsString("EC2Region");
                 }
-                
             }
             catch (Exception ex)
             {

--- a/mRemoteNG/Connection/AbstractConnectionRecord.cs
+++ b/mRemoteNG/Connection/AbstractConnectionRecord.cs
@@ -22,6 +22,9 @@ namespace mRemoteNG.Connection
         private string _panel;
 
         private string _hostname;
+        private string _ec2InstanceId = "";
+        private string _ec2Region = "";
+        private string _userViaAPI = "";
         private string _username = "";
         private string _password = "";
         private string _domain = "";
@@ -163,9 +166,18 @@ namespace mRemoteNG.Connection
         }
 
         [LocalizedAttributes.LocalizedCategory(nameof(Language.Connection), 2),
+         LocalizedAttributes.LocalizedDisplayName(nameof(Language.UserViaAPI)),
+         LocalizedAttributes.LocalizedDescription(nameof(Language.PropertyDescriptionUserViaAPI)),
+         AttributeUsedInAllProtocolsExcept(ProtocolType.VNC, ProtocolType.Telnet, ProtocolType.Rlogin, ProtocolType.RAW)]
+        public virtual string UserViaAPI
+        {
+            get => GetPropertyValue("UserViaAPI", _userViaAPI);
+            set => SetField(ref _userViaAPI, value, "UserViaAPI");
+        }
+        [LocalizedAttributes.LocalizedCategory(nameof(Language.Connection), 2),
          LocalizedAttributes.LocalizedDisplayName(nameof(Language.Username)),
          LocalizedAttributes.LocalizedDescription(nameof(Language.PropertyDescriptionUsername)),
-         AttributeUsedInAllProtocolsExcept(ProtocolType.VNC, ProtocolType.Telnet, ProtocolType.Rlogin, ProtocolType.RAW)]
+         AttributeUsedInProtocol(ProtocolType.RDP, ProtocolType.SSH1, ProtocolType.SSH2)]
         public virtual string Username
         {
             get => GetPropertyValue("Username", _username);
@@ -191,6 +203,26 @@ namespace mRemoteNG.Connection
         {
             get => GetPropertyValue("Domain", _domain).Trim();
             set => SetField(ref _domain, value?.Trim(), "Domain");
+        }
+
+        [LocalizedAttributes.LocalizedCategory(nameof(Language.Connection), 2),
+        LocalizedAttributes.LocalizedDisplayName(nameof(Language.EC2InstanceId)),
+        LocalizedAttributes.LocalizedDescription(nameof(Language.PropertyDescriptionEC2InstanceId)),
+        AttributeUsedInProtocol(ProtocolType.RDP, ProtocolType.SSH2)]
+        public string EC2InstanceId
+        {
+            get => GetPropertyValue("EC2InstanceId", _ec2InstanceId).Trim();
+            set => SetField(ref _ec2InstanceId, value?.Trim(), "EC2InstanceId");
+        }
+
+        [LocalizedAttributes.LocalizedCategory(nameof(Language.Connection), 2),
+        LocalizedAttributes.LocalizedDisplayName(nameof(Language.EC2Region)),
+        LocalizedAttributes.LocalizedDescription(nameof(Language.PropertyDescriptionEC2Region)),
+        AttributeUsedInProtocol(ProtocolType.RDP, ProtocolType.SSH2)]
+        public string EC2Region
+        {
+            get => GetPropertyValue("EC2Region", _ec2Region).Trim();
+            set => SetField(ref _ec2Region, value?.Trim(), "EC2Region");
         }
 
         [LocalizedAttributes.LocalizedCategory(nameof(Language.Connection), 2),

--- a/mRemoteNG/Connection/ConnectionInfo.cs
+++ b/mRemoteNG/Connection/ConnectionInfo.cs
@@ -296,6 +296,7 @@ namespace mRemoteNG.Connection
         private void SetConnectionDefaults()
         {
             Hostname = string.Empty;
+            EC2Region = Settings.Default.ConDefaultEC2Region;
         }
 
         private void SetProtocolDefaults()

--- a/mRemoteNG/Connection/ConnectionInfoInheritance.cs
+++ b/mRemoteNG/Connection/ConnectionInfoInheritance.cs
@@ -51,6 +51,12 @@ namespace mRemoteNG.Connection
         #endregion
 
         #region Connection
+        [LocalizedAttributes.LocalizedCategory(nameof(Language.Connection), 3),
+         LocalizedAttributes.LocalizedDisplayNameInherit(nameof(Language.UserViaAPI)),
+         LocalizedAttributes.LocalizedDescriptionInherit(nameof(Language.PropertyDescriptionUserViaAPI)),
+         TypeConverter(typeof(MiscTools.YesNoTypeConverter))]
+        [Browsable(true)]
+        public bool UserViaAPI { get; set; }
 
         [LocalizedAttributes.LocalizedCategory(nameof(Language.Connection), 3),
          LocalizedAttributes.LocalizedDisplayNameInherit(nameof(Language.Username)),

--- a/mRemoteNG/Connection/ConnectionInitiator.cs
+++ b/mRemoteNG/Connection/ConnectionInitiator.cs
@@ -62,6 +62,18 @@ namespace mRemoteNG.Connection
 
             try
             {
+                if (!string.IsNullOrEmpty(connectionInfo.EC2InstanceId))
+                {
+                    try
+                    {
+                        string host = await ExternalConnectors.AWS.EC2FetchDataService.GetEC2InstanceDataAsync("AWSAPI:" + connectionInfo.EC2InstanceId, connectionInfo.EC2Region);
+                        connectionInfo.Hostname = host;
+                    }
+                    catch
+                    {
+                    }
+                }
+
                 if (connectionInfo.Hostname == "" && connectionInfo.Protocol != ProtocolType.IntApp)
                 {
                     Runtime.MessageCollector.AddMessage(MessageClass.WarningMsg,

--- a/mRemoteNG/Connection/Protocol/PuttyBase.cs
+++ b/mRemoteNG/Connection/Protocol/PuttyBase.cs
@@ -82,6 +82,19 @@ namespace mRemoteNG.Connection.Protocol
                         var username = "";
                         var password = "";
 
+                        // access secret server api if necessary
+                        if (!string.IsNullOrEmpty(InterfaceControl.Info?.UserViaAPI))
+                        {
+                            var domain = ""; // dummy
+                            try
+                            {
+                                ExternalConnectors.TSS.SecretServerInterface.FetchSecretFromServer("SSAPI:" + InterfaceControl.Info?.UserViaAPI, out username, out password, out domain);
+                            }
+                            catch (Exception ex)
+                            {
+                                Event_ErrorOccured(this, "Secret Server Interface Error: " + ex.Message, 0);
+                            }
+                        }
                         if (!string.IsNullOrEmpty(InterfaceControl.Info?.Username))
                         {
                             username = InterfaceControl.Info.Username;
@@ -111,20 +124,6 @@ namespace mRemoteNG.Connection.Protocol
                                 var cryptographyProvider = new LegacyRijndaelCryptographyProvider();
                                 password = cryptographyProvider.Decrypt(Settings.Default.DefaultPassword,
                                                                         Runtime.EncryptionKey);
-                            }
-                        }
-
-                        // access secret server api if necessary
-                        if (username.StartsWith("SSAPI:"))
-                        {
-                            var domain = ""; // dummy
-                            try
-                            {
-                                ExternalConnectors.TSS.SecretServerInterface.FetchSecretFromServer(username, out username, out password, out domain);
-                            }
-                            catch (Exception ex)
-                            {
-                                Event_ErrorOccured(this, "Secret Server Interface Error: " + ex.Message, 0);
                             }
                         }
 

--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol6.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol6.cs
@@ -465,11 +465,11 @@ namespace mRemoteNG.Connection.Protocol.RDP
                 var domain = connectionInfo?.Domain ?? "";
 
                 // access secret server api if necessary
-                if (userName.StartsWith("SSAPI:"))
+                if (!string.IsNullOrEmpty(connectionInfo?.UserViaAPI))
                 {
                     try
                     {
-                        ExternalConnectors.TSS.SecretServerInterface.FetchSecretFromServer(userName, out userName, out password, out domain);
+                        ExternalConnectors.TSS.SecretServerInterface.FetchSecretFromServer("SSAPI:" + connectionInfo?.UserViaAPI, out userName, out password, out domain);
                     }
                     catch (Exception ex)
                     {

--- a/mRemoteNG/Language/Language.Designer.cs
+++ b/mRemoteNG/Language/Language.Designer.cs
@@ -1626,7 +1626,50 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Domain", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to EC2InstanceId.
+        /// </summary>
+        internal static string EC2InstanceId
+        {
+            get
+            {
+                return ResourceManager.GetString("EC2InstanceId", resourceCulture);
+            }
+        }
+        /// <summary>
+        ///   Looks up a localized string similar to PropertyDescriptionEC2InstanceId.
+        /// </summary>
+        internal static string PropertyDescriptionEC2InstanceId
+        {
+            get
+            {
+                return ResourceManager.GetString("PropertyDescriptionEC2InstanceId", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to EC2InstanceId.
+        /// </summary>
+        internal static string EC2Region
+        {
+            get
+            {
+                return ResourceManager.GetString("EC2Region", resourceCulture);
+            }
+        }
+        /// <summary>
+        ///   Looks up a localized string similar to PropertyDescriptionEC2InstanceId.
+        /// </summary>
+        internal static string PropertyDescriptionEC2Region
+        {
+            get
+            {
+                return ResourceManager.GetString("PropertyDescriptionEC2Region", resourceCulture);
+            }
+        }
+
+
         /// <summary>
         ///   Looks up a localized string similar to Donate.
         /// </summary>
@@ -4034,7 +4077,18 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionUser1", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Enter your username..
+        /// </summary>
+        internal static string PropertyDescriptionUserViaAPI
+        {
+            get
+            {
+                return ResourceManager.GetString("PropertyDescriptionUserViaAPI", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Enter your username..
         /// </summary>
@@ -6072,7 +6126,18 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UserField", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Username.
+        /// </summary>
+        internal static string UserViaAPI
+        {
+            get
+            {
+                return ResourceManager.GetString("UserViaAPI", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Username.
         /// </summary>

--- a/mRemoteNG/Language/Language.resx
+++ b/mRemoteNG/Language/Language.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="About" xml:space="preserve">
     <value>About</value>
@@ -263,6 +263,9 @@
   </data>
   <data name="CheckboxUpdateUseProxy" xml:space="preserve">
     <value>Use a proxy server to connect</value>
+  </data>
+  <data name="UserViaAPI" xml:space="preserve">
+    <value>API User ID</value>
   </data>
   <data name="Username" xml:space="preserve">
     <value>Username</value>
@@ -1085,6 +1088,9 @@ If you run into such an error, please create a new connection file!</value>
   </data>
   <data name="PropertyDescriptionUser1" xml:space="preserve">
     <value>Feel free to enter any information you need here.</value>
+  </data>
+  <data name="PropertyDescriptionUserViaAPI" xml:space="preserve">
+    <value>Enter the ID of user data in external API (e.g. secret server). when used, leave username/password/domain fields empty</value>
   </data>
   <data name="PropertyDescriptionUsername" xml:space="preserve">
     <value>Enter your username.</value>
@@ -2183,12 +2189,10 @@ Nightly Channel includes Alphas, Betas &amp; Release Candidates.</value>
   </data>
   <data name="OpeningCommand" xml:space="preserve">
     <value>TODO</value>
-    <comment></comment>
   </data>
   <data name="PropertyDescriptionOpeningCommand" xml:space="preserve">
     <value>TODO</value>
   </data>
-
   <data name="RedirectDrives" xml:space="preserve">
     <value>Disk Drives</value>
   </data>
@@ -2206,5 +2210,17 @@ Nightly Channel includes Alphas, Betas &amp; Release Candidates.</value>
   </data>
   <data name="RemoteDesktopServices" xml:space="preserve">
     <value>Remote Desktop Services</value>
+  </data>
+  <data name="EC2InstanceId" xml:space="preserve">
+    <value>EC2 Instance Id</value>
+  </data>
+  <data name="EC2Region" xml:space="preserve">
+    <value>EC2 Region</value>
+  </data>
+  <data name="PropertyDescriptionEC2InstanceId" xml:space="preserve">
+    <value>use this instance id to fetch public ip from aws ec2 instance</value>
+  </data>
+  <data name="PropertyDescriptionEC2Region" xml:space="preserve">
+    <value>fetch aws instance info from this region</value>
   </data>
 </root>

--- a/mRemoteNG/Properties/Settings.Designer.cs
+++ b/mRemoteNG/Properties/Settings.Designer.cs
@@ -430,7 +430,22 @@ namespace mRemoteNG.Properties {
                 this["ConDefaultProtocol"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("eu-central-1")]
+        public string ConDefaultEC2Region
+        {
+            get
+            {
+                return ((string)(this["ConDefaultEC2Region"]));
+            }
+            set
+            {
+                this["ConDefaultEC2Region"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Default Settings")]

--- a/mRemoteNG/Properties/Settings.settings
+++ b/mRemoteNG/Properties/Settings.settings
@@ -104,6 +104,9 @@
     <Setting Name="ConDefaultProtocol" Type="System.String" Scope="User">
       <Value Profile="(Default)">RDP</Value>
     </Setting>
+    <Setting Name="ConDefaultEC2Region" Type="System.String" Scope="User">
+      <Value Profile="(Default)">eu-central-1</Value>
+    </Setting>
     <Setting Name="ConDefaultPuttySession" Type="System.String" Scope="User">
       <Value Profile="(Default)">Default Settings</Value>
     </Setting>

--- a/mRemoteNG/UI/Forms/OptionsPages/CredentialsPage.Designer.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/CredentialsPage.Designer.cs
@@ -30,10 +30,12 @@
         {
             this.pnlDefaultCredentials = new System.Windows.Forms.Panel();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.txtCredentialsUserViaAPI = new mRemoteNG.UI.Controls.MrngTextBox();
             this.txtCredentialsUsername = new mRemoteNG.UI.Controls.MrngTextBox();
             this.txtCredentialsPassword = new mRemoteNG.UI.Controls.MrngTextBox();
             this.txtCredentialsDomain = new mRemoteNG.UI.Controls.MrngTextBox();
             this.lblCredentialsDomain = new mRemoteNG.UI.Controls.MrngLabel();
+            this.lblCredentialsUserViaAPI = new mRemoteNG.UI.Controls.MrngLabel();
             this.lblCredentialsUsername = new mRemoteNG.UI.Controls.MrngLabel();
             this.lblCredentialsPassword = new mRemoteNG.UI.Controls.MrngLabel();
             this.radCredentialsCustom = new mRemoteNG.UI.Controls.MrngRadioButton();
@@ -61,12 +63,14 @@
             this.tableLayoutPanel1.ColumnCount = 2;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 160F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Controls.Add(this.txtCredentialsUsername, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.txtCredentialsPassword, 1, 1);
-            this.tableLayoutPanel1.Controls.Add(this.txtCredentialsDomain, 1, 2);
-            this.tableLayoutPanel1.Controls.Add(this.lblCredentialsDomain, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.lblCredentialsUsername, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.lblCredentialsPassword, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.txtCredentialsUserViaAPI, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.txtCredentialsUsername, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.txtCredentialsPassword, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.txtCredentialsDomain, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.lblCredentialsUserViaAPI, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.lblCredentialsUsername, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.lblCredentialsPassword, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.lblCredentialsDomain, 0, 3);
             this.tableLayoutPanel1.Location = new System.Drawing.Point(23, 85);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 3;
@@ -75,6 +79,17 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 26F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(332, 82);
             this.tableLayoutPanel1.TabIndex = 1;
+            // 
+            // txtCredentialsUserViaAPI
+            // 
+            this.txtCredentialsUserViaAPI.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.txtCredentialsUserViaAPI.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtCredentialsUserViaAPI.Enabled = false;
+            this.txtCredentialsUserViaAPI.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.txtCredentialsUserViaAPI.Location = new System.Drawing.Point(163, 3);
+            this.txtCredentialsUserViaAPI.Name = "txtCredentialsUserViaAPI";
+            this.txtCredentialsUserViaAPI.Size = new System.Drawing.Size(166, 22);
+            this.txtCredentialsUserViaAPI.TabIndex = 5;
             // 
             // txtCredentialsUsername
             // 
@@ -120,6 +135,17 @@
             this.lblCredentialsDomain.TabIndex = 8;
             this.lblCredentialsDomain.Text = "Domain:";
             this.lblCredentialsDomain.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // lblCredentialsUserViaAPI
+            // 
+            this.lblCredentialsUserViaAPI.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblCredentialsUserViaAPI.Enabled = false;
+            this.lblCredentialsUserViaAPI.Location = new System.Drawing.Point(3, 3);
+            this.lblCredentialsUserViaAPI.Name = "lblCredentialsUserViaAPI";
+            this.lblCredentialsUserViaAPI.Size = new System.Drawing.Size(154, 19);
+            this.lblCredentialsUserViaAPI.TabIndex = 4;
+            this.lblCredentialsUserViaAPI.Text = "User via API ID:";
+            this.lblCredentialsUserViaAPI.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // lblCredentialsUsername
             // 
@@ -211,9 +237,11 @@
         internal Controls.MrngRadioButton radCredentialsNoInfo;
         internal Controls.MrngRadioButton radCredentialsWindows;
         internal Controls.MrngTextBox txtCredentialsDomain;
+        internal Controls.MrngLabel lblCredentialsUserViaAPI;
         internal Controls.MrngLabel lblCredentialsUsername;
         internal Controls.MrngTextBox txtCredentialsPassword;
         internal Controls.MrngLabel lblCredentialsPassword;
+        internal Controls.MrngTextBox txtCredentialsUserViaAPI;
         internal Controls.MrngTextBox txtCredentialsUsername;
         internal Controls.MrngLabel lblCredentialsDomain;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;


### PR DESCRIPTION
add new connection panel fields for external connectors (currently only secret server)
![image](https://user-images.githubusercontent.com/4305825/147223998-684e0153-1fda-4993-a0d3-cfb64bf70e26.png)

add ec2 instance connector. this allows to fetch ip address from aws ec2 instance id dynamically before connection
![image](https://user-images.githubusercontent.com/4305825/147224143-22a68e28-f8d6-4622-9c82-ce790c2b5e38.png)



## Description
added new properties for the fields api id, ec2 instance id, ec2 region
added language fields and config xml save/load code

## Motivation and Context
improve external connectors functionality by providing option fields instead of "SSAPI:" workarounds. 

## How Has This Been Tested?
using it in production

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation


