### PR TITLE
Combined instances of ConnectionInitiator to help with issue #2119

### DIFF
--- a/mRemoteNG/App/Runtime.cs
+++ b/mRemoteNG/App/Runtime.cs
@@ -49,6 +49,8 @@ namespace mRemoteNG.App
 
         public static ICredentialRepositoryList CredentialProviderCatalog { get; } = new CredentialRepositoryList();
 
+        public static ConnectionInitiator ConnectionInitiator { get; set; } = new ConnectionInitiator();
+
         public static ConnectionsService ConnectionsService { get; } =
             new ConnectionsService(PuttySessionsManager.Instance);
 

--- a/mRemoteNG/Connection/WebHelper.cs
+++ b/mRemoteNG/Connection/WebHelper.cs
@@ -1,4 +1,5 @@
-﻿using mRemoteNG.Connection.Protocol;
+﻿using mRemoteNG.App;
+using mRemoteNG.Connection.Protocol;
 using mRemoteNG.Resources.Language;
 
 namespace mRemoteNG.Connection
@@ -17,8 +18,7 @@ namespace mRemoteNG.Connection
             if (string.IsNullOrEmpty(connectionInfo.Panel))
                 connectionInfo.Panel = Language.General;
             connectionInfo.IsQuickConnect = true;
-            var connectionInitiator = new ConnectionInitiator();
-            connectionInitiator.OpenConnection(connectionInfo, ConnectionInfo.Force.DoNotJump);
+            Runtime.ConnectionInitiator.OpenConnection(connectionInfo, ConnectionInfo.Force.DoNotJump);
         }
     }
 }

