### PR TITLE
Made changes to prevent two settings-scenarios that brick the app.

### DIFF
--- a/mRemoteNG/UI/Tabs/TabHelper.cs
+++ b/mRemoteNG/UI/Tabs/TabHelper.cs
@@ -48,8 +48,9 @@ namespace mRemoteNG.UI.Tabs
             set
             {
                 currentPanel = value;
-                Runtime.MessageCollector.AddMessage(Messages.MessageClass.DebugMsg,
-                                                    "Panel got focused: " + currentPanel.TabText);
+                //Disabled due to interaction with popups that would show this information and cause a softlock
+                //Runtime.MessageCollector.AddMessage(Messages.MessageClass.DebugMsg,
+                //                                    "Panel got focused: " + currentPanel.TabText);
             }
         }
     }

--- a/mRemoteNG/UI/Window/ConnectionTreeWindow.cs
+++ b/mRemoteNG/UI/Window/ConnectionTreeWindow.cs
@@ -141,7 +141,7 @@ namespace mRemoteNG.UI.Window
                 new RootNodeExpander()
             };
 
-            if (Settings.Default.OpenConsFromLastSession && !Settings.Default.NoReconnect)
+            if (Settings.Default.OpenConsFromLastSession && !Settings.Default.NoReconnect && !Settings.Default.AlwaysShowPanelSelectionDlg)
                 actions.Add(new PreviousSessionOpener(Runtime.ConnectionInitiator));
 
             ConnectionTree.PostSetupActions = actions;


### PR DESCRIPTION
## Description
Two changes:

- The DebugMsg that is created when a panel gains focus is now disabled
- The "Reconnect to previous sessions" action is skipped if the setting to "force a Panel selection dialog on every connection" is enabled

## Motivation and Context
I was looking at mRemoteNG/mRemoteNG#2128 when I discovered two settings configuration scenarios that can brick the app.

If "reconnect to previously opened sessions on startup" and "always show panel selections dialog" are both set True, then on startup when the app tries to reconnect it will present the panel selection form, which cannot be interacted-with because the startup-splash-logo is still present.

If "Informations" Popups are checked, then when one such popup is displayed, dismissing it will cause a panel focus event, which triggers another popup, which then will cause the same thing to happen when it is dismissed.

## How Has This Been Tested?
I used these code changes to unlock my mRemoteNG instance with the previously bad settings configurations. I think the changes are uninvasive enough to where no regressions will be created. Tests still pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
- [x ] My code follows the code style of this project.
- [x ] All Tests within VisualStudio are passing
- [x ] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
