### PR TITLE
Extended the field [RenderingEngine] from 10 chars to 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - #319: Override quick connect username when using user@domain
 - #283: Support for native PowerShell remoting as new protocol
 ### Changed
+- #2102: Extended the field RenderingEngine from 10 chars to 16
 - #2022: Replaced CefSharp with WebView2
 - #2014: Revised icons
 - #2013: Removed components check

--- a/mRemoteNGDocumentation/mssql_db_setup.sql
+++ b/mRemoteNGDocumentation/mssql_db_setup.sql
@@ -69,7 +69,7 @@ CREATE TABLE [dbo].[tblCons] (
 	[RedirectPrinters] bit NOT NULL,
 	[RedirectSmartCards] bit NOT NULL,
 	[RedirectSound] varchar(64) NOT NULL,
-	[RenderingEngine] varchar(10),
+	[RenderingEngine] varchar(16),
 	[Resolution] varchar(32) NOT NULL,
 	[SSHOptions] varchar(1024) NOT NULL,
 	[SSHTunnelConnectionName] varchar(128) NOT NULL,

--- a/mRemoteNGDocumentation/mysql_db_setup.sql
+++ b/mRemoteNGDocumentation/mysql_db_setup.sql
@@ -70,7 +70,7 @@ CREATE TABLE `tblCons` (
 	`RedirectPrinters` tinyint(1) NOT NULL,
 	`RedirectSmartCards` tinyint(1) NOT NULL,
 	`RedirectSound` varchar(64) NOT NULL,  
-	`RenderingEngine` varchar(10) DEFAULT NULL,
+	`RenderingEngine` varchar(16) DEFAULT NULL,
 	`Resolution` varchar(32) NOT NULL,
 	`SSHOptions` varchar(1024) NOT NULL,
 	`SSHTunnelConnectionName` varchar(128) NOT NULL,


### PR DESCRIPTION
This is not the full fix of issue #2057, because the scripts are not "migration" scripts.

## Description
Increased the field length in *.sql scripts

## Motivation and Context
Make the product better

## How Has This Been Tested?
Use Debug Portable build

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