--- a/mRemoteNG/Tools/ExternalTool.cs
+++ b/mRemoteNG/Tools/ExternalTool.cs
@@ -17,7 +17,6 @@ namespace mRemoteNG.Tools
 {
     public class ExternalTool : INotifyPropertyChanged
     {
-        private readonly IConnectionInitiator _connectionInitiator = new ConnectionInitiator();
         private string _displayName;
         private string _fileName;
         private bool _waitForExit;
@@ -166,7 +165,7 @@ namespace mRemoteNG.Tools
             try
             {
                 var newConnectionInfo = BuildConnectionInfoForIntegratedApp();
-                _connectionInitiator.OpenConnection(newConnectionInfo);
+                Runtime.ConnectionInitiator.OpenConnection(newConnectionInfo);
             }
             catch (Exception ex)
             {

--- a/mRemoteNG/Tools/NotificationAreaIcon.cs
+++ b/mRemoteNG/Tools/NotificationAreaIcon.cs
@@ -16,7 +16,6 @@ namespace mRemoteNG.Tools
         private readonly NotifyIcon _nI;
         private readonly ContextMenuStrip _cMen;
         private readonly ToolStripMenuItem _cMenCons;
-        private readonly IConnectionInitiator _connectionInitiator = new ConnectionInitiator();
         private static readonly FrmMain FrmMain = FrmMain.Default;
 
         public bool Disposed { get; private set; }
@@ -129,7 +128,7 @@ namespace mRemoteNG.Tools
             if (((ToolStripMenuItem)sender).Tag is ContainerInfo) return;
             if (FrmMain.Visible == false)
                 ShowForm();
-            _connectionInitiator.OpenConnection((ConnectionInfo)((ToolStripMenuItem)sender).Tag);
+            Runtime.ConnectionInitiator.OpenConnection((ConnectionInfo)((ToolStripMenuItem)sender).Tag);
         }
 
         private static void cMenExit_Click(object sender, EventArgs e)

--- a/mRemoteNG/UI/Controls/ConnectionContextMenu.cs
+++ b/mRemoteNG/UI/Controls/ConnectionContextMenu.cs
@@ -55,13 +55,11 @@ namespace mRemoteNG.UI.Controls
         private ToolStripMenuItem _cMenTreeApplyInheritanceToChildren;
         private ToolStripMenuItem _cMenTreeApplyDefaultInheritance;
         private readonly ConnectionTree.ConnectionTree _connectionTree;
-        private readonly IConnectionInitiator _connectionInitiator;
 
 
         public ConnectionContextMenu(ConnectionTree.ConnectionTree connectionTree)
         {
             _connectionTree = connectionTree;
-            _connectionInitiator = new ConnectionInitiator();
             InitializeComponent();
             ApplyLanguage();
             EnableShortcutKeys();
@@ -692,75 +690,76 @@ namespace mRemoteNG.UI.Controls
         {
             var selectedNodeAsContainer = _connectionTree.SelectedNode as ContainerInfo;
             if (selectedNodeAsContainer != null)
-                _connectionInitiator.OpenConnection(selectedNodeAsContainer, ConnectionInfo.Force.DoNotJump);
+                Runtime.ConnectionInitiator.OpenConnection(selectedNodeAsContainer, ConnectionInfo.Force.DoNotJump);
             else
-                _connectionInitiator.OpenConnection(_connectionTree.SelectedNode, ConnectionInfo.Force.DoNotJump);
+                Runtime.ConnectionInitiator.OpenConnection(_connectionTree.SelectedNode, ConnectionInfo.Force.DoNotJump);
         }
 
         private void OnConnectToConsoleSessionClicked(object sender, EventArgs e)
         {
             var selectedNodeAsContainer = _connectionTree.SelectedNode as ContainerInfo;
             if (selectedNodeAsContainer != null)
-                _connectionInitiator.OpenConnection(selectedNodeAsContainer,
-                                                    ConnectionInfo.Force.UseConsoleSession |
-                                                    ConnectionInfo.Force.DoNotJump);
+                Runtime.ConnectionInitiator.OpenConnection(selectedNodeAsContainer,
+                                                           ConnectionInfo.Force.UseConsoleSession |
+                                                           ConnectionInfo.Force.DoNotJump);
             else
-                _connectionInitiator.OpenConnection(_connectionTree.SelectedNode,
-                                                    ConnectionInfo.Force.UseConsoleSession |
-                                                    ConnectionInfo.Force.DoNotJump);
+                Runtime.ConnectionInitiator.OpenConnection(_connectionTree.SelectedNode,
+                                                           ConnectionInfo.Force.UseConsoleSession |
+                                                           ConnectionInfo.Force.DoNotJump);
+
         }
 
         private void OnDontConnectToConsoleSessionClicked(object sender, EventArgs e)
         {
             var selectedNodeAsContainer = _connectionTree.SelectedNode as ContainerInfo;
             if (selectedNodeAsContainer != null)
-                _connectionInitiator.OpenConnection(selectedNodeAsContainer,
-                                                    ConnectionInfo.Force.DontUseConsoleSession |
-                                                    ConnectionInfo.Force.DoNotJump);
+                Runtime.ConnectionInitiator.OpenConnection(selectedNodeAsContainer,
+                                                           ConnectionInfo.Force.DontUseConsoleSession |
+                                                           ConnectionInfo.Force.DoNotJump);
             else
-                _connectionInitiator.OpenConnection(_connectionTree.SelectedNode,
-                                                    ConnectionInfo.Force.DontUseConsoleSession |
-                                                    ConnectionInfo.Force.DoNotJump);
+                Runtime.ConnectionInitiator.OpenConnection(_connectionTree.SelectedNode,
+                                                           ConnectionInfo.Force.DontUseConsoleSession |
+                                                           ConnectionInfo.Force.DoNotJump);
         }
 
         private void OnConnectInFullscreenClicked(object sender, EventArgs e)
         {
             var selectedNodeAsContainer = _connectionTree.SelectedNode as ContainerInfo;
             if (selectedNodeAsContainer != null)
-                _connectionInitiator.OpenConnection(selectedNodeAsContainer,
-                                                    ConnectionInfo.Force.Fullscreen | ConnectionInfo.Force.DoNotJump);
+                Runtime.ConnectionInitiator.OpenConnection(selectedNodeAsContainer,
+                                                           ConnectionInfo.Force.Fullscreen | ConnectionInfo.Force.DoNotJump);
             else
-                _connectionInitiator.OpenConnection(_connectionTree.SelectedNode,
-                                                    ConnectionInfo.Force.Fullscreen | ConnectionInfo.Force.DoNotJump);
+                Runtime.ConnectionInitiator.OpenConnection(_connectionTree.SelectedNode,
+                                                           ConnectionInfo.Force.Fullscreen | ConnectionInfo.Force.DoNotJump);
         }
 
         private void OnConnectWithNoCredentialsClick(object sender, EventArgs e)
         {
             var selectedNodeAsContainer = _connectionTree.SelectedNode as ContainerInfo;
             if (selectedNodeAsContainer != null)
-                _connectionInitiator.OpenConnection(selectedNodeAsContainer, ConnectionInfo.Force.NoCredentials);
+                Runtime.ConnectionInitiator.OpenConnection(selectedNodeAsContainer, ConnectionInfo.Force.NoCredentials);
             else
-                _connectionInitiator.OpenConnection(_connectionTree.SelectedNode, ConnectionInfo.Force.NoCredentials);
+                Runtime.ConnectionInitiator.OpenConnection(_connectionTree.SelectedNode, ConnectionInfo.Force.NoCredentials);
         }
 
         private void OnChoosePanelBeforeConnectingClicked(object sender, EventArgs e)
         {
             var selectedNodeAsContainer = _connectionTree.SelectedNode as ContainerInfo;
             if (selectedNodeAsContainer != null)
-                _connectionInitiator.OpenConnection(selectedNodeAsContainer,
-                                                    ConnectionInfo.Force.OverridePanel |
-                                                    ConnectionInfo.Force.DoNotJump);
+                Runtime.ConnectionInitiator.OpenConnection(selectedNodeAsContainer,
+                                                           ConnectionInfo.Force.OverridePanel |
+                                                           ConnectionInfo.Force.DoNotJump);
             else
-                _connectionInitiator.OpenConnection(_connectionTree.SelectedNode,
-                                                    ConnectionInfo.Force.OverridePanel |
-                                                    ConnectionInfo.Force.DoNotJump);
+                Runtime.ConnectionInitiator.OpenConnection(_connectionTree.SelectedNode,
+                                                           ConnectionInfo.Force.OverridePanel |
+                                                           ConnectionInfo.Force.DoNotJump);
         }
 
         private void ConnectWithOptionsViewOnlyOnClick(object sender, EventArgs e)
         {
             var connectionTarget = _connectionTree.SelectedNode as ContainerInfo
                                    ?? _connectionTree.SelectedNode;
-            _connectionInitiator.OpenConnection(connectionTarget, ConnectionInfo.Force.ViewOnly);
+            Runtime.ConnectionInitiator.OpenConnection(connectionTarget, ConnectionInfo.Force.ViewOnly);
         }
 
         private void OnDisconnectClicked(object sender, EventArgs e)

--- a/mRemoteNG/UI/Controls/QuickConnectToolStrip.cs
+++ b/mRemoteNG/UI/Controls/QuickConnectToolStrip.cs
@@ -24,21 +24,10 @@ namespace mRemoteNG.UI.Controls
         private ContextMenuStrip _mnuQuickConnectProtocol;
         private QuickConnectComboBox _cmbQuickConnect;
         private ContextMenuStrip _mnuConnections;
-        private IConnectionInitiator _connectionInitiator = new ConnectionInitiator();
         private readonly ThemeManager _themeManager;
         private WeifenLuo.WinFormsUI.Docking.VisualStudioToolStripExtender vsToolStripExtender;
         private readonly DisplayProperties _display;
 
-        public IConnectionInitiator ConnectionInitiator
-        {
-            get => _connectionInitiator;
-            set
-            {
-                if (value == null)
-                    return;
-                _connectionInitiator = value;
-            }
-        }
 
         public QuickConnectToolStrip()
         {
@@ -208,7 +197,7 @@ namespace mRemoteNG.UI.Controls
                 }
 
                 _cmbQuickConnect.Add(connectionInfo);
-                ConnectionInitiator.OpenConnection(connectionInfo, ConnectionInfo.Force.DoNotJump);
+                Runtime.ConnectionInitiator.OpenConnection(connectionInfo, ConnectionInfo.Force.DoNotJump);
             }
             catch (Exception ex)
             {
@@ -293,7 +282,7 @@ namespace mRemoteNG.UI.Controls
                 case ContainerInfo _:
                     return;
                 case ConnectionInfo connectionInfo:
-                    ConnectionInitiator.OpenConnection(connectionInfo);
+                    Runtime.ConnectionInitiator.OpenConnection(connectionInfo);
                     break;
             }
         }

--- a/mRemoteNG/UI/Forms/frmMain.Designer.cs
+++ b/mRemoteNG/UI/Forms/frmMain.Designer.cs
@@ -32,7 +32,6 @@
         private void InitializeComponent()
 		{
             this.components = new System.ComponentModel.Container();
-            mRemoteNG.Connection.ConnectionInitiator connectionInitiator1 = new mRemoteNG.Connection.ConnectionInitiator();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmMain));
             this.pnlDock = new WeifenLuo.WinFormsUI.Docking.DockPanel();
             this.msMain = new System.Windows.Forms.MenuStrip();
