### PR TITLE
Fix tests that were broken by PR #2100

### DIFF
--- a/mRemoteNGTests/UI/Window/ConfigWindowTests/ConfigWindowGeneralTests.cs
+++ b/mRemoteNGTests/UI/Window/ConfigWindowTests/ConfigWindowGeneralTests.cs
@@ -288,7 +288,7 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                         nameof(ConnectionInfo.SSHOptions),
                         nameof(ConnectionInfo.PuttySession),
                         nameof(ConnectionInfo.OpeningCommand),
-                        nameof(ConnectionInfo.UserViaAPI)
+                        nameof(ConnectionInfo.UserViaAPI),
 			nameof(ConnectionInfo.EC2InstanceId),
                     	nameof(ConnectionInfo.EC2Region)
                     });

--- a/mRemoteNGTests/UI/Window/ConfigWindowTests/ConfigWindowGeneralTests.cs
+++ b/mRemoteNGTests/UI/Window/ConfigWindowTests/ConfigWindowGeneralTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -261,9 +261,10 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
 			nameof(ConnectionInfo.RdpVersion),
                         nameof(ConnectionInfo.RDPStartProgram),
                         nameof(ConnectionInfo.RDPStartProgramWorkDir),
+			nameof(ConnectionInfo.UserViaAPI)
                         nameof(ConnectionInfo.EC2InstanceId),
                         nameof(ConnectionInfo.EC2Region),
-                        nameof(ConnectionInfo.UserViaAPI)
+
                     });
                     break;
                 case ProtocolType.VNC:
@@ -274,6 +275,9 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                         nameof(ConnectionInfo.Port),
                         nameof(ConnectionInfo.VNCSmartSizeMode),
                         nameof(ConnectionInfo.VNCViewOnly),
+			nameof(ConnectionInfo.UserViaAPI)
+			nameof(ConnectionInfo.EC2InstanceId),
+                    	nameof(ConnectionInfo.EC2Region),
                     });
                     break;
                 case ProtocolType.SSH1:
@@ -286,6 +290,8 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                         nameof(ConnectionInfo.PuttySession),
                         nameof(ConnectionInfo.OpeningCommand),
                         nameof(ConnectionInfo.UserViaAPI)
+			nameof(ConnectionInfo.EC2InstanceId),
+                    	nameof(ConnectionInfo.EC2Region),
                     });
                     break;
                 case ProtocolType.SSH2:
@@ -300,6 +306,8 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                         nameof(ConnectionInfo.EC2InstanceId),
                         nameof(ConnectionInfo.EC2Region),
                         nameof(ConnectionInfo.UserViaAPI)
+			nameof(ConnectionInfo.EC2InstanceId),
+                    	nameof(ConnectionInfo.EC2Region),
                     });
                     break;
                 case ProtocolType.Telnet:

--- a/mRemoteNGTests/UI/Window/ConfigWindowTests/ConfigWindowGeneralTests.cs
+++ b/mRemoteNGTests/UI/Window/ConfigWindowTests/ConfigWindowGeneralTests.cs
@@ -115,9 +115,9 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
 			_configWindow.SelectedTreeNode = selectedObject;
 
 			var shouldBeAvailable = selectedObject != null &&
-									!(selectedObject is RootNodeInfo) &&
-									!(selectedObject is PuttySessionInfo) &&
-									!(selectedObject.Parent is RootNodeInfo);
+									selectedObject is not RootNodeInfo &&
+									selectedObject is not PuttySessionInfo &&
+									selectedObject.Parent is not RootNodeInfo;
 
 			Assert.That(_configWindow.CanShowInheritance, Is.EqualTo(shouldBeAvailable));
 		}
@@ -170,9 +170,9 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
 				.Concat(new[]
 				{
 					new TestCaseData(new RootNodeInfo(RootNodeType.Connection)).SetName("RootNode"),
-					new TestCaseData(new RootPuttySessionsNodeInfo()).SetName("RootPuttyNode"), 
-					new TestCaseData(new PuttySessionInfo()).SetName("PuttyNode"), 
-					new TestCaseData(null).SetName("Null"), 
+					new TestCaseData(new RootPuttySessionsNodeInfo()).SetName("RootPuttyNode"),
+					new TestCaseData(new PuttySessionInfo()).SetName("PuttyNode"),
+					new TestCaseData(null).SetName("Null")
 				});
 		}
 
