### PR TITLE
Fixed string parsing logic for Quick Connect toolbar.

### DIFF
--- a/mRemoteNG/Connection/ConnectionsService.cs
+++ b/mRemoteNG/Connection/ConnectionsService.cs
@@ -80,17 +80,17 @@ namespace mRemoteNG.Connection
                 {
                     var x = connectionString.Split('@');
                     uriBuilder.UserName = x[0];
-                    uriBuilder.Host = x[1];
+                    connectionString = x[1];
                 }
-                if (uriBuilder.Host.Contains(":"))
+                if (connectionString.Contains(":"))
                 {
-                    var x = uriBuilder.Host.Split(':');
-                    uriBuilder.Host = x[0];
+                    var x = connectionString.Split(':');
+                    connectionString = x[0];
                     uriBuilder.Port = Convert.ToInt32(x[1]);
                 }
-                else
-                    uriBuilder.Host = connectionString;
-                
+
+                uriBuilder.Host = connectionString;
+
                 var newConnectionInfo = new ConnectionInfo();
                 newConnectionInfo.CopyFrom(DefaultConnectionInfo.Instance);
 
@@ -99,11 +99,16 @@ namespace mRemoteNG.Connection
                     : uriBuilder.Host;
 
                 newConnectionInfo.Protocol = protocol;
+                newConnectionInfo.Hostname = uriBuilder.Host;
                 newConnectionInfo.Username = uriBuilder.UserName;
 
                 if (uriBuilder.Port == -1)
                 {
                     newConnectionInfo.SetDefaultPort();
+                }
+                else
+                {
+                    newConnectionInfo.Port = uriBuilder.Port;
                 }
 
                 if (string.IsNullOrEmpty(newConnectionInfo.Panel))


### PR DESCRIPTION
## Description
I have made the Quick Connect toolbar functional for input strings like:

1. `127.0.0.1`
2. `root@127.0.0.1`
3. `127.0.0.1:22`
4. `root@127.0.0.1:22`



## Motivation and Context
Commit 04c83c608b5396086a23d0354838891a31e55a31 broke the aforementioned scenarios 1 and 3.

## How Has This Been Tested?
Built MRemoteNG in Visual Studio 2022, ran the tests and observed all passes. (8 tests skipped, but that was unchanged)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
- [x ] My code follows the code style of this project.
- [x ] All Tests within VisualStudio are passing
- [x ] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