@@ -84,8 +83,7 @@
             this.msMain.Text = "Main Toolbar";
             // 
             // fileMenu
-            // 
-            this.fileMenu.ConnectionInitiator = null;
+            //
             this.fileMenu.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
             this.fileMenu.Name = "mMenFile";
             this.fileMenu.Size = new System.Drawing.Size(37, 19);
@@ -152,7 +150,6 @@
             // _quickConnectToolStrip
             // 
             this._quickConnectToolStrip.BackColor = System.Drawing.SystemColors.Control;
-            this._quickConnectToolStrip.ConnectionInitiator = connectionInitiator1;
             this._quickConnectToolStrip.Dock = System.Windows.Forms.DockStyle.None;
             this._quickConnectToolStrip.ForeColor = System.Drawing.SystemColors.ControlText;
             this._quickConnectToolStrip.Location = new System.Drawing.Point(114, 25);

--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -280,9 +280,7 @@ namespace mRemoteNG.UI.Forms
 
         private void SetMenuDependencies()
         {
-            var connectionInitiator = new ConnectionInitiator();
             fileMenu.TreeWindow = Windows.TreeForm;
-            fileMenu.ConnectionInitiator = connectionInitiator;
 
             viewMenu.TsExternalTools = _externalToolsToolStrip;
             viewMenu.TsQuickConnect = _quickConnectToolStrip;
@@ -292,8 +290,6 @@ namespace mRemoteNG.UI.Forms
 
             toolsMenu.MainForm = this;
             toolsMenu.CredentialProviderCatalog = Runtime.CredentialProviderCatalog;
-
-            _quickConnectToolStrip.ConnectionInitiator = connectionInitiator;
         }
 
         //Theming support

