### PR TITLE
fix (Toolbar): Remove unused `modeToolStripmenuItem` from Main toolbar

### DIFF
--- a/mRemoteNG/UI/Forms/frmMain.Designer.cs
+++ b/mRemoteNG/UI/Forms/frmMain.Designer.cs
@@ -39,7 +39,6 @@
             this.viewMenu = new mRemoteNG.UI.Menu.ViewMenu();
             this.toolsMenu = new mRemoteNG.UI.Menu.ToolsMenu();
             this.helpMenu = new mRemoteNG.UI.Menu.HelpMenu();
-            this.modeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mMenSep3 = new System.Windows.Forms.ToolStripSeparator();
             this.tsContainer = new System.Windows.Forms.ToolStripContainer();
             this._quickConnectToolStrip = new mRemoteNG.UI.Controls.QuickConnectToolStrip();
@@ -47,7 +46,6 @@
             this._externalToolsToolStrip = new mRemoteNG.UI.Controls.ExternalToolsToolStrip();
             this.tmrAutoSave = new System.Windows.Forms.Timer(this.components);
             this.vsToolStripExtender = new WeifenLuo.WinFormsUI.Docking.VisualStudioToolStripExtender(this.components);
-            this.modeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tsModeAdmin = new System.Windows.Forms.ToolStripMenuItem();
             this.tsModeUser = new System.Windows.Forms.ToolStripMenuItem();
             this.msMain.SuspendLayout();
@@ -77,8 +75,7 @@
             this.fileMenu,
             this.viewMenu,
             this.toolsMenu,
-            this.helpMenu,
-            this.modeToolStripMenuItem});
+            this.helpMenu});
             this.msMain.Location = new System.Drawing.Point(3, 0);
             this.msMain.Name = "msMain";
             this.msMain.Padding = new System.Windows.Forms.Padding(0, 0, 1, 0);
@@ -124,11 +121,6 @@
             this.helpMenu.Size = new System.Drawing.Size(44, 19);
             this.helpMenu.Text = "&Help";
             this.helpMenu.TextDirection = System.Windows.Forms.ToolStripTextDirection.Horizontal;
-            // 
-            // modeToolStripMenuItem
-            // 
-            this.modeToolStripMenuItem.Name = "modeToolStripMenuItem";
-            this.modeToolStripMenuItem.Size = new System.Drawing.Size(12, 25);
             // 
             // mMenSep3
             // 
@@ -254,7 +246,6 @@
 		internal mRemoteNG.UI.Controls.MultiSshToolStrip _multiSshToolStrip;
         //theming support
         private WeifenLuo.WinFormsUI.Docking.VisualStudioToolStripExtender vsToolStripExtender;
-        private System.Windows.Forms.ToolStripMenuItem modeToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem tsModeAdmin;
         private System.Windows.Forms.ToolStripMenuItem tsModeUser;
     }


### PR DESCRIPTION
## Description
Remove unused `modeToolStripmenuitem` from main toolbar

## Motivation and Context
Remove used UI element, appears to serve no purpose.  
Resolves #2234

## How Has This Been Tested?
Visual test only, removed code, no new code.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
