### PR TITLE
support extraction of SSH private keys from external cred prov

### DIFF
--- a/ExternalConnectors/ExternalConnectors.csproj
+++ b/ExternalConnectors/ExternalConnectors.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="AWSSDK.Core" Version="3.7.12.15" />
     <PackageReference Include="AWSSDK.EC2" Version="3.7.79.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ExternalConnectors/PuttyKeyFileGenerator.cs
+++ b/ExternalConnectors/PuttyKeyFileGenerator.cs
@@ -1,0 +1,109 @@
+﻿using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ExternalConnectors;
+
+public class PuttyKeyFileGenerator
+{
+    private const int prefixSize = 4;
+    private const int paddedPrefixSize = prefixSize + 1;
+    private const int lineLength = 64;
+    private const string keyType = "ssh-rsa";
+    private const string encryptionType = "none";
+
+    // source from
+    // https://gist.github.com/canton7/5670788?permalink_comment_id=3240331
+    // https://gist.github.com/bosima/ee6630d30b533c7d7b2743a849e9b9d0
+
+    public static string ToPuttyPrivateKey(RSACryptoServiceProvider cryptoServiceProvider, string Comment = "imported-openssh-key")
+    {
+        var publicParameters = cryptoServiceProvider.ExportParameters(false);
+        byte[] publicBuffer = new byte[3 + keyType.Length + GetPrefixSize(publicParameters.Exponent) + publicParameters.Exponent.Length +
+                GetPrefixSize(publicParameters.Modulus) + publicParameters.Modulus.Length + 1];
+
+        using (var bw = new BinaryWriter(new MemoryStream(publicBuffer)))
+        {
+            bw.Write(new byte[] { 0x00, 0x00, 0x00 });
+            bw.Write(keyType);
+            PutPrefixed(bw, publicParameters.Exponent, CheckIsNeddPadding(publicParameters.Exponent));
+            PutPrefixed(bw, publicParameters.Modulus, CheckIsNeddPadding(publicParameters.Modulus));
+        }
+        var publicBlob = System.Convert.ToBase64String(publicBuffer);
+
+        var privateParameters = cryptoServiceProvider.ExportParameters(true);
+        byte[] privateBuffer = new byte[paddedPrefixSize + privateParameters.D.Length + paddedPrefixSize + privateParameters.P.Length + paddedPrefixSize + privateParameters.Q.Length + paddedPrefixSize + privateParameters.InverseQ.Length];
+
+        using (var bw = new BinaryWriter(new MemoryStream(privateBuffer)))
+        {
+            PutPrefixed(bw, privateParameters.D, true);
+            PutPrefixed(bw, privateParameters.P, true);
+            PutPrefixed(bw, privateParameters.Q, true);
+            PutPrefixed(bw, privateParameters.InverseQ, true);
+        }
+        var privateBlob = System.Convert.ToBase64String(privateBuffer);
+
+        HMACSHA1 hmacsha1 = new HMACSHA1(new SHA1CryptoServiceProvider().ComputeHash(Encoding.ASCII.GetBytes("putty-private-key-file-mac-key")));
+        //byte[] bytesToHash = new byte[4 + 7 + 4 + 4 + 4 + Comment.Length + 4 + publicBuffer.Length + 4 + privateBuffer.Length];
+        byte[] bytesToHash = new byte[prefixSize + keyType.Length + prefixSize + encryptionType.Length + prefixSize + Comment.Length +
+                                      prefixSize + publicBuffer.Length + prefixSize + privateBuffer.Length];
+
+        using (var bw = new BinaryWriter(new MemoryStream(bytesToHash)))
+        {
+            PutPrefixed(bw, Encoding.ASCII.GetBytes("ssh-rsa"));
+            PutPrefixed(bw, Encoding.ASCII.GetBytes("none"));
+            PutPrefixed(bw, Encoding.ASCII.GetBytes(Comment));
+            PutPrefixed(bw, publicBuffer);
+            PutPrefixed(bw, privateBuffer);
+        }
+
+        var hash = string.Join("", hmacsha1.ComputeHash(bytesToHash).Select(x => string.Format("{0:x2}", x)));
+
+        var sb = new StringBuilder();
+        sb.AppendLine("PuTTY-User-Key-File-2: " + keyType);
+        sb.AppendLine("Encryption: " + encryptionType);
+        sb.AppendLine("Comment: " + Comment);
+
+        var publicLines = SpliceText(publicBlob, lineLength);
+        sb.AppendLine("Public-Lines: " + publicLines.Length);
+        foreach (var line in publicLines)
+        {
+            sb.AppendLine(line);
+        }
+
+        var privateLines = SpliceText(privateBlob, lineLength);
+        sb.AppendLine("Private-Lines: " + privateLines.Length);
+        foreach (var line in privateLines)
+        {
+            sb.AppendLine(line);
+        }
+
+        sb.AppendLine("Private-MAC: " + hash);
+
+        return sb.ToString();
+    }
+    private static void PutPrefixed(BinaryWriter bw, byte[] bytes, bool addLeadingNull = false)
+    {
+        bw.Write(BitConverter.GetBytes(bytes.Length + (addLeadingNull ? 1 : 0)).Reverse().ToArray());
+        if (addLeadingNull)
+            bw.Write(new byte[] { 0x00 });
+        bw.Write(bytes);
+    }
+    
+    private static string[] SpliceText(string text, int lineLength)
+    {
+        return Regex.Matches(text, ".{1," + lineLength + "}").Cast<Match>().Select(m => m.Value).ToArray();
+    }
+    private static int GetPrefixSize(byte[] bytes)
+    {
+        return CheckIsNeddPadding(bytes) ? paddedPrefixSize : prefixSize;
+    }
+    private static bool CheckIsNeddPadding(byte[] bytes)
+    {
+        // 128 == 10000000
+        // This means that the number of bits can be divided by 8.
+        // According to the algorithm in putty, you need to add a padding.
+        return bytes[0] >= 128;
+    }
+
+}