@@ -181,7 +181,7 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
             // build connection info. set certain connection properties so
             // that toggled properties are hidden in the property grid. We
             // will test those separately in the special protocol tests.
-            var node = isContainer 
+            var node = isContainer
                 ? new ContainerInfo()
                 : new ConnectionInfo();
 
@@ -260,7 +260,10 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                         nameof(ConnectionInfo.RedirectAudioCapture),
 						nameof(ConnectionInfo.RdpVersion),
                         nameof(ConnectionInfo.RDPStartProgram),
-                        nameof(ConnectionInfo.RDPStartProgramWorkDir)
+                        nameof(ConnectionInfo.RDPStartProgramWorkDir),
+                        nameof(ConnectionInfo.EC2InstanceId),
+                        nameof(ConnectionInfo.EC2Region),
+                        nameof(ConnectionInfo.UserViaAPI)
                     });
                     break;
                 case ProtocolType.VNC:
@@ -273,6 +276,17 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                     });
                     break;
                 case ProtocolType.SSH1:
+                    expectedProperties.AddRange(new[]
+                    {
+                        nameof(ConnectionInfo.Username),
+                        nameof(ConnectionInfo.Password),
+                        nameof(ConnectionInfo.Port),
+                        nameof(ConnectionInfo.SSHOptions),
+                        nameof(ConnectionInfo.PuttySession),
+                        nameof(ConnectionInfo.OpeningCommand),
+                        nameof(ConnectionInfo.UserViaAPI)
+                    });
+                    break;
                 case ProtocolType.SSH2:
                     expectedProperties.AddRange(new []
                     {
@@ -281,7 +295,10 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                         nameof(ConnectionInfo.Port),
                         nameof(ConnectionInfo.SSHOptions),
                         nameof(ConnectionInfo.PuttySession),
-                        nameof(ConnectionInfo.OpeningCommand)
+                        nameof(ConnectionInfo.OpeningCommand),
+                        nameof(ConnectionInfo.EC2InstanceId),
+                        nameof(ConnectionInfo.EC2Region),
+                        nameof(ConnectionInfo.UserViaAPI)
                     });
                     break;
                 case ProtocolType.Telnet:
