### PR TITLE
Fixed behavior of toolbar visibility toggles in the View menu

### DIFF
--- a/mRemoteNG/UI/Menu/ViewMenu.cs
+++ b/mRemoteNG/UI/Menu/ViewMenu.cs
@@ -199,7 +199,7 @@ namespace mRemoteNG.UI.Menu
             {
                 var tItem = new ToolStripMenuItem(Runtime.WindowList[i].Text,
                                                   Runtime.WindowList[i].Icon.ToBitmap(), ConnectionPanelMenuItem_Click)
-                    {Tag = Runtime.WindowList[i]};
+                { Tag = Runtime.WindowList[i] };
                 _mMenViewConnectionPanels.DropDownItems.Add(tItem);
             }
 
@@ -261,11 +261,13 @@ namespace mRemoteNG.UI.Menu
             {
                 Settings.Default.ViewMenuExternalTools = false;
                 _mMenViewExtAppsToolbar.Checked = false;
+                TsExternalTools.Visible = false;
             }
             else
             {
                 Settings.Default.ViewMenuExternalTools = true;
                 _mMenViewExtAppsToolbar.Checked = true;
+                TsExternalTools.Visible = true;
             }
         }
 
@@ -275,11 +277,13 @@ namespace mRemoteNG.UI.Menu
             {
                 Settings.Default.ViewMenuQuickConnect = false;
                 _mMenViewQuickConnectToolbar.Checked = false;
+                TsQuickConnect.Visible = false;
             }
             else
             {
                 Settings.Default.ViewMenuQuickConnect = true;
                 _mMenViewQuickConnectToolbar.Checked = true;
+                TsQuickConnect.Visible = true;
             }
         }
 
@@ -289,11 +293,13 @@ namespace mRemoteNG.UI.Menu
             {
                 Settings.Default.ViewMenuMultiSSH = false;
                 _mMenViewMultiSshToolbar.Checked = false;
+                TsMultiSsh.Visible = false;
             }
             else
             {
                 Settings.Default.ViewMenuMultiSSH = true;
                 _mMenViewMultiSshToolbar.Checked = true;
+                TsMultiSsh.Visible = true;
             }
         }
 


### PR DESCRIPTION
## Description
The visibility of 3 toolbars should be toggled when the corresponding item in the View menu is clicked.

## Motivation and Context
Commit 100f856b5f2233854c97bca1a72233c2beb87336 added the persistence of the toolbar visibility via new settings, but inadvertently broke the ability to toggle them in the current instance of the mRemoteNG application.

## How Has This Been Tested?
I'm able to build the modified code using VS 2022, and have confirmed that the visibility toggling is fixed

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
- [x ] My code follows the code style of this project.
- [x ] All Tests within VisualStudio are passing *(43 failed before fix, the same 43 still fail afterwards)
- [x ] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
