### PR TITLE
Fix for splash screen to appear on the primary screen.

### DIFF
--- a/mRemoteNG/App/ProgramRoot.cs
+++ b/mRemoteNG/App/ProgramRoot.cs
@@ -33,7 +33,7 @@ namespace mRemoteNG.App
 
             var frmSplashScreen = FrmSplashScreenNew.GetInstance();
 
-            Screen targetScreen = (Screen.AllScreens.Length > 1) ? Screen.AllScreens[1] : Screen.AllScreens[0];
+            var targetScreen = Screen.PrimaryScreen;
 
             Rectangle viewport = targetScreen.WorkingArea;
             frmSplashScreen.Top = viewport.Top;


### PR DESCRIPTION
## Description
This code change will make the splash screen always appear on the primary screen.

## Motivation and Context
Currently, the splash screen appears on the first or second monitor, and the check in the code is made against the number of monitors. This code change fixes this behavior to always show on the primary screen.

## How Has This Been Tested?
Executed and run locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [ ] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