--- a/mRemoteNG/UI/Menu/FileMenu.cs
+++ b/mRemoteNG/UI/Menu/FileMenu.cs
@@ -22,7 +22,6 @@ namespace mRemoteNG.UI.Menu
         private ToolStripSeparator _mMenFileSep1;
 
         public ConnectionTreeWindow TreeWindow { get; set; }
-        public IConnectionInitiator ConnectionInitiator { get; set; }
 
         public FileMenu()
         {

--- a/mRemoteNG/UI/Menu/ViewMenu.cs
+++ b/mRemoteNG/UI/Menu/ViewMenu.cs
@@ -32,7 +32,6 @@ namespace mRemoteNG.UI.Menu
         public ToolStrip TsMultiSsh { get; set; }
         public FullscreenHandler FullscreenHandler { get; set; }
         public FrmMain MainForm { get; set; }
-        public IConnectionInitiator ConnectionInitiator { get; set; }
 
 
         public ViewMenu()
@@ -317,7 +316,7 @@ namespace mRemoteNG.UI.Menu
                 if (!(window is ConnectionWindow connectionWindow))
                     return;
 
-                connectionWindow.reconnectAll(ConnectionInitiator);
+                connectionWindow.reconnectAll(Runtime.ConnectionInitiator);
             }
         }
 

--- a/mRemoteNG/UI/Window/ConnectionTreeWindow.cs
+++ b/mRemoteNG/UI/Window/ConnectionTreeWindow.cs
@@ -24,7 +24,6 @@ namespace mRemoteNG.UI.Window
 {
     public partial class ConnectionTreeWindow
     {
-        private readonly IConnectionInitiator _connectionInitiator = new ConnectionInitiator();
         private ThemeManager _themeManager;
         private bool _sortedAz = true;
 
@@ -126,7 +125,7 @@ namespace mRemoteNG.UI.Window
         {
             ConnectionTree.NodeDeletionConfirmer =
                 new SelectedConnectionDeletionConfirmer(prompt => CTaskDialog.MessageBox(
-                    Application.ProductName,prompt,"",ETaskDialogButtons.YesNo,ESysIcons.Question));
+                    Application.ProductName, prompt, "", ETaskDialogButtons.YesNo, ESysIcons.Question));
             ConnectionTree.KeyDown += TvConnections_KeyDown;
             ConnectionTree.KeyPress += TvConnections_KeyPress;
             SetTreePostSetupActions();
@@ -143,7 +142,7 @@ namespace mRemoteNG.UI.Window
             };
 
             if (Settings.Default.OpenConsFromLastSession && !Settings.Default.NoReconnect)