--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol6.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol6.cs
@@ -409,14 +409,15 @@ namespace mRemoteNG.Connection.Protocol.RDP
                             string gwu = connectionInfo.RDGatewayUsername;
                             string gwp = connectionInfo.RDGatewayPassword;
                             string gwd = connectionInfo.RDGatewayDomain;
+                            string pkey = "";
 
                             // access secret server api if necessary
                             if (InterfaceControl.Info.RDGatewayExternalCredentialProvider == ExternalCredentialProvider.DelineaSecretServer)
                             {
                                 try
                                 {
-                                    string idviaapi = InterfaceControl.Info.RDGatewayUserViaAPI;
-                                    ExternalConnectors.DSS.SecretServerInterface.FetchSecretFromServer($"{idviaapi}", out gwu, out gwp, out gwd);
+                                    string RDGUserViaAPI = InterfaceControl.Info.RDGatewayUserViaAPI;
+                                    ExternalConnectors.DSS.SecretServerInterface.FetchSecretFromServer($"{RDGUserViaAPI}", out gwu, out gwp, out gwd, out pkey);
                                 }
                                 catch (Exception ex)
                                 {
@@ -494,13 +495,14 @@ namespace mRemoteNG.Connection.Protocol.RDP
                 var password = connectionInfo?.Password ?? "";
                 var domain = connectionInfo?.Domain ?? "";
                 var UserViaAPI = connectionInfo?.UserViaAPI ?? "";
+                string pkey = "";
 
                 // access secret server api if necessary
                 if (InterfaceControl.Info.ExternalCredentialProvider == ExternalCredentialProvider.DelineaSecretServer)
                 {
                     try
                     {
-                        ExternalConnectors.DSS.SecretServerInterface.FetchSecretFromServer($"{UserViaAPI}", out userName, out password, out domain);
+                        ExternalConnectors.DSS.SecretServerInterface.FetchSecretFromServer($"{UserViaAPI}", out userName, out password, out domain, out pkey);
                     }
                     catch (Exception ex)
                     {
@@ -522,7 +524,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
                         case "custom":
                             try
                             {
-                                ExternalConnectors.DSS.SecretServerInterface.FetchSecretFromServer("SSAPI:" + Properties.OptionsCredentialsPage.Default.UserViaAPDefault, out userName, out password, out domain);
+                                ExternalConnectors.DSS.SecretServerInterface.FetchSecretFromServer(Properties.OptionsCredentialsPage.Default.UserViaAPIDefault, out userName, out password, out domain, out pkey);
                                 _rdpClient.UserName = userName;
                             }
                             catch (Exception ex)

--- a/mRemoteNG/Language/Language.resx
+++ b/mRemoteNG/Language/Language.resx
@@ -2200,10 +2200,10 @@ Nightly Channel includes Alphas, Betas &amp; Release Candidates.</value>
     <comment>https://docs.microsoft.com/en-us/windows/win32/termserv/imstscsecuredsettings-workdir</comment>
   </data>
   <data name="OpeningCommand" xml:space="preserve">
-    <value>TODO</value>
+    <value>OpeningCommand TODO</value>
   </data>
   <data name="PropertyDescriptionOpeningCommand" xml:space="preserve">
-    <value>TODO</value>
+    <value>Description of OpeningCommand TODO</value>
   </data>
   <data name="RedirectDrives" xml:space="preserve">
     <value>Disk Drives</value>

--- a/mRemoteNG/Properties/OptionsCredentialsPage.Designer.cs
+++ b/mRemoteNG/Properties/OptionsCredentialsPage.Designer.cs
@@ -8,6 +8,8 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
+using Connection;
+
 namespace mRemoteNG.Properties {
     
     
@@ -58,16 +60,31 @@ namespace mRemoteNG.Properties {
                 this["DefaultDomain"] = value;
             }
         }
-        
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string UserViaAPDefault {
+        public ExternalCredentialProvider ExternalCredentialProviderDefault
+        {
+            get
+            {
+                return ((ExternalCredentialProvider)(this["ExternalCredentialProviderDefault"]));
+            }
+            set
+            {
+                this["ExternalCredentialProviderDefault"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string UserViaAPIDefault {
             get {
-                return ((string)(this["UserViaAPDefault"]));
+                return ((string)(this["UserViaAPIDefault"]));
             }
             set {
-                this["UserViaAPDefault"] = value;
+                this["UserViaAPIDefault"] = value;
             }
         }
         

--- a/mRemoteNG/UI/Forms/OptionsPages/CredentialsPage.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/CredentialsPage.cs
@@ -54,7 +54,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             txtCredentialsPassword.Text =
                 cryptographyProvider.Decrypt(Properties.OptionsCredentialsPage.Default.DefaultPassword, Runtime.EncryptionKey);
             txtCredentialsDomain.Text = Properties.OptionsCredentialsPage.Default.DefaultDomain;
-            txtCredentialsUserViaAPI.Text = Properties.OptionsCredentialsPage.Default.UserViaAPDefault;
+            txtCredentialsUserViaAPI.Text = Properties.OptionsCredentialsPage.Default.UserViaAPIDefault;
         }
 
         public override void SaveSettings()
@@ -77,7 +77,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             Properties.OptionsCredentialsPage.Default.DefaultPassword =
                 cryptographyProvider.Encrypt(txtCredentialsPassword.Text, Runtime.EncryptionKey);
             Properties.OptionsCredentialsPage.Default.DefaultDomain = txtCredentialsDomain.Text;
-            Properties.OptionsCredentialsPage.Default.UserViaAPDefault = txtCredentialsUserViaAPI.Text;
+            Properties.OptionsCredentialsPage.Default.UserViaAPIDefault = txtCredentialsUserViaAPI.Text;
         }
 
         private void radCredentialsCustom_CheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
mremote can now extract ssh private keys from external credential provider (DSS) for ssh authentication

supported formats: rsa, rsa with passphrase, putty private key



