### PR TITLE
Update session display settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - #2138: Improve compatibility with Remote Desktop Connection Manager v2.83
 - #2123: Thycotic Secret Server - Added 2FA OTP support
+### Changed
+- #1546: Enable resize without reconnect for RDP Version Rdc9 or higher
  
 ## [1.77.2]
 ### Added

--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol8.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol8.cs
@@ -29,7 +29,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
             protected set
             {
                 base.SmartSize = value;
-                ReconnectForResize();
+                DoResizeClient();
             }
         }
 
@@ -39,7 +39,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
             protected set
             {
                 base.Fullscreen = value;
-                ReconnectForResize();
+                DoResizeClient();
             }
         }
 
@@ -50,19 +50,19 @@ namespace mRemoteNG.Connection.Protocol.RDP
 
         public override void Resize(object sender, EventArgs e)
         {
-            if (DoResize() && _controlBeginningSize.IsEmpty)
+            if (DoResizeControl() && _controlBeginningSize.IsEmpty)
             {
-                ReconnectForResize();
+                DoResizeClient();
             }
             base.Resize(sender, e);
         }
 
         public override void ResizeEnd(object sender, EventArgs e)
         {
-            DoResize();
+            DoResizeControl();
             if (!(Control.Size == _controlBeginningSize))
             {
-                ReconnectForResize();
+                DoResizeClient();
             }
             _controlBeginningSize = Size.Empty;
         }
@@ -72,7 +72,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
             return new AxMsRdpClient8NotSafeForScripting();
         }
 
-        private void ReconnectForResize()
+        private void DoResizeClient()
         {
             if (!loginComplete)
                 return;
@@ -95,7 +95,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
                 var size = Fullscreen
                     ? Screen.FromControl(Control).Bounds.Size
                     : Control.Size;
-                RdpClient8.Reconnect((uint)size.Width, (uint)size.Height);
+                UpdateSessionDisplaySettings((uint)size.Width, (uint)size.Height);
             }
             catch (Exception ex)
             {
@@ -106,7 +106,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
             }
         }
 
-        private bool DoResize()
+        private bool DoResizeControl()
         {
             Control.Location = InterfaceControl.Location;
             // kmscode - this doesn't look right to me. But I'm not aware of any functionality issues with this currently...
@@ -119,6 +119,11 @@ namespace mRemoteNG.Connection.Protocol.RDP
             {
                 return false;
             }
+        }
+
+        protected virtual void UpdateSessionDisplaySettings(uint width, uint height)
+        {
+            RdpClient8.Reconnect(width, height);
         }
     }
 }

--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol9.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol9.cs
@@ -1,15 +1,24 @@
 ﻿using System.Windows.Forms;
 using AxMSTSCLib;
+using MSTSCLib;
 
 namespace mRemoteNG.Connection.Protocol.RDP
 {
     public class RdpProtocol9 : RdpProtocol8
     {
+        private MsRdpClient9NotSafeForScripting RdpClient9 =>
+            (MsRdpClient9NotSafeForScripting)((AxHost)Control).GetOcx();
+
         protected override RdpVersion RdpProtocolVersion => RdpVersion.Rdc9;
 
         protected override AxHost CreateActiveXRdpClientControl()
         {
             return new AxMsRdpClient9NotSafeForScripting();
+        }
+
+        protected override void UpdateSessionDisplaySettings(uint width, uint height)
+        {
+            RdpClient9.UpdateSessionDisplaySettings(width, height, width, height, 0, 1, 1);
         }
     }
 }

--- a/mRemoteNGDocumentation/known_issues.rst
+++ b/mRemoteNGDocumentation/known_issues.rst
@@ -121,10 +121,11 @@ the following connection options are set:
 
 To prevent reconnecting, you can do one of several things:
 
+- Change RDP Version to Rdc9 or higher. Rdc9 supports resolution changes without reconnecting.
 - Change the resolution to Smart Size. This will scale the original connection area when the view window size changes. This does not preserve aspect ratio.
 - Turn off Automatic Resize. When the view window size changes, you will see scroll bars or dead space.
 
-There is no way to update the view window size without a reconnect.
+There is no way to update the view window size without a reconnect in RDP Version lower than Rdc9.
 This is an RDP protocol limitation.
 
 AltGr key combinations stop working in other apps when connected to RDP

--- a/mRemoteNGDocumentation/protocols/rdp.rst
+++ b/mRemoteNGDocumentation/protocols/rdp.rst
@@ -118,7 +118,16 @@ In RDP 8, support was improved for reconnecting RDP connections for resizing ope
 RDP 9
 -----
 
-We support this protocol version, but are not yet using any of its features.
+In RDP 9, support was further improved for reconnecting RDP connections for resizing operations.
+
+.. list-table::
+	:widths: 30 70
+	:header-rows: 1
+
+	* - Property
+	  - Description
+	* - Automatic Resize
+	  - When this property is enabled and ``Resolution`` is set to ``Fit to Panel`` and the connection window is resized, the RDP connection will automatically change the resolution without reconnecting.
 
 
 RDP 10


### PR DESCRIPTION
## Description

Use IMsRdpClient9::UpdateSessionDisplaySettings to dynamically update the
session display settings without reconnecting. RDP Version needs to be
Rdc9 or Highest for this to work.

## Motivation and Context

Fixes #1546

## How Has This Been Tested?

Tested locally by connecting and verifying that resolution changes properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

This modifies the resize behaviour.

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [x] I have updated the documentation accordingly, if necessary.
