### PR TITLE
Improve compatibility with Remote Desktop Connection Manager v2.83

### DIFF
--- a/mRemoteNG/Config/Serializers/MiscSerializers/RemoteDesktopConnectionManagerDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/MiscSerializers/RemoteDesktopConnectionManagerDeserializer.cs
@@ -183,8 +183,8 @@ namespace mRemoteNG.Config.Serializers.MiscSerializers
             {
 				if (bool.TryParse(connectionSettingsNode.SelectSingleNode("./connectToConsole")?.InnerText, out var useConsole))
 					connectionInfo.UseConsoleSession = useConsole;
-                connectionInfo.RDPStartProgram = connectionSettingsNode.SelectSingleNode("./startProgram")?.InnerText;
-                connectionInfo.RDPStartProgramWorkDir = connectionSettingsNode.SelectSingleNode("./startProgramWorkDir")?.InnerText;
+                connectionInfo.RDPStartProgram = connectionSettingsNode.SelectSingleNode("./startProgram")?.InnerText ?? string.Empty;
+                connectionInfo.RDPStartProgramWorkDir = connectionSettingsNode.SelectSingleNode("./startProgramWorkDir")?.InnerText ?? string.Empty;
                 if (int.TryParse(connectionSettingsNode.SelectSingleNode("./port")?.InnerText, out var port))
 					connectionInfo.Port = port;
             }

--- a/mRemoteNG/Config/Serializers/MiscSerializers/RemoteDesktopConnectionManagerDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/MiscSerializers/RemoteDesktopConnectionManagerDeserializer.cs
@@ -57,7 +57,7 @@ namespace mRemoteNG.Config.Serializers.MiscSerializers
             if (versionAttribute != null)
             {
                 var version = new Version(versionAttribute);
-                if (!(version == new Version(2, 7)))
+                if (!(version == new Version(2, 7)) && !(version == new Version(2, 83)))
                 {
                     throw new FileFormatException($"Unsupported file version ({version}).");
                 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Fixing Null value exception, when saving imported connections from Remote Desktop Connection Manager
- Allow importing connections from Remote Desktop Connection Manager v2.83

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After importing some connections from Remote Desktop Connection Manager the saved Connection File was empty and the log file showed following error:
```
[13] ERROR - SaveToXml failed
Value cannot be null. (Parameter 'value')
   at System.Xml.Linq.XAttribute..ctor(XName name, Object value)
```

It was not possible to import connections from the current version [v2.83](https://docs.microsoft.com/en-us/sysinternals/downloads/rdcman) of Remote Desktop Connection Manager.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With some personal connection files from Remote Desktop Connection Manager v2.7 and v2.83.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
