### PR TITLE
Implement Show/Hide file menu in view menu

### DIFF
--- a/mRemoteNG/Language/Language.Designer.cs
+++ b/mRemoteNG/Language/Language.Designer.cs
@@ -1042,6 +1042,17 @@ namespace mRemoteNG.Resources.Language {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to reset the panels to their default layout?.
+        /// </summary>
+        internal static string FileMenuWillBeHiddenNow
+        {
+            get
+            {
+                return ResourceManager.GetString("FileMenuWillBeHiddenNow", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Connect.
         /// </summary>
         internal static string Connect {
@@ -3147,6 +3158,17 @@ namespace mRemoteNG.Resources.Language {
         internal static string Notifications {
             get {
                 return ResourceManager.GetString("Notifications", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to FileMenu.
+        /// </summary>
+        internal static string FileMenu
+        {
+            get
+            {
+                return ResourceManager.GetString("FileMenu", resourceCulture);
             }
         }
 

--- a/mRemoteNG/Language/Language.resx
+++ b/mRemoteNG/Language/Language.resx
@@ -2280,4 +2280,10 @@ Nightly Channel includes Alphas, Betas &amp; Release Candidates.</value>
   <data name="FiltermRemoteRemoteDesktopManagerCSV" xml:space="preserve">
     <value>Remote Desktop Manager Files (*.csv)</value>
   </data>
+  <data name="FileMenu" xml:space="preserve">
+    <value>File menu</value>
+  </data>
+  <data name="FileMenuWillBeHiddenNow" xml:space="preserve">
+    <value>File menu is hidded now. Press Alt button to peek</value>
+  </data>
 </root>

--- a/mRemoteNG/UI/Forms/frmMain.Designer.cs
+++ b/mRemoteNG/UI/Forms/frmMain.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace mRemoteNG.UI.Forms
+﻿using System.Windows.Forms;
+
+namespace mRemoteNG.UI.Forms
 {
 	public partial class FrmMain : System.Windows.Forms.Form
 	{
@@ -229,9 +231,22 @@
             this.tsContainer.ResumeLayout(false);
             this.tsContainer.PerformLayout();
             this.ResumeLayout(false);
-
 		}
-		internal WeifenLuo.WinFormsUI.Docking.DockPanel pnlDock;
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (keyData == (Keys.Alt | Keys.Menu))
+            {
+                if(!msMain.Visible)
+                {
+                    msMain.Visible = true;
+                }
+            }
+
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        internal WeifenLuo.WinFormsUI.Docking.DockPanel pnlDock;
 		internal System.Windows.Forms.MenuStrip msMain;
 		internal System.Windows.Forms.ToolStripContainer tsContainer;
 		internal System.Windows.Forms.Timer tmrAutoSave;

--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -727,7 +727,22 @@ namespace mRemoteNG.UI.Forms
             Windows.ErrorsForm.Show(pnlDock, DockState.DockBottomAutoHide);
             viewMenu._mMenViewErrorsAndInfos.Checked = true;
 
+            ShowFileMenu();
+
             pnlDock.Visible = true;
+        }
+
+        public void ShowFileMenu()
+        {
+            msMain.Visible = true;
+            viewMenu._mMenViewFileMenu.Checked = true;
+        }
+
+        public void HideFileMenu()
+        {
+            msMain.Visible = false;
+            viewMenu._mMenViewFileMenu.Checked = false;
+            MessageBox.Show(Language.FileMenuWillBeHiddenNow, string.Empty, MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
 
         public void SetLayout()

--- a/mRemoteNG/UI/Menu/msMain/ViewMenu.cs
+++ b/mRemoteNG/UI/Menu/msMain/ViewMenu.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Windows.Forms;
 using mRemoteNG.App;
-using mRemoteNG.Connection;
 using mRemoteNG.Properties;
+using mRemoteNG.Resources.Language;
 using mRemoteNG.UI.Forms;
 using mRemoteNG.UI.Panels;
 using mRemoteNG.UI.Window;
-using mRemoteNG.Resources.Language;
 
 namespace mRemoteNG.UI.Menu
 {
@@ -16,6 +15,7 @@ namespace mRemoteNG.UI.Menu
         private ToolStripMenuItem _mMenReconnectAll;
         private ToolStripSeparator _mMenViewSep1;
         public ToolStripMenuItem _mMenViewErrorsAndInfos;
+        public ToolStripMenuItem _mMenViewFileMenu;
         private ToolStripMenuItem _mMenViewAddConnectionPanel;
         private ToolStripSeparator _mMenViewSep2;
         private ToolStripMenuItem _mMenViewFullscreen;
@@ -45,6 +45,7 @@ namespace mRemoteNG.UI.Menu
             _mMenViewAddConnectionPanel = new ToolStripMenuItem();
             _mMenViewConnectionPanels = new ToolStripMenuItem();
             _mMenViewSep1 = new ToolStripSeparator();
+            _mMenViewFileMenu = new ToolStripMenuItem();
             _mMenViewErrorsAndInfos = new ToolStripMenuItem();
             _mMenViewResetLayout = new ToolStripMenuItem();
             _mMenViewLockToolbars = new ToolStripMenuItem();
@@ -60,6 +61,7 @@ namespace mRemoteNG.UI.Menu
             // 
             DropDownItems.AddRange(new ToolStripItem[]
             {
+                _mMenViewFileMenu,
                 _mMenViewErrorsAndInfos,
                 _mMenViewQuickConnectToolbar,
                 _mMenViewExtAppsToolbar,
@@ -105,6 +107,15 @@ namespace mRemoteNG.UI.Menu
             // 
             _mMenViewSep1.Name = "mMenViewSep1";
             _mMenViewSep1.Size = new System.Drawing.Size(225, 6);
+            // 
+            // mMenViewFile
+            // 
+            _mMenViewFileMenu.Checked = true;
+            _mMenViewFileMenu.CheckState = CheckState.Checked;
+            _mMenViewFileMenu.Name = "mMenViewFile";
+            _mMenViewFileMenu.Size = new System.Drawing.Size(228, 22);
+            _mMenViewFileMenu.Text = Language.FileMenu;
+            _mMenViewFileMenu.Click += mMenViewFileMenu_Click;
             // 
             // mMenViewErrorsAndInfos
             // 
@@ -221,6 +232,18 @@ namespace mRemoteNG.UI.Menu
             {
                 Windows.ErrorsForm.Hide();
                 _mMenViewErrorsAndInfos.Checked = false;
+            }
+        }
+
+        private void mMenViewFileMenu_Click(object sender, EventArgs e)
+        {
+            if (_mMenViewFileMenu.Checked == false)
+            {
+                MainForm.ShowFileMenu();
+            }
+            else
+            {
+                MainForm.HideFileMenu();
             }
         }
 


### PR DESCRIPTION
## Description
Add an option to Hide/Show file menu

## Motivation and Context
Screen real estate is pricy when connecting to remote systems with graphical UI
The file menu strip is not used frequently but there is no way to hide it
So i dediced to implement that functionality by:
   - in View menu add 'File menu' as first item. Checked by default
   - when clicking on checked item, it will show dialog that warns that file menu will be hidden, pressing ALT button will peek it
   - when clicking on un-checked item, the file menu will be shown
   - when clicking on reset view menu item, the the file menu will be shown

## How Has This Been Tested?
Tested manually on my win, 10 pro environment

## Screenshots (if appropriate):
![mRemoteNG_fZJmGZ82sD](https://user-images.githubusercontent.com/212429/178035520-59c9e024-8c0c-4a25-b42a-da60c844585c.gif)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

