### PR TITLE
Specify "Desktop Runtime" in Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You will need to compile it yourself using Visual Studio.
 ### Minimum Requirements
 
 * [Microsoft Visual C++ Redistributable for Visual Studio 2015 - 2022](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
-* [Microsoft .NET 6.0](https://dotnet.microsoft.com/download/dotnet/6.0)
+* [Microsoft .NET 6.0 Desktop Runtime](https://dotnet.microsoft.com/download/dotnet/6.0)
 * Microsoft Terminal Service Client 6.0 or later
   * Needed if you use RDP. mstscax.dll and/or msrdp.ocx be registered.
 


### PR DESCRIPTION
## Description
I updated the readme in order to reflect the requirement of using the .Net 6.0 Desktop runtime as the .Net 6.0 Runtime itself is not enough to run mRemoteNG.

## Motivation and Context
I'd like to make the life of an user easier by improving the documentation and clarify what software really is required. Issue #2229 gave me the motivation to do so.

## How Has This Been Tested?
Documentation was updated, no tests required. 

## Screenshots (if appropriate):
<left out intentionally>

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation
- [X] Updated Documentation

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [ ] ~My code follows the code style of this project.~
- [ ] ~All Tests within VisualStudio are passing~
- [X] This pull request does not target the master branch.
- [ ] ~I have updated the changelog file accordingly, if necessary.~
- [X] I have updated the documentation accordingly, if necessary.