-                actions.Add(new PreviousSessionOpener(_connectionInitiator));
+                actions.Add(new PreviousSessionOpener(Runtime.ConnectionInitiator));
 
             ConnectionTree.PostSetupActions = actions;
         }
@@ -157,15 +156,15 @@ namespace mRemoteNG.UI.Window
             };
 
             if (Settings.Default.SingleClickOnConnectionOpensIt)
-                singleClickHandlers.Add(new OpenConnectionClickHandler(_connectionInitiator));
+                singleClickHandlers.Add(new OpenConnectionClickHandler(Runtime.ConnectionInitiator));
             else
-                doubleClickHandlers.Add(new OpenConnectionClickHandler(_connectionInitiator));
+                doubleClickHandlers.Add(new OpenConnectionClickHandler(Runtime.ConnectionInitiator));
 
             if (Settings.Default.SingleClickSwitchesToOpenConnection)
-                singleClickHandlers.Add(new SwitchToConnectionClickHandler(_connectionInitiator));
+                singleClickHandlers.Add(new SwitchToConnectionClickHandler(Runtime.ConnectionInitiator));
 
-            ConnectionTree.SingleClickHandler = new TreeNodeCompositeClickHandler {ClickHandlers = singleClickHandlers};
-            ConnectionTree.DoubleClickHandler = new TreeNodeCompositeClickHandler {ClickHandlers = doubleClickHandlers};
+            ConnectionTree.SingleClickHandler = new TreeNodeCompositeClickHandler { ClickHandlers = singleClickHandlers };
+            ConnectionTree.DoubleClickHandler = new TreeNodeCompositeClickHandler { ClickHandlers = doubleClickHandlers };
         }
 
         private void ConnectionsServiceOnConnectionsLoaded(object o, ConnectionsLoadedEventArgs connectionsLoadedEventArgs)
@@ -237,7 +236,7 @@ namespace mRemoteNG.UI.Window
         private void FavoriteMenuItem_MouseUp(object sender, MouseEventArgs e)
         {
             if (((ToolStripMenuItem)sender).Tag is ContainerInfo) return;
-            _connectionInitiator.OpenConnection((ConnectionInfo)((ToolStripMenuItem)sender).Tag);
+            Runtime.ConnectionInitiator.OpenConnection((ConnectionInfo)((ToolStripMenuItem)sender).Tag);
         }
 
         #endregion
@@ -269,19 +268,19 @@ namespace mRemoteNG.UI.Window
                         ConnectionTree.Focus();
                         break;
                     case Keys.Up:
-                    {
-                        var match = ConnectionTree.NodeSearcher.PreviousMatch();
-                        JumpToNode(match);
-                        e.Handled = true;
-                        break;
-                    }
+                        {
+                            var match = ConnectionTree.NodeSearcher.PreviousMatch();
+                            JumpToNode(match);
+                            e.Handled = true;
+                            break;
+                        }
                     case Keys.Down:
-                    {
-                        var match = ConnectionTree.NodeSearcher.NextMatch();
-                        JumpToNode(match);
-                        e.Handled = true;
-                        break;
-                    }
+                        {
+                            var match = ConnectionTree.NodeSearcher.NextMatch();
+                            JumpToNode(match);
+                            e.Handled = true;
+                            break;
+                        }
                     default:
                         TvConnections_KeyDown(sender, e);
                         break;
@@ -365,7 +364,7 @@ namespace mRemoteNG.UI.Window
                     e.Handled = true;
                     if (SelectedNode == null)
                         return;