@@ -297,7 +314,7 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                 case ProtocolType.HTTPS:
                     expectedProperties.AddRange(new []
                     {
-                        nameof(ConnectionInfo.Username),
+                        nameof(ConnectionInfo.UserViaAPI),
                         nameof(ConnectionInfo.Password),
                         nameof(ConnectionInfo.Port),
                         nameof(ConnectionInfo.RenderingEngine),
@@ -306,7 +323,7 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                 case ProtocolType.PowerShell:
                     expectedProperties.AddRange(new[]
                     {
-                        nameof(ConnectionInfo.Username),
+                        nameof(ConnectionInfo.UserViaAPI),
                         nameof(ConnectionInfo.Password),
                         nameof(ConnectionInfo.Domain),
                         nameof(ConnectionInfo.Port),
@@ -315,7 +332,7 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                 case ProtocolType.IntApp:
                     expectedProperties.AddRange(new[]
                     {
-                        nameof(ConnectionInfo.Username),
+                        nameof(ConnectionInfo.UserViaAPI),
                         nameof(ConnectionInfo.Password),
                         nameof(ConnectionInfo.Domain),
                         nameof(ConnectionInfo.Port),

--- a/mRemoteNGTests/UI/Window/ConfigWindowTests/ConfigWindowGeneralTests.cs
+++ b/mRemoteNGTests/UI/Window/ConfigWindowTests/ConfigWindowGeneralTests.cs
@@ -258,7 +258,7 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                         nameof(ConnectionInfo.RedirectSmartCards),
                         nameof(ConnectionInfo.RedirectSound),
                         nameof(ConnectionInfo.RedirectAudioCapture),
-						nameof(ConnectionInfo.RdpVersion),
+			nameof(ConnectionInfo.RdpVersion),
                         nameof(ConnectionInfo.RDPStartProgram),
                         nameof(ConnectionInfo.RDPStartProgramWorkDir),
                         nameof(ConnectionInfo.EC2InstanceId),
@@ -269,6 +269,7 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                 case ProtocolType.VNC:
                     expectedProperties.AddRange(new []
                     {
+			nameof(ConnectionInfo.Username),
                         nameof(ConnectionInfo.Password),
                         nameof(ConnectionInfo.Port),
                         nameof(ConnectionInfo.VNCSmartSizeMode),
@@ -315,6 +316,7 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                     expectedProperties.AddRange(new []
                     {
                         nameof(ConnectionInfo.UserViaAPI),
+			nameof(ConnectionInfo.Username),
                         nameof(ConnectionInfo.Password),
                         nameof(ConnectionInfo.Port),
                         nameof(ConnectionInfo.RenderingEngine),
@@ -324,6 +326,7 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                     expectedProperties.AddRange(new[]
                     {
                         nameof(ConnectionInfo.UserViaAPI),
+			nameof(ConnectionInfo.Username),
                         nameof(ConnectionInfo.Password),
                         nameof(ConnectionInfo.Domain),
                         nameof(ConnectionInfo.Port),
@@ -333,6 +336,7 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                     expectedProperties.AddRange(new[]
                     {
                         nameof(ConnectionInfo.UserViaAPI),
+			nameof(ConnectionInfo.Username),
                         nameof(ConnectionInfo.Password),
                         nameof(ConnectionInfo.Domain),
                         nameof(ConnectionInfo.Port),

--- a/mRemoteNGTests/UI/Window/ConfigWindowTests/ConfigWindowGeneralTests.cs
+++ b/mRemoteNGTests/UI/Window/ConfigWindowTests/ConfigWindowGeneralTests.cs
@@ -261,10 +261,9 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
 			nameof(ConnectionInfo.RdpVersion),
                         nameof(ConnectionInfo.RDPStartProgram),
                         nameof(ConnectionInfo.RDPStartProgramWorkDir),
-			nameof(ConnectionInfo.UserViaAPI)
+			nameof(ConnectionInfo.UserViaAPI),
                         nameof(ConnectionInfo.EC2InstanceId),
-                        nameof(ConnectionInfo.EC2Region),
-
+                        nameof(ConnectionInfo.EC2Region)
                     });
                     break;
                 case ProtocolType.VNC:
@@ -275,9 +274,9 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                         nameof(ConnectionInfo.Port),
                         nameof(ConnectionInfo.VNCSmartSizeMode),
                         nameof(ConnectionInfo.VNCViewOnly),
-			nameof(ConnectionInfo.UserViaAPI)
+			nameof(ConnectionInfo.UserViaAPI),
 			nameof(ConnectionInfo.EC2InstanceId),
-                    	nameof(ConnectionInfo.EC2Region),
+                    	nameof(ConnectionInfo.EC2Region)
                     });
                     break;
                 case ProtocolType.SSH1:
@@ -291,7 +290,7 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                         nameof(ConnectionInfo.OpeningCommand),
                         nameof(ConnectionInfo.UserViaAPI)
 			nameof(ConnectionInfo.EC2InstanceId),
-                    	nameof(ConnectionInfo.EC2Region),
+                    	nameof(ConnectionInfo.EC2Region)
                     });
                     break;
                 case ProtocolType.SSH2:
@@ -305,9 +304,9 @@ namespace mRemoteNGTests.UI.Window.ConfigWindowTests
                         nameof(ConnectionInfo.OpeningCommand),
                         nameof(ConnectionInfo.EC2InstanceId),
                         nameof(ConnectionInfo.EC2Region),
-                        nameof(ConnectionInfo.UserViaAPI)
+                        nameof(ConnectionInfo.UserViaAPI),
 			nameof(ConnectionInfo.EC2InstanceId),
-                    	nameof(ConnectionInfo.EC2Region),
+                    	nameof(ConnectionInfo.EC2Region)
                     });
                     break;
                 case ProtocolType.Telnet:


### PR DESCRIPTION
## Description
Every time when a new property is added to a connection node, the tests **ConfigWindowGeneralTests** should be corrected. The code there checks what properties **must** be available for different connection types, and what not.

Currently PR #2100 broke the tests that were green.

## Motivation and Context
Make the project better

## How Has This Been Tested?
VS 2022

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