-                    _connectionInitiator.OpenConnection(SelectedNode);
+                    Runtime.ConnectionInitiator.OpenConnection(SelectedNode);
                 }
                 else if (e.Control && e.KeyCode == Keys.F)
                 {

--- a/mRemoteNG/UI/Window/ConnectionWindow.cs
+++ b/mRemoteNG/UI/Window/ConnectionWindow.cs
@@ -24,7 +24,6 @@ namespace mRemoteNG.UI.Window
 {
     public partial class ConnectionWindow : BaseWindow
     {
-        private readonly IConnectionInitiator _connectionInitiator = new ConnectionInitiator();
         private VisualStudioToolStripExtender vsToolStripExtender;
         private readonly ToolStripRenderer _toolStripProfessionalRenderer = new ToolStripProfessionalRenderer();
 
@@ -232,33 +231,33 @@ namespace mRemoteNG.UI.Window
             switch (DockState)
             {
                 case DockState.Float:
-                {
-                    if (_documentHandlersAdded)
                     {
-                        FrmMain.Default.ResizeBegin -= Connection_ResizeBegin;
-                        FrmMain.Default.ResizeEnd -= Connection_ResizeEnd;
-                        _documentHandlersAdded = false;
-                    }
+                        if (_documentHandlersAdded)
+                        {
+                            FrmMain.Default.ResizeBegin -= Connection_ResizeBegin;
+                            FrmMain.Default.ResizeEnd -= Connection_ResizeEnd;
+                            _documentHandlersAdded = false;
+                        }
 
-                    DockHandler.FloatPane.FloatWindow.ResizeBegin += Connection_ResizeBegin;
-                    DockHandler.FloatPane.FloatWindow.ResizeEnd += Connection_ResizeEnd;
-                    _floatHandlersAdded = true;
-                    break;
-                }
+                        DockHandler.FloatPane.FloatWindow.ResizeBegin += Connection_ResizeBegin;
+                        DockHandler.FloatPane.FloatWindow.ResizeEnd += Connection_ResizeEnd;
+                        _floatHandlersAdded = true;
+                        break;
+                    }
                 case DockState.Document:
-                {
-                    if (_floatHandlersAdded)
                     {
-                        DockHandler.FloatPane.FloatWindow.ResizeBegin -= Connection_ResizeBegin;
-                        DockHandler.FloatPane.FloatWindow.ResizeEnd -= Connection_ResizeEnd;
-                        _floatHandlersAdded = false;
-                    }
+                        if (_floatHandlersAdded)
+                        {
+                            DockHandler.FloatPane.FloatWindow.ResizeBegin -= Connection_ResizeBegin;
+                            DockHandler.FloatPane.FloatWindow.ResizeEnd -= Connection_ResizeEnd;
+                            _floatHandlersAdded = false;
+                        }
 
-                    FrmMain.Default.ResizeBegin += Connection_ResizeBegin;
-                    FrmMain.Default.ResizeEnd += Connection_ResizeEnd;
-                    _documentHandlersAdded = true;
-                    break;
-                }
+                        FrmMain.Default.ResizeBegin += Connection_ResizeBegin;
+                        FrmMain.Default.ResizeEnd += Connection_ResizeEnd;
+                        _documentHandlersAdded = true;
+                        break;
+                    }
             }
         }
 
@@ -725,7 +724,7 @@ namespace mRemoteNG.UI.Window
             {
                 var interfaceControl = GetInterfaceControl();
                 if (interfaceControl == null) return;
-                _connectionInitiator.OpenConnection(interfaceControl.Info, ConnectionInfo.Force.DoNotJump);
+                Runtime.ConnectionInitiator.OpenConnection(interfaceControl.Info, ConnectionInfo.Force.DoNotJump);
             }
             catch (Exception ex)
             {
@@ -746,7 +745,7 @@ namespace mRemoteNG.UI.Window
                 }
 
                 Invoke(new Action(() => Prot_Event_Closed(interfaceControl.Protocol)));
-                _connectionInitiator.OpenConnection(interfaceControl.Info, ConnectionInfo.Force.DoNotJump);
+                Runtime.ConnectionInitiator.OpenConnection(interfaceControl.Info, ConnectionInfo.Force.DoNotJump);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Description
I refactored all uses of ConnectionInitiator to share one instance accessed through `Runtime.ConnectionInitiator`.

## Motivation and Context
`mRemoteNG/Connection/ConnectionInitiator.cs` contains logic to associate connection tabs with entries in the connection tree, as well as a data structure that tracks active connections for the "reopen previous connections" feature. It doesn't seem like those purposes can be fulfilled unless the whole application only has one instance of a ConnectionInitiator. I could never reproduce issue #2119, but I suspect the myriad of places were a new ConnectionInitiator is constructed could be the problem.

## How Has This Been Tested?
Built with Visual Studio 2022, confirmed that tests were passing, tested multiple flows where connections were reopened after closing/reopening the app. I tested for regressions against the various ways to open a connection (quick connect toolbar, connection tree, context menu, etc).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
- [x ] My code follows the code style of this project.
- [x ] All Tests within VisualStudio are passing
- [x ] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
