### PR TITLE
set language.resx to auto generate the designer class

### DIFF
--- a/mRemoteNG/Language/Language.Designer.cs
+++ b/mRemoteNG/Language/Language.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace mRemoteNG.Resources.Language {
     using System;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,15 +23,15 @@ namespace mRemoteNG.Resources.Language {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Language {
-
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Language() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace mRemoteNG.Resources.Language {
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,7 +59,7 @@ namespace mRemoteNG.Resources.Language {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Browse....
         /// </summary>
@@ -68,7 +68,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_Browse", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Cancel.
         /// </summary>
@@ -77,7 +77,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_Cancel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Close.
         /// </summary>
@@ -86,7 +86,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_Close", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Warn me when closing connections.
         /// </summary>
@@ -95,7 +95,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_CloseWarnAll", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Delete.
         /// </summary>
@@ -104,7 +104,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_Delete", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Export to File....
         /// </summary>
@@ -113,7 +113,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_ExportToFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;File.
         /// </summary>
@@ -122,7 +122,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_File", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Help.
         /// </summary>
@@ -131,7 +131,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_Help", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Import.
         /// </summary>
@@ -140,7 +140,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_Import", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Launch.
         /// </summary>
@@ -149,7 +149,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_Launch", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;New.
         /// </summary>
@@ -158,7 +158,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_New", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;OK.
         /// </summary>
@@ -167,7 +167,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_Ok", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Scan.
         /// </summary>
@@ -176,7 +176,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_Scan", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Stop.
         /// </summary>
@@ -185,7 +185,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_Stop", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Tools.
         /// </summary>
@@ -194,7 +194,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_Tools", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Try again.
         /// </summary>
@@ -203,7 +203,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_TryAgain", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;View.
         /// </summary>
@@ -212,7 +212,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("_View", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to About.
         /// </summary>
@@ -221,7 +221,34 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("About", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hidden.
+        /// </summary>
+        internal static string ACLPermissionsHidden {
+            get {
+                return ResourceManager.GetString("ACLPermissionsHidden", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ReadOnly.
+        /// </summary>
+        internal static string ACLPermissionsReadOnly {
+            get {
+                return ResourceManager.GetString("ACLPermissionsReadOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to WriteAllow.
+        /// </summary>
+        internal static string ACLPermissionsWriteAllow {
+            get {
+                return ResourceManager.GetString("ACLPermissionsWriteAllow", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Active Directory.
         /// </summary>
@@ -230,7 +257,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ActiveDirectory", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Add.
         /// </summary>
@@ -239,7 +266,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Add", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Add Connection Panel.
         /// </summary>
@@ -248,7 +275,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AddConnectionPanel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to AddNodeFromXML failed!.
         /// </summary>
@@ -257,7 +284,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AddNodeFromXmlFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Address:.
         /// </summary>
@@ -266,7 +293,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Address", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Advanced.
         /// </summary>
@@ -275,7 +302,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Advanced", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Advanced security options.
         /// </summary>
@@ -284,7 +311,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AdvancedSecurityOptions", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to All.
         /// </summary>
@@ -293,7 +320,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("All", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Allow only a single instance of the application (mRemoteNG restart required).
         /// </summary>
@@ -302,7 +329,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AllowOnlySingleInstance", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Always.
         /// </summary>
@@ -311,7 +338,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Always", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Always connect, even if authentication fails.
         /// </summary>
@@ -320,7 +347,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AlwaysConnectEvenIfAuthFails", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Always show connection tabs.
         /// </summary>
@@ -329,7 +356,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AlwaysShowConnectionTabs", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Always show panel selection dialog when opening connections.
         /// </summary>
@@ -338,7 +365,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AlwaysShowPanelSelection", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Always show panel tabs.
         /// </summary>
@@ -347,7 +374,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AlwaysShowPanelTabs", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Always show notification area icon.
         /// </summary>
@@ -356,7 +383,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AlwaysShowSysTrayIcon", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Appearance.
         /// </summary>
@@ -365,7 +392,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Appearance", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Apply.
         /// </summary>
@@ -374,34 +401,34 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Apply", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Sucht eine lokalisierte Zeichenfolge, die Apply default inheritance ähnelt.
+        ///   Looks up a localized string similar to Apply default inheritance.
         /// </summary>
         internal static string ApplyDefaultInheritance {
             get {
                 return ResourceManager.GetString("ApplyDefaultInheritance", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Sucht eine lokalisierte Zeichenfolge, die Apply inheritance to children ähnelt.
+        ///   Looks up a localized string similar to Apply inheritance to children.
         /// </summary>
         internal static string ApplyInheritanceToChildren {
             get {
                 return ResourceManager.GetString("ApplyInheritanceToChildren", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Sucht eine lokalisierte Zeichenfolge, die Arguments ähnelt.
+        ///   Looks up a localized string similar to Arguments.
         /// </summary>
         internal static string Arguments {
             get {
                 return ResourceManager.GetString("Arguments", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Ask me again later.
         /// </summary>
@@ -410,7 +437,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AskUpdatesCommandAskLater", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Customize the settings now.
         /// </summary>
@@ -419,7 +446,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AskUpdatesCommandCustom", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use the recommended settings.
         /// </summary>
@@ -428,7 +455,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AskUpdatesCommandRecommended", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} can automatically check for updates that may provide new features and bug fixes. It is recommended that you allow {0} to check for updates weekly..
         /// </summary>
@@ -437,7 +464,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AskUpdatesContent", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Automatic update settings.
         /// </summary>
@@ -446,7 +473,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AskUpdatesMainInstruction", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Aspect.
         /// </summary>
@@ -455,7 +482,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Aspect", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Assigned Credential.
         /// </summary>
@@ -464,7 +491,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AssignedCredential", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Audio Capture.
         /// </summary>
@@ -473,7 +500,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AudioCapture", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Server Authentication.
         /// </summary>
@@ -482,7 +509,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AuthenticationLevel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Authentication mode.
         /// </summary>
@@ -491,7 +518,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AuthenticationMode", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An error occurred while trying to reconnect to RDP host &apos;{0}&apos;.
         /// </summary>
@@ -500,7 +527,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AutomaticReconnectError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Automatic resize.
         /// </summary>
@@ -509,7 +536,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AutomaticResize", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Auto save time in minutes (0 means disabled):.
         /// </summary>
@@ -518,7 +545,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AutoSaveEvery", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Latest version.
         /// </summary>
@@ -527,7 +554,16 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("AvailableVersion", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Browse.
+        /// </summary>
+        internal static string btnBrowsePath {
+            get {
+                return ResourceManager.GetString("btnBrowsePath", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Default Inheritance.
         /// </summary>
@@ -536,7 +572,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ButtonDefaultInheritance", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Default Properties.
         /// </summary>
@@ -545,7 +581,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ButtonDefaultProperties", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Launch PuTTY.
         /// </summary>
@@ -554,7 +590,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ButtonLaunchPutty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Cache Bitmaps.
         /// </summary>
@@ -563,7 +599,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CacheBitmaps", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Cannot start Port Scan, incorrect IP format!.
         /// </summary>
@@ -572,7 +608,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CannotStartPortScan", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Change.
         /// </summary>
@@ -581,7 +617,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Change", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An error occurred while trying to change the connection resolution to host &apos;{0}&apos;.
         /// </summary>
@@ -590,7 +626,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ChangeConnectionResolutionError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Changelog.
         /// </summary>
@@ -599,7 +635,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Changelog", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Check Again.
         /// </summary>
@@ -608,7 +644,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CheckAgain", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Automatically try to reconnect when disconnected from server (RDP &amp;&amp; ICA only).
         /// </summary>
@@ -617,7 +653,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CheckboxAutomaticReconnect", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Do not show this message again..
         /// </summary>
@@ -626,7 +662,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CheckboxDoNotShowThisMessageAgain", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to This proxy server requires authentication.
         /// </summary>
@@ -635,7 +671,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CheckboxProxyAuthentication", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use custom PuTTY path:.
         /// </summary>
@@ -644,7 +680,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CheckboxPuttyPath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Reconnect when ready.
         /// </summary>
@@ -653,7 +689,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CheckboxReconnectWhenReady", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use a proxy server to connect.
         /// </summary>
@@ -662,7 +698,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CheckboxUpdateUseProxy", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Check failed!.
         /// </summary>
@@ -671,7 +707,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CheckFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Check for Updates.
         /// </summary>
@@ -680,7 +716,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CheckForUpdates", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Check for updates at startup.
         /// </summary>
@@ -689,7 +725,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CheckForUpdatesOnStartup", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Check now.
         /// </summary>
@@ -698,7 +734,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CheckNow", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Check proper installation of components at startup.
         /// </summary>
@@ -707,7 +743,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CheckProperInstallationOfComponentsAtStartup", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Choose a path for the mRemoteNG log file.
         /// </summary>
@@ -716,7 +752,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ChooseLogPath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Choose panel before connecting.
         /// </summary>
@@ -725,7 +761,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ChoosePanelBeforeConnecting", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Choose path.
         /// </summary>
@@ -734,7 +770,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ChoosePath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Clear search string.
         /// </summary>
@@ -743,7 +779,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ClearSearchString", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Clipboard.
         /// </summary>
@@ -752,7 +788,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Clipboard", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Closed Ports.
         /// </summary>
@@ -761,7 +797,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ClosedPorts", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Close to notification area.
         /// </summary>
@@ -770,7 +806,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CloseToSysTray", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to When closing connections:.
         /// </summary>
@@ -779,7 +815,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ClosingConnections", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Collapse all folders.
         /// </summary>
@@ -788,16 +824,16 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CollapseAllFolders", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Colours.
+        ///   Looks up a localized string similar to Colors.
         /// </summary>
         internal static string Colors {
             get {
                 return ResourceManager.GetString("Colors", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to E&amp;xit {0}.
         /// </summary>
@@ -806,7 +842,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CommandExitProgram", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t parse command line args!.
         /// </summary>
@@ -815,7 +851,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CommandLineArgsCouldNotBeParsed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Open a connection file.
         /// </summary>
@@ -824,7 +860,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CommandOpenConnectionFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} has detected the Lenovo Auto Scroll Utility running on this system. This utility is known to cause problems with {0}. It is recommended that you disable or uninstall it..
         /// </summary>
@@ -833,7 +869,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CompatibilityLenovoAutoScrollUtilityDetected", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Compatibility problem detected.
         /// </summary>
@@ -842,7 +878,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CompatibilityProblemDetected", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Compression.
         /// </summary>
@@ -851,7 +887,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Compression", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Config.
         /// </summary>
@@ -860,7 +896,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Config", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to btnIcon_Click failed!.
         /// </summary>
@@ -869,7 +905,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfigPropertyGridButtonIconClickFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to ShowHideGridItems failed!.
         /// </summary>
@@ -878,7 +914,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfigPropertyGridHideItemsFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to IconMenu_Click failed!.
         /// </summary>
@@ -887,7 +923,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfigPropertyGridMenuClickFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Property Grid object failed!.
         /// </summary>
@@ -896,7 +932,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfigPropertyGridObjectFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SetHostStatus failed!.
         /// </summary>
@@ -905,7 +941,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfigPropertyGridSetHostStatusFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to pGrid_PopertyValueChanged failed!.
         /// </summary>
@@ -914,7 +950,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfigPropertyGridValueFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Config UI load failed!.
         /// </summary>
@@ -923,7 +959,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfigUiLoadFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Create a New Connection File.
         /// </summary>
@@ -932,7 +968,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfigurationCreateNew", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use a Custom File Path.
         /// </summary>
@@ -941,7 +977,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfigurationCustomPath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Import an Existing File.
         /// </summary>
@@ -950,7 +986,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfigurationImportFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to close all connections except for &quot;{0}&quot;?.
         /// </summary>
@@ -959,7 +995,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfirmCloseConnectionOthersInstruction", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to close the panel, &quot;{0}&quot;? Any connections that it contains will also be closed..
         /// </summary>
@@ -968,7 +1004,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfirmCloseConnectionPanelMainInstruction", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to delete the credential record, {0}?.
         /// </summary>
@@ -977,7 +1013,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfirmDeleteCredentialRecord", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to delete the external tool, &quot;{0}&quot;?.
         /// </summary>
@@ -986,7 +1022,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfirmDeleteExternalTool", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to delete the {0} selected external tools?.
         /// </summary>
@@ -995,7 +1031,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfirmDeleteExternalToolMultiple", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to delete the connection, &quot;{0}&quot;?.
         /// </summary>
@@ -1004,7 +1040,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfirmDeleteNodeConnection", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to delete the empty folder, &quot;{0}&quot;?.
         /// </summary>
@@ -1013,7 +1049,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfirmDeleteNodeFolder", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to delete the folder, &quot;{0}&quot;? Any folders or connections that it contains will also be deleted..
         /// </summary>
@@ -1022,7 +1058,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfirmDeleteNodeFolderNotEmpty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Do you want to close all open connections?.
         /// </summary>
@@ -1031,7 +1067,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfirmExitMainInstruction", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Are you sure you want to reset the panels to their default layout?.
         /// </summary>
@@ -1040,18 +1076,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConfirmResetLayout", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to reset the panels to their default layout?.
-        /// </summary>
-        internal static string FileMenuWillBeHiddenNow
-        {
-            get
-            {
-                return ResourceManager.GetString("FileMenuWillBeHiddenNow", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connect.
         /// </summary>
@@ -1060,7 +1085,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Connect", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connect in fullscreen mode.
         /// </summary>
@@ -1069,7 +1094,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectInFullscreen", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connecting....
         /// </summary>
@@ -1078,7 +1103,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Connecting", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connect in View Only mode.
         /// </summary>
@@ -1087,7 +1112,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectInViewOnlyMode", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connection.
         /// </summary>
@@ -1096,7 +1121,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Connection", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Protocol Event Connected.
         /// </summary>
@@ -1105,7 +1130,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionEventConnected", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connection to &quot;{0}&quot; via &quot;{1}&quot; established by user &quot;{2}&quot; (Description: &quot;{3}&quot;; User Field: &quot;{4}&quot;).
         /// </summary>
@@ -1114,7 +1139,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionEventConnectedDetail", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A connection protocol error occurred. Host: &quot;{1}&quot;; Error code: &quot;{2}&quot;; Error Description: &quot;{0}&quot;.
         /// </summary>
@@ -1123,7 +1148,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionEventErrorOccured", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connection failed!.
         /// </summary>
@@ -1132,7 +1157,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The connection file could not be found..
         /// </summary>
@@ -1141,7 +1166,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionFileNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Opening connection failed!.
         /// </summary>
@@ -1150,7 +1175,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionOpenFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Cannot open connection: No hostname specified!.
         /// </summary>
@@ -1159,7 +1184,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionOpenFailedNoHostname", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connection Panels.
         /// </summary>
@@ -1168,7 +1193,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionPanels", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connections.
         /// </summary>
@@ -1177,7 +1202,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Connections", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Daily.
         /// </summary>
@@ -1186,7 +1211,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionsBackupFrequencyDaily", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Never backup connections.
         /// </summary>
@@ -1195,7 +1220,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionsBackupFrequencyNever", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to On Edit.
         /// </summary>
@@ -1204,7 +1229,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionsBackupFrequencyOnEdit", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to On Exit.
         /// </summary>
@@ -1213,7 +1238,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionsBackupFrequencyOnExit", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Weekly.
         /// </summary>
@@ -1222,7 +1247,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionsBackupFrequencyWeekly", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t set default port!.
         /// </summary>
@@ -1231,7 +1256,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionSetDefaultPortFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t create backup of connections file!.
         /// </summary>
@@ -1240,7 +1265,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionsFileBackupFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connections file &quot;{0}&quot; could not be loaded!.
         /// </summary>
@@ -1249,7 +1274,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionsFileCouldNotBeLoaded", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connections file &quot;{0}&quot; could not be loaded!
         ///Starting with new connections file..
@@ -1259,7 +1284,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionsFileCouldNotBeLoadedNew", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t save connections file as &quot;{0}&quot;!.
         /// </summary>
@@ -1268,7 +1293,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionsFileCouldNotSaveAs", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connection successful.
         /// </summary>
@@ -1277,7 +1302,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectionSuccessful", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connect without credentials.
         /// </summary>
@@ -1286,7 +1311,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectNoCredentials", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connect to console session.
         /// </summary>
@@ -1295,7 +1320,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectToConsoleSession", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connect (with options).
         /// </summary>
@@ -1304,7 +1329,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnectWithOptions", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connection to {0} via {1} closed by user {2}..
         /// </summary>
@@ -1313,7 +1338,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnenctionClosedByUser", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connection Event Closed.
         /// </summary>
@@ -1322,7 +1347,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnenctionCloseEvent", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connection Event Closed failed!.
         /// </summary>
@@ -1331,7 +1356,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ConnenctionCloseEventFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Copy.
         /// </summary>
@@ -1340,7 +1365,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Copy", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Copy All.
         /// </summary>
@@ -1349,7 +1374,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CopyAll", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Copy Hostname.
         /// </summary>
@@ -1358,7 +1383,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CopyHostname", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t create new connections file!.
         /// </summary>
@@ -1367,7 +1392,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CouldNotCreateNewConnectionsFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Could not find external tool with name &quot;{0}&quot;.
         /// </summary>
@@ -1376,7 +1401,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CouldNotFindExternalTool", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Could not find ToolStrip control in FilteredPropertyGrid..
         /// </summary>
@@ -1385,7 +1410,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CouldNotFindToolStripInFilteredPropertyGrid", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Create an empty panel when mRemoteNG starts.
         /// </summary>
@@ -1394,7 +1419,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CreateEmptyPanelOnStartUp", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Credentials.
         /// </summary>
@@ -1403,7 +1428,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Credentials", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Credential not available.
         /// </summary>
@@ -1412,7 +1437,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CredentialUnavailable", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Credits.
         /// </summary>
@@ -1421,7 +1446,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Credits", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Ctrl-Alt-Del.
         /// </summary>
@@ -1430,7 +1455,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CtrlAltDel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Ctrl-Esc.
         /// </summary>
@@ -1439,7 +1464,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("CtrlEsc", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Daily.
         /// </summary>
@@ -1448,7 +1473,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Daily", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Database:.
         /// </summary>
@@ -1457,7 +1482,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Database", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Database &apos;{0}&apos; not available..
         /// </summary>
@@ -1466,7 +1491,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DatabaseNotAvailable", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Debug.
         /// </summary>
@@ -1475,7 +1500,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Debug", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Delete.
         /// </summary>
@@ -1484,7 +1509,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Delete", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Delete All.
         /// </summary>
@@ -1493,7 +1518,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DeleteAll", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Delete External Tool....
         /// </summary>
@@ -1502,7 +1527,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DeleteExternalTool", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Description.
         /// </summary>
@@ -1511,7 +1536,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Description", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Detect.
         /// </summary>
@@ -1520,7 +1545,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Detect", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Disable Cursor blinking.
         /// </summary>
@@ -1529,7 +1554,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DisableCursorBlinking", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Disable Cursor Shadow.
         /// </summary>
@@ -1538,7 +1563,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DisableCursorShadow", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Disable Full Window drag.
         /// </summary>
@@ -1547,7 +1572,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DisableFullWindowDrag", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Disable Menu Animations.
         /// </summary>
@@ -1556,7 +1581,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DisableMenuAnimations", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Disconnect.
         /// </summary>
@@ -1565,7 +1590,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Disconnect", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Disconnect All But This.
         /// </summary>
@@ -1574,7 +1599,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DisconnectOthers", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Disconnect Tabs To The Right.
         /// </summary>
@@ -1583,7 +1608,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DisconnectOthersRight", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Disk Drives.
         /// </summary>
@@ -1592,7 +1617,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DiskDrives", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Display.
         /// </summary>
@@ -1601,7 +1626,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Display", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Display Name.
         /// </summary>
@@ -1610,7 +1635,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DisplayName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Display Themes.
         /// </summary>
@@ -1619,7 +1644,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DisplayThemes", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Display Wallpaper.
         /// </summary>
@@ -1628,7 +1653,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DisplayWallpaper", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Domain.
         /// </summary>
@@ -1637,79 +1662,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Domain", resourceCulture);
             }
         }
-
-        internal static string ExternalAddressProvider
-        {
-            get
-            {
-                return ResourceManager.GetString("ExternalAddressProvider", resourceCulture);
-            }
-        }
-        internal static string PropertyDescriptionExternalAddressProvider
-        {
-            get
-            {
-                return ResourceManager.GetString("PropertyDescriptionExternalAddressProvider", resourceCulture);
-            }
-        }
-        internal static string EAPNone
-        {
-            get
-            {
-                return ResourceManager.GetString("EAPNone", resourceCulture);
-            }
-        }
-        internal static string EAPAmazonWebServices
-        {
-            get
-            {
-                return ResourceManager.GetString("EAPAmazonWebServices", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to EC2InstanceId.
-        /// </summary>
-        internal static string EC2InstanceId
-        {
-            get
-            {
-                return ResourceManager.GetString("EC2InstanceId", resourceCulture);
-            }
-        }
-        /// <summary>
-        ///   Looks up a localized string similar to PropertyDescriptionEC2InstanceId.
-        /// </summary>
-        internal static string PropertyDescriptionEC2InstanceId
-        {
-            get
-            {
-                return ResourceManager.GetString("PropertyDescriptionEC2InstanceId", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to EC2InstanceId.
-        /// </summary>
-        internal static string EC2Region
-        {
-            get
-            {
-                return ResourceManager.GetString("EC2Region", resourceCulture);
-            }
-        }
-        /// <summary>
-        ///   Looks up a localized string similar to PropertyDescriptionEC2InstanceId.
-        /// </summary>
-        internal static string PropertyDescriptionEC2Region
-        {
-            get
-            {
-                return ResourceManager.GetString("PropertyDescriptionEC2Region", resourceCulture);
-            }
-        }
-
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Donate.
         /// </summary>
@@ -1718,7 +1671,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Donate", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Do not play.
         /// </summary>
@@ -1727,7 +1680,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DoNotPlay", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Do not trim spaces from usernames.
         /// </summary>
@@ -1736,7 +1689,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DoNotTrimUsername", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Don&apos;t connect to console session.
         /// </summary>
@@ -1745,7 +1698,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DontConnectToConsoleSession", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Don&apos;t connect if authentication fails.
         /// </summary>
@@ -1754,7 +1707,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DontConnectWhenAuthFails", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Double click on tab closes it.
         /// </summary>
@@ -1763,7 +1716,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DoubleClickTabClosesIt", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Download.
         /// </summary>
@@ -1772,7 +1725,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Download", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Download and Install.
         /// </summary>
@@ -1781,7 +1734,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DownloadAndInstall", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Duplicate.
         /// </summary>
@@ -1790,7 +1743,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Duplicate", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Duplicate Tab.
         /// </summary>
@@ -1799,7 +1752,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("DuplicateTab", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Dynamic.
         /// </summary>
@@ -1808,7 +1761,61 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Dynamic", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AmazonEC2.
+        /// </summary>
+        internal static string EAPAmazonWebServices {
+            get {
+                return ResourceManager.GetString("EAPAmazonWebServices", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to None.
+        /// </summary>
+        internal static string EAPNone {
+            get {
+                return ResourceManager.GetString("EAPNone", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to EC2 Instance Id.
+        /// </summary>
+        internal static string EC2InstanceId {
+            get {
+                return ResourceManager.GetString("EC2InstanceId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to EC2 Region.
+        /// </summary>
+        internal static string EC2Region {
+            get {
+                return ResourceManager.GetString("EC2Region", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delinea Secret Server.
+        /// </summary>
+        internal static string ECPDelineaSecretServer {
+            get {
+                return ResourceManager.GetString("ECPDelineaSecretServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to None.
+        /// </summary>
+        internal static string ECPNone {
+            get {
+                return ResourceManager.GetString("ECPNone", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Do you want to continue with no password?.
         /// </summary>
@@ -1817,7 +1824,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("EmptyPasswordContinue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to For empty Username, Password or Domain fields use:.
         /// </summary>
@@ -1826,7 +1833,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("EmptyUsernamePasswordDomainFields", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Desktop Composition.
         /// </summary>
@@ -1835,7 +1842,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("EnableDesktopComposition", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Encoding.
         /// </summary>
@@ -1844,7 +1851,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Encoding", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Completely encrypt connection file.
         /// </summary>
@@ -1853,7 +1860,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("EncryptCompleteConnectionFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Block Cipher Mode.
         /// </summary>
@@ -1862,7 +1869,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("EncryptionBlockCipherMode", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Encryption Engine.
         /// </summary>
@@ -1871,7 +1878,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("EncryptionEngine", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Key Derivation Function Iterations.
         /// </summary>
@@ -1880,7 +1887,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("EncryptionKeyDerivationIterations", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Encryption Test.
         /// </summary>
@@ -1889,7 +1896,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("EncryptionTest", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Encrypting {0} entries using {1}/{2} and {3} iterations took {4} seconds..
         /// </summary>
@@ -1898,7 +1905,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("EncryptionTestResultMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Environment.
         /// </summary>
@@ -1907,7 +1914,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Environment", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to AddExternalToolsToToolBar (frmMain) failed. {0}.
         /// </summary>
@@ -1916,7 +1923,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ErrorAddExternalToolsToToolBarFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to AddFolder (UI.Window.ConnectionTreeWindow) failed. {0}.
         /// </summary>
@@ -1925,7 +1932,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ErrorAddFolderFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The database version {0} is not compatible with this version of {1}..
         /// </summary>
@@ -1934,7 +1941,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ErrorBadDatabaseVersion", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The connection list could not be saved..
         /// </summary>
@@ -1943,7 +1950,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ErrorConnectionListSaveFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to PuTTY could not be launched..
         /// </summary>
@@ -1952,7 +1959,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ErrorCouldNotLaunchPutty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Decryption failed. {0}.
         /// </summary>
@@ -1961,7 +1968,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ErrorDecryptionFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Encryption failed. {0}.
         /// </summary>
@@ -1970,9 +1977,9 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ErrorEncryptionFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to The Windows security setting, &quot;System cryptography: Use FIPS compliant algorithms for encryption, hashing, and signing&quot;, is enabled.
+        ///   Looks up a localized string similar to The Windows security setting, &quot;System cryptography: Use FIPS compliant algorithms for encryption, hashing, and signing&quot;, is enabled. 
         ///
         ///See the Microsoft Support article at http://support.microsoft.com/kb/811833 for more information.
         ///
@@ -1983,7 +1990,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ErrorFipsPolicyIncompatible", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Errors.
         /// </summary>
@@ -1992,7 +1999,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Errors", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The startup connection file could not be loaded.{0}{0}{2}{0}{3}{0}{0}In order to prevent data loss, {1} will now exit..
         /// </summary>
@@ -2001,7 +2008,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ErrorStartupConnectionFileLoad", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to VerifyDatabaseVersion (Config.Connections.Save) failed. {0}.
         /// </summary>
@@ -2010,7 +2017,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ErrorVerifyDatabaseVersionFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to This exception will force mRemoteNG to close.
         /// </summary>
@@ -2019,7 +2026,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExceptionForcesmRemoteNGToClose", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Exception Message.
         /// </summary>
@@ -2028,7 +2035,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExceptionMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Exit.
         /// </summary>
@@ -2037,7 +2044,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Exit", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Expand all folders.
         /// </summary>
@@ -2046,7 +2053,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExpandAllFolders", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Experimental.
         /// </summary>
@@ -2055,7 +2062,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Experimental", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Export.
         /// </summary>
@@ -2064,7 +2071,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Export", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Export everything.
         /// </summary>
@@ -2073,7 +2080,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExportEverything", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Export File.
         /// </summary>
@@ -2082,7 +2089,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExportFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Export Items.
         /// </summary>
@@ -2091,7 +2098,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExportItems", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Export Properties.
         /// </summary>
@@ -2100,7 +2107,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExportProperties", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Export the currently selected connection.
         /// </summary>
@@ -2109,7 +2116,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExportSelectedConnection", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Export the currently selected folder.
         /// </summary>
@@ -2118,7 +2125,25 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExportSelectedFolder", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to External Address Provider.
+        /// </summary>
+        internal static string ExternalAddressProvider {
+            get {
+                return ResourceManager.GetString("ExternalAddressProvider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to External Credential Provider.
+        /// </summary>
+        internal static string ExternalCredentialProvider {
+            get {
+                return ResourceManager.GetString("ExternalCredentialProvider", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to External Tool.
         /// </summary>
@@ -2127,7 +2152,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExternalTool", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to External Tool After.
         /// </summary>
@@ -2136,7 +2161,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExternalToolAfter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to External Tool Before.
         /// </summary>
@@ -2145,7 +2170,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExternalToolBefore", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to New External Tool.
         /// </summary>
@@ -2154,7 +2179,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExternalToolDefaultName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to External Tool Properties.
         /// </summary>
@@ -2163,7 +2188,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExternalToolProperties", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to External Tools Toolbar.
         /// </summary>
@@ -2172,7 +2197,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ExternalToolsToolbar", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Favorite.
         /// </summary>
@@ -2181,7 +2206,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Favorite", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Favorites.
         /// </summary>
@@ -2190,7 +2215,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Favorites", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to File &amp;Format:.
         /// </summary>
@@ -2199,7 +2224,25 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FileFormat", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File menu.
+        /// </summary>
+        internal static string FileMenu {
+            get {
+                return ResourceManager.GetString("FileMenu", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File menu is hidded now. Press Alt button to peek.
+        /// </summary>
+        internal static string FileMenuWillBeHiddenNow {
+            get {
+                return ResourceManager.GetString("FileMenuWillBeHiddenNow", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Filename.
         /// </summary>
@@ -2208,7 +2251,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Filename", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Files.
         /// </summary>
@@ -2217,7 +2260,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Files", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to All Files (*.*).
         /// </summary>
@@ -2226,7 +2269,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FilterAll", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to All importable files.
         /// </summary>
@@ -2235,7 +2278,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FilterAllImportable", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Application Files (*.exe).
         /// </summary>
@@ -2244,7 +2287,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FilterApplication", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to mRemote CSV Files (*.csv).
         /// </summary>
@@ -2253,16 +2296,16 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FiltermRemoteCSV", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Remote Desktop Manager CSV Files (*.csv).
+        ///   Looks up a localized string similar to Remote Desktop Manager Files (*.csv).
         /// </summary>
         internal static string FiltermRemoteRemoteDesktopManagerCSV {
             get {
                 return ResourceManager.GetString("FiltermRemoteRemoteDesktopManagerCSV", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to mRemote XML Files (*.xml).
         /// </summary>
@@ -2271,7 +2314,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FiltermRemoteXML", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to PuTTY Connection Manager files.
         /// </summary>
@@ -2280,7 +2323,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FilterPuttyConnectionManager", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Remote Desktop Connection Manager files (*.rdg).
         /// </summary>
@@ -2289,7 +2332,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FilterRdgFiles", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP Files (*.rdp).
         /// </summary>
@@ -2298,7 +2341,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FilterRDP", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Filter search matches in connection tree.
         /// </summary>
@@ -2307,7 +2350,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FilterSearchMatchesInConnectionTree", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to First IP.
         /// </summary>
@@ -2316,7 +2359,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FirstIp", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to First Port.
         /// </summary>
@@ -2325,7 +2368,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FirstPort", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Fit To Panel.
         /// </summary>
@@ -2334,7 +2377,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FitToPanel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Font Smoothing.
         /// </summary>
@@ -2343,7 +2386,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FontSmoothing", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Inherit {0}.
         /// </summary>
@@ -2352,7 +2395,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FormatInherit", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Description of inherited property: {0}.
         /// </summary>
@@ -2361,7 +2404,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("FormatInheritDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Free.
         /// </summary>
@@ -2370,7 +2413,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Free", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Fullscreen.
         /// </summary>
@@ -2379,16 +2422,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Fullscreen", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Gateway.
-        /// </summary>
-        internal static string RDPGateway {
-            get {
-                return ResourceManager.GetString("RDPGateway", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to General.
         /// </summary>
@@ -2397,7 +2431,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("General", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An error occured while loading the connection entry for &quot;{0}&quot; from &quot;{1}&quot;. {2}.
         /// </summary>
@@ -2406,7 +2440,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("GetConnectionInfoFromXmlFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Automatic Reconnect.
         /// </summary>
@@ -2415,7 +2449,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("GroupboxAutomaticReconnect", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to mRemoteNG Help.
         /// </summary>
@@ -2424,7 +2458,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("HelpContents", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to High.
         /// </summary>
@@ -2433,7 +2467,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("High", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Host.
         /// </summary>
@@ -2442,7 +2476,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Host", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Hostname:.
         /// </summary>
@@ -2451,7 +2485,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Hostname", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Hostname/IP.
         /// </summary>
@@ -2460,7 +2494,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("HostnameIp", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to HTTP.
         /// </summary>
@@ -2469,7 +2503,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Http", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Edge Chromium.
         /// </summary>
@@ -2478,7 +2512,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("HttpCEF", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to HTTP Connect Failed!.
         /// </summary>
@@ -2487,7 +2521,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("HttpConnectFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t create new HTTP Connection!.
         /// </summary>
@@ -2496,7 +2530,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("HttpConnectionFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Changing HTTP Document Tile Failed!.
         /// </summary>
@@ -2505,7 +2539,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("HttpDocumentTileChangeFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Failed to contruct the URL to load.
         /// </summary>
@@ -2514,7 +2548,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("HttpFailedUrlBuild", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Internet Explorer.
         /// </summary>
@@ -2523,7 +2557,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("HttpInternetExplorer", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to HTTPS.
         /// </summary>
@@ -2532,7 +2566,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Https", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Set HTTP Props failed!.
         /// </summary>
@@ -2541,7 +2575,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("HttpSetPropsFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Icon.
         /// </summary>
@@ -2550,7 +2584,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Icon", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Identify quick connect tabs by adding the prefix &quot;Quick:&quot;.
         /// </summary>
@@ -2559,7 +2593,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("IdentifyQuickConnectTabs", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Import from Active Directory.
         /// </summary>
@@ -2568,7 +2602,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ImportAD", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An error occurred while importing the file &quot;{0}&quot;..
         /// </summary>
@@ -2577,7 +2611,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ImportFileFailedContent", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Import from &amp;File....
         /// </summary>
@@ -2586,7 +2620,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ImportFromFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Import from Port Scan.
         /// </summary>
@@ -2595,7 +2629,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ImportPortScan", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Import sub OUs.
         /// </summary>
@@ -2604,7 +2638,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ImportSubOUs", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Informations.
         /// </summary>
@@ -2613,7 +2647,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Informations", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Inheritance.
         /// </summary>
@@ -2622,7 +2656,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Inheritance", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Dispose of Int App process failed!.
         /// </summary>
@@ -2631,7 +2665,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("IntAppDisposeFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Int App Focus Failed!.
         /// </summary>
@@ -2640,7 +2674,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("IntAppFocusFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Int App Handle: {0}.
         /// </summary>
@@ -2649,7 +2683,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("IntAppHandle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Killing Int App Process failed!.
         /// </summary>
@@ -2658,7 +2692,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("IntAppKillFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Int App Resize failed!.
         /// </summary>
@@ -2667,7 +2701,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("IntAppResizeFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to --- IntApp Stuff ---.
         /// </summary>
@@ -2676,7 +2710,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("IntAppStuff", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Int App Title: {0}.
         /// </summary>
@@ -2685,7 +2719,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("IntAppTitle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to (Automatically Detect).
         /// </summary>
@@ -2694,7 +2728,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LanguageDefault", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} must be restarted before changes to the language will take effect..
         /// </summary>
@@ -2703,7 +2737,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LanguageRestartRequired", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Language.
         /// </summary>
@@ -2712,7 +2746,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LanguageString", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Last IP.
         /// </summary>
@@ -2721,7 +2755,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LastIp", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Last Port.
         /// </summary>
@@ -2730,7 +2764,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LastPort", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Launch External Tool.
         /// </summary>
@@ -2739,7 +2773,70 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LaunchExternalTool", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ACL for user.
+        /// </summary>
+        internal static string lblACL {
+            get {
+                return ResourceManager.GetString("lblACL", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Backups for connection data.
+        /// </summary>
+        internal static string lblBackupEnable {
+            get {
+                return ResourceManager.GetString("lblBackupEnable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Backup file name format.
+        /// </summary>
+        internal static string lblBackupNameFormat {
+            get {
+                return ResourceManager.GetString("lblBackupNameFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Backup type.
+        /// </summary>
+        internal static string lblBackupType {
+            get {
+                return ResourceManager.GetString("lblBackupType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Connection Backup Frequency.
+        /// </summary>
+        internal static string lblConnectionsBackupFrequency {
+            get {
+                return ResourceManager.GetString("lblConnectionsBackupFrequency", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum number of backups.
+        /// </summary>
+        internal static string lblConnectionsBackupMaxCount {
+            get {
+                return ResourceManager.GetString("lblConnectionsBackupMaxCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select location for connection data backup folder.
+        /// </summary>
+        internal static string lblConnectionsBackupPath {
+            get {
+                return ResourceManager.GetString("lblConnectionsBackupPath", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to License.
         /// </summary>
@@ -2748,7 +2845,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("License", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Load Balance Info.
         /// </summary>
@@ -2757,7 +2854,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LoadBalanceInfo", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use UTF8 encoding for RDP &quot;Load Balance Info&quot; property.
         /// </summary>
@@ -2766,7 +2863,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LoadBalanceInfoUseUtf8", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Load from SQL failed.
         /// </summary>
@@ -2775,7 +2872,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LoadFromSqlFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The connection information could not be loaded from the SQL server..
         /// </summary>
@@ -2784,7 +2881,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LoadFromSqlFailedContent", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Load From XML failed!.
         /// </summary>
@@ -2793,7 +2890,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LoadFromXmlFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Local file.
         /// </summary>
@@ -2802,7 +2899,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LocalFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Local file does not exist!.
         /// </summary>
@@ -2811,7 +2908,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LocalFileDoesNotExist", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Lock toolbar positions.
         /// </summary>
@@ -2820,7 +2917,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LockToolbars", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Log file path.
         /// </summary>
@@ -2829,7 +2926,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LogFilePath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Logging.
         /// </summary>
@@ -2838,7 +2935,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Logging", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Login failed for user &apos;{0}&apos;..
         /// </summary>
@@ -2847,7 +2944,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LoginFailedForUser", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Log these message types.
         /// </summary>
@@ -2856,7 +2953,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LogTheseMessageTypes", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Log to application directory.
         /// </summary>
@@ -2865,7 +2962,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("LogToAppDir", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to MAC Address.
         /// </summary>
@@ -2874,7 +2971,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("MacAddress", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Medium.
         /// </summary>
@@ -2883,7 +2980,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Medium", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Message.
         /// </summary>
@@ -2892,7 +2989,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Message", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Minimize to notification area.
         /// </summary>
@@ -2901,7 +2998,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("MinimizeToSysTray", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Minutes to Idle.
         /// </summary>
@@ -2910,7 +3007,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("MinutesToIdleTimeout", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Miscellaneous.
         /// </summary>
@@ -2919,7 +3016,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Miscellaneous", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Monthly.
         /// </summary>
@@ -2928,7 +3025,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Monthly", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Move down.
         /// </summary>
@@ -2937,7 +3034,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("MoveDown", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Move up.
         /// </summary>
@@ -2946,7 +3043,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("MoveUp", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to mRemoteNG CSV.
         /// </summary>
@@ -2955,7 +3052,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("MremoteNgCsv", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to mRemoteNG Unhandled Exception.
         /// </summary>
@@ -2964,7 +3061,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("mRemoteNGUnhandledException", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to mRemoteNG XML.
         /// </summary>
@@ -2973,7 +3070,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("MremoteNgXml", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Multi SSH:.
         /// </summary>
@@ -2982,7 +3079,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("MultiSsh", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Multi SSH toolbar.
         /// </summary>
@@ -2991,7 +3088,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("MultiSshToolbar", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Press ENTER to send. Ctrl+C is sent immediately..
         /// </summary>
@@ -3000,7 +3097,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("MultiSshToolTip", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Must Be Between 0 and 255.
         /// </summary>
@@ -3009,7 +3106,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("MustBeBetween0And255", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to My current credentials (Windows logon information).
         /// </summary>
@@ -3018,7 +3115,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("MyCurrentWindowsCreds", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Name.
         /// </summary>
@@ -3027,7 +3124,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Name", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Never.
         /// </summary>
@@ -3036,7 +3133,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Never", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to New Connection.
         /// </summary>
@@ -3045,7 +3142,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NewConnection", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to New Connection File.
         /// </summary>
@@ -3054,7 +3151,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NewConnectionFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to New External Tool.
         /// </summary>
@@ -3063,7 +3160,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NewExternalTool", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to New Folder.
         /// </summary>
@@ -3072,7 +3169,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NewFolder", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to New Panel.
         /// </summary>
@@ -3081,7 +3178,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NewPanel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to New Title.
         /// </summary>
@@ -3090,7 +3187,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NewTitle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No.
         /// </summary>
@@ -3099,7 +3196,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("No", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No сompression.
         /// </summary>
@@ -3108,7 +3205,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NoCompression", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to This node is already in this folder..
         /// </summary>
@@ -3117,7 +3214,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NodeAlreadyInFolder", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Cannot drag node onto itself..
         /// </summary>
@@ -3126,7 +3223,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NodeCannotDragOnSelf", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Cannot drag parent node onto child..
         /// </summary>
@@ -3135,7 +3232,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NodeCannotDragParentOnChild", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to This node is not draggable..
         /// </summary>
@@ -3144,7 +3241,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NodeNotDraggable", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No ext. app specified..
         /// </summary>
@@ -3153,7 +3250,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NoExtAppDefined", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to None.
         /// </summary>
@@ -3162,7 +3259,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("None", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Normal.
         /// </summary>
@@ -3171,7 +3268,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Normal", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No SmartSize.
         /// </summary>
@@ -3180,7 +3277,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NoSmartSize", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Notifications.
         /// </summary>
@@ -3189,18 +3286,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Notifications", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to FileMenu.
-        /// </summary>
-        internal static string FileMenu
-        {
-            get
-            {
-                return ResourceManager.GetString("FileMenu", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No update available.
         /// </summary>
@@ -3209,7 +3295,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NoUpdateAvailable", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to You are trying to load a connection file that was created using an very early version of mRemote, this could result in an runtime error.
         ///If you run into such an error, please create a new connection file!.
@@ -3219,7 +3305,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("OldConffile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Open a different file.
         /// </summary>
@@ -3228,7 +3314,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("OpenADifferentFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Open Connection File....
         /// </summary>
@@ -3237,7 +3323,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("OpenConnectionFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Open file.
         /// </summary>
@@ -3246,16 +3332,16 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("OpenFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Opening Command.
+        ///   Looks up a localized string similar to OpeningCommand TODO.
         /// </summary>
         internal static string OpeningCommand {
             get {
                 return ResourceManager.GetString("OpeningCommand", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Open new tab to the right of the currently selected tab.
         /// </summary>
@@ -3264,7 +3350,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("OpenNewTabRight", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Open Ports.
         /// </summary>
@@ -3273,7 +3359,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("OpenPorts", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Options.
         /// </summary>
@@ -3282,7 +3368,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Options", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to mRemoteNG Options.
         /// </summary>
@@ -3291,7 +3377,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("OptionsPageTitle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Testing....
         /// </summary>
@@ -3300,7 +3386,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("OptionsProxyTesting", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Warning: Restart is required to commit any theme configuration change..
         /// </summary>
@@ -3309,7 +3395,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("OptionsThemeChangeWarning", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Do you really want to delete the theme?.
         /// </summary>
@@ -3318,7 +3404,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("OptionsThemeDeleteConfirmation", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to New theme name.
         /// </summary>
@@ -3327,7 +3413,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("OptionsThemeNewThemeCaption", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Cannot create theme, name already present or special characters in the name.
         /// </summary>
@@ -3336,7 +3422,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("OptionsThemeNewThemeError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Type the new theme name.
         /// </summary>
@@ -3345,7 +3431,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("OptionsThemeNewThemeText", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Out Of Range.
         /// </summary>
@@ -3354,7 +3440,16 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("OutOfRange", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Page control in Options menu.
+        /// </summary>
+        internal static string PageСontrolInOptionsMenu {
+            get {
+                return ResourceManager.GetString("PageСontrolInOptionsMenu", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Panel.
         /// </summary>
@@ -3363,7 +3458,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Panel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Panel Handle: {0}.
         /// </summary>
@@ -3372,7 +3467,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PanelHandle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Panel Name.
         /// </summary>
@@ -3381,7 +3476,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PanelName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Password.
         /// </summary>
@@ -3390,7 +3485,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Password", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Password must contain at least {0} of the following characters: {1}.
         /// </summary>
@@ -3399,7 +3494,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PasswordConstainsSpecialCharactersConstraintHint", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Password must contain at least {0} lower case character(s).
         /// </summary>
@@ -3408,7 +3503,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PasswordContainsLowerCaseConstraintHint", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Password must contain at least {0} number(s).
         /// </summary>
@@ -3417,7 +3512,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PasswordContainsNumbersConstraint", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Password must contain at least {0} upper case character(s).
         /// </summary>
@@ -3426,7 +3521,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PasswordContainsUpperCaseConstraintHint", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Password length must be between {0} and {1}.
         /// </summary>
@@ -3435,7 +3530,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PasswordLengthConstraintHint", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Password protect.
         /// </summary>
@@ -3444,7 +3539,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PasswordProtect", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Both passwords must match..
         /// </summary>
@@ -3453,7 +3548,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PasswordStatusMustMatch", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The password must be at least 3 characters long..
         /// </summary>
@@ -3462,7 +3557,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PasswordStatusTooShort", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Place search bar above connection tree.
         /// </summary>
@@ -3471,7 +3566,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PlaceSearchBarAboveConnectionTree", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Please fill all fields.
         /// </summary>
@@ -3480,7 +3575,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PleaseFillAllFields", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Popups.
         /// </summary>
@@ -3489,7 +3584,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Popups", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Port.
         /// </summary>
@@ -3498,7 +3593,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Port", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Portable Edition.
         /// </summary>
@@ -3507,7 +3602,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PortableEdition", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Ports.
         /// </summary>
@@ -3516,7 +3611,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Ports", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Port Scan.
         /// </summary>
@@ -3525,7 +3620,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PortScan", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Port scan complete..
         /// </summary>
@@ -3534,7 +3629,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PortScanComplete", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t load PortScan panel!.
         /// </summary>
@@ -3543,7 +3638,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PortScanCouldNotLoadPanel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to PowerShell.
         /// </summary>
@@ -3552,7 +3647,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PowerShell", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Printers.
         /// </summary>
@@ -3561,7 +3656,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Printers", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Properties.
         /// </summary>
@@ -3570,7 +3665,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Properties", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Toggle all inheritance options..
         /// </summary>
@@ -3579,7 +3674,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionAll", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select which authentication level this connection should use..
         /// </summary>
@@ -3588,7 +3683,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionAuthenticationLevel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select how you want to authenticate against the VNC server..
         /// </summary>
@@ -3597,7 +3692,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionAuthenticationMode", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select whether to automatically resize the connection when the window is resized or when fullscreen mode is toggled. Requires RDC 8.0 or higher..
         /// </summary>
@@ -3606,7 +3701,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionAutomaticResize", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select whether to use bitmap caching or not..
         /// </summary>
@@ -3615,16 +3710,16 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionCacheBitmaps", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Select the colour quality to be used..
+        ///   Looks up a localized string similar to Select the color quality to be used..
         /// </summary>
         internal static string PropertyDescriptionColors {
             get {
                 return ResourceManager.GetString("PropertyDescriptionColors", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select the compression value to be used..
         /// </summary>
@@ -3633,7 +3728,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionCompression", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Put your notes or a description for the host here..
         /// </summary>
@@ -3642,7 +3737,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionDescription", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Determines whether cursor flashes should be disabled..
         /// </summary>
@@ -3651,7 +3746,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionDisableCursorBlinking", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Determines whether a mouse shadow should be visible..
         /// </summary>
@@ -3660,7 +3755,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionDisableCursorShadow", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Determines whether window content is displayed when you drag the window to a new location..
         /// </summary>
@@ -3669,7 +3764,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionDisableFullWindowDrag", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Determines whether menus and windows can be displayed with animation effects in the remote session..
         /// </summary>
@@ -3678,7 +3773,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionDisableMenuAnimations", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select yes if the theme of the remote host should be displayed..
         /// </summary>
@@ -3687,7 +3782,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionDisplayThemes", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select yes if the wallpaper of the remote host should be displayed..
         /// </summary>
@@ -3696,7 +3791,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionDisplayWallpaper", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Enter your domain..
         /// </summary>
@@ -3705,7 +3800,25 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionDomain", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to use this instance id to fetch public ip from aws ec2 instance.
+        /// </summary>
+        internal static string PropertyDescriptionEC2InstanceId {
+            get {
+                return ResourceManager.GetString("PropertyDescriptionEC2InstanceId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to fetch aws instance info from this region.
+        /// </summary>
+        internal static string PropertyDescriptionEC2Region {
+            get {
+                return ResourceManager.GetString("PropertyDescriptionEC2Region", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Select whether to use desktop composition or not..
         /// </summary>
@@ -3714,7 +3827,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionEnableDesktopComposition", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select whether to use font smoothing or not..
         /// </summary>
@@ -3723,7 +3836,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionEnableFontSmoothing", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select the encoding mode to be used..
         /// </summary>
@@ -3732,7 +3845,25 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionEncoding", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to External provider to retrieve host address from.
+        /// </summary>
+        internal static string PropertyDescriptionExternalAddressProvider {
+            get {
+                return ResourceManager.GetString("PropertyDescriptionExternalAddressProvider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to External credential provider / vault to retrieve credentials from.
+        /// </summary>
+        internal static string PropertyDescriptionExternalCredentialProvider {
+            get {
+                return ResourceManager.GetString("PropertyDescriptionExternalCredentialProvider", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Select the external tool to be started..
         /// </summary>
@@ -3741,7 +3872,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionExternalTool", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select a external tool to be started after the disconnection to the remote host..
         /// </summary>
@@ -3750,7 +3881,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionExternalToolAfter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select a external tool to be started before the connection to the remote host is established..
         /// </summary>
@@ -3759,7 +3890,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionExternalToolBefore", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Show this connection in the favorites menu..
         /// </summary>
@@ -3768,7 +3899,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionFavorite", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Enter the hostname or ip you want to connect to..
         /// </summary>
@@ -3777,7 +3908,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionHostnameIp", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Choose a icon that will be displayed when connected to the host..
         /// </summary>
@@ -3786,7 +3917,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionIcon", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Specifies the load balancing information for use by load balancing routers to choose the best server..
         /// </summary>
@@ -3795,7 +3926,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionLoadBalanceInfo", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Enter the MAC address of the remote host if you wish to use it in an external tool..
         /// </summary>
@@ -3804,7 +3935,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionMACAddress", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to This is the name that will be displayed in the connections tree..
         /// </summary>
@@ -3813,16 +3944,16 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionName", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to A command to run on the remote server after successfully connecting..
+        ///   Looks up a localized string similar to Description of OpeningCommand TODO.
         /// </summary>
         internal static string PropertyDescriptionOpeningCommand {
             get {
                 return ResourceManager.GetString("PropertyDescriptionOpeningCommand", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Sets the panel in which the connection will open..
         /// </summary>
@@ -3831,7 +3962,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionPanel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Enter your password..
         /// </summary>
@@ -3840,7 +3971,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionPassword", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Set a password needed to encrypt the connection file with. You will be prompted to enter your passcode before starting mRemoteNG..
         /// </summary>
@@ -3849,7 +3980,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionPasswordProtect", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Enter the port the selected protocol is listening on..
         /// </summary>
@@ -3858,7 +3989,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionPort", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Choose the protocol mRemoteNG should use to connect to the host..
         /// </summary>
@@ -3867,7 +3998,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionProtocol", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select a PuTTY session to be used when connecting..
         /// </summary>
@@ -3876,7 +4007,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionPuttySession", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Specifies the domain name that a user provides to connect to the RD Gateway server..
         /// </summary>
@@ -3885,7 +4016,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRDGatewayDomain", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Specifies the host name of the Remote Desktop Gateway server..
         /// </summary>
@@ -3894,7 +4025,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRDGatewayHostname", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Specifies whether or not to log on to the gateway using the same username and password as the connection..
         /// </summary>
@@ -3903,7 +4034,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRDGatewayUseConnectionCredentials", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Specifies the user name that a user provides to connect to the RD Gateway server..
         /// </summary>
@@ -3912,7 +4043,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRDGatewayUsername", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select whether to receive an alert after the RDP session disconnects due to inactivity.
         /// </summary>
@@ -3921,7 +4052,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRDPAlertIdleTimeout", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Specifies the password of the Remote Desktop Gateway server..
         /// </summary>
@@ -3930,7 +4061,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRdpGatewayPassword", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Specifies when to use a Remote Desktop Gateway (RD Gateway) server..
         /// </summary>
@@ -3939,7 +4070,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRdpGatewayUsageMethod", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The number of minutes for the RDP session to sit idle before automatically disconnecting (for no limit use 0).
         /// </summary>
@@ -3948,7 +4079,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRDPMinutesToIdleTimeout", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The program to be started on the remote server upon connection..
         /// </summary>
@@ -3957,7 +4088,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRDPStartProgram", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Specifies the working directory of the alternate shell..
         /// </summary>
@@ -3966,7 +4097,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRDPStartProgramWorkDir", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Sets the version of RDP to use when opening connections..
         /// </summary>
@@ -3975,7 +4106,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRdpVersion", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select whether the default audio input device on the remote machine should be redirected to this computer..
         /// </summary>
@@ -3984,7 +4115,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRedirectAudioCapture", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select whether the clipboard should be shared..
         /// </summary>
@@ -3993,7 +4124,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRedirectClipboard", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select whether local disk drives should be shown on the remote host..
         /// </summary>
@@ -4002,7 +4133,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRedirectDrives", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select whether key combinations (e.g. Alt-Tab) should be redirected to the remote host..
         /// </summary>
@@ -4011,7 +4142,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRedirectKeys", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select whether local ports (ie. com, parallel) should be shown on the remote host..
         /// </summary>
@@ -4020,7 +4151,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRedirectPorts", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select whether local printers should be shown on the remote host..
         /// </summary>
@@ -4029,7 +4160,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRedirectPrinters", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select whether local smart cards should be available on the remote host..
         /// </summary>
@@ -4038,7 +4169,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRedirectSmartCards", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select how remote sound should be redirected..
         /// </summary>
@@ -4047,7 +4178,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRedirectSounds", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select one of the available rendering engines that will be used to display HTML..
         /// </summary>
@@ -4056,7 +4187,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionRenderingEngine", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Choose the resolution or mode this connection will open in..
         /// </summary>
@@ -4065,7 +4196,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionResolution", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select the SmartSize mode to be used..
         /// </summary>
@@ -4074,7 +4205,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionSmartSizeMode", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Choose the Sound Quality provided by the protocol: Dynamic, Medium, High.
         /// </summary>
@@ -4083,7 +4214,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionSoundQuality", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Specify here additional options to be used for SSH connection. See putty documentation for further details..
         /// </summary>
@@ -4092,7 +4223,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionSshOptions", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to For connection through a SSH tunnel (jump host) specify SSH connection to be used to establish SSH tunnel..
         /// </summary>
@@ -4101,7 +4232,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionSshTunnel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connect to the console session of the remote host..
         /// </summary>
@@ -4110,7 +4241,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionUseConsoleSession", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use the Credential Security Support Provider (CredSSP) for authentication if it is available..
         /// </summary>
@@ -4119,29 +4250,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionUseCredSsp", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string for UseRestrictedAdmin Description
-        /// </summary>
-        internal static string PropertyDescriptionUseRestrictedAdmin
-        {
-            get
-            {
-                return ResourceManager.GetString("PropertyDescriptionUseRestrictedAdmin", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string for UseRCG Description
-        /// </summary>
-        internal static string PropertyDescriptionUseRCG
-        {
-            get
-            {
-                return ResourceManager.GetString("PropertyDescriptionUseRCG", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connect to a Hyper-V host with enhanced mode enabled..
         /// </summary>
@@ -4150,7 +4259,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionUseEnhancedMode", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Feel free to enter any information you need here..
         /// </summary>
@@ -4159,9 +4268,25 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionUser1", resourceCulture);
             }
         }
-
-
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use Remote Credential Guard to tunnel authentication on target back to source through the RDP channel..
+        /// </summary>
+        internal static string PropertyDescriptionUseRCG {
+            get {
+                return ResourceManager.GetString("PropertyDescriptionUseRCG", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use restricted admin mode on the target host (local system context)..
+        /// </summary>
+        internal static string PropertyDescriptionUseRestrictedAdmin {
+            get {
+                return ResourceManager.GetString("PropertyDescriptionUseRestrictedAdmin", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Enter your username..
         /// </summary>
@@ -4170,7 +4295,16 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionUsername", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enter the ID of user data in external API (e.g. secret server). when used, leave username/password/domain fields empty.
+        /// </summary>
+        internal static string PropertyDescriptionUserViaAPI {
+            get {
+                return ResourceManager.GetString("PropertyDescriptionUserViaAPI", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Use VM ID to connect to VM running on Hyper-V..
         /// </summary>
@@ -4179,7 +4313,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionUseVmId", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to If you want to establish a view only connection to the host select yes..
         /// </summary>
@@ -4188,7 +4322,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionViewOnly", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The ID of the Hyper-V virtual machine to connect to..
         /// </summary>
@@ -4197,7 +4331,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionVmId", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Enter the proxy address to be used..
         /// </summary>
@@ -4206,7 +4340,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionVNCProxyAddress", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Enter your password for authenticating against the proxy..
         /// </summary>
@@ -4215,7 +4349,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionVNCProxyPassword", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Enter the port the proxy server listens on..
         /// </summary>
@@ -4224,7 +4358,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionVNCProxyPort", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to If you use a proxy to tunnel VNC connections, select which type it is..
         /// </summary>
@@ -4233,7 +4367,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionVNCProxyType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Enter your username for authenticating against the proxy..
         /// </summary>
@@ -4242,7 +4376,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionVNCProxyUsername", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Protocol.
         /// </summary>
@@ -4251,7 +4385,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Protocol", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Protocol Event Disconnected. Host: &quot;{1}&quot;; Protocol: &quot;{2}&quot; Message: &quot;{0}&quot;.
         /// </summary>
@@ -4260,7 +4394,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ProtocolEventDisconnected", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Protocol Event Disconnected failed.
         ///{0}.
@@ -4270,7 +4404,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ProtocolEventDisconnectFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Protocol to import.
         /// </summary>
@@ -4279,7 +4413,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ProtocolToImport", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Proxy.
         /// </summary>
@@ -4288,7 +4422,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Proxy", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Proxy Address.
         /// </summary>
@@ -4297,7 +4431,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ProxyAddress", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Proxy Password.
         /// </summary>
@@ -4306,7 +4440,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ProxyPassword", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Proxy Port.
         /// </summary>
@@ -4315,7 +4449,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ProxyPort", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Proxy test failed!.
         /// </summary>
@@ -4324,7 +4458,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ProxyTestFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Proxy test succeeded!.
         /// </summary>
@@ -4333,7 +4467,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ProxyTestSucceeded", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Proxy Type.
         /// </summary>
@@ -4342,7 +4476,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ProxyType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Proxy Username.
         /// </summary>
@@ -4351,7 +4485,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ProxyUsername", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Dispose of Putty process failed!.
         /// </summary>
@@ -4360,7 +4494,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PuttyDisposeFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t set focus!.
         /// </summary>
@@ -4369,7 +4503,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PuttyFocusFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Putty Handle: {0}.
         /// </summary>
@@ -4378,7 +4512,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PuttyHandle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Killing Putty Process failed!.
         /// </summary>
@@ -4387,7 +4521,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PuttyKillFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Putty Resize Failed!.
         /// </summary>
@@ -4396,7 +4530,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PuttyResizeFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to PuTTY Saved Sessions.
         /// </summary>
@@ -4405,7 +4539,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PuttySavedSessionsRootName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to PuTTY Session.
         /// </summary>
@@ -4414,7 +4548,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PuttySession", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to To configure PuTTY sessions click this button:.
         /// </summary>
@@ -4423,7 +4557,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PuttySessionsConfig", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to PuTTY Settings.
         /// </summary>
@@ -4432,7 +4566,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PuttySettings", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Show PuTTY Settings Dialog failed!.
         /// </summary>
@@ -4441,7 +4575,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PuttyShowSettingsDialogFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to --- PuTTY Stuff ---.
         /// </summary>
@@ -4450,7 +4584,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PuttyStuff", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Maximum PuTTY and integrated external tools wait time:.
         /// </summary>
@@ -4459,7 +4593,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PuttyTimeout", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to PuTTY Title: {0}.
         /// </summary>
@@ -4468,7 +4602,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PuttyTitle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Quick: {0}.
         /// </summary>
@@ -4477,7 +4611,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Quick", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Quick Connect.
         /// </summary>
@@ -4486,7 +4620,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("QuickConnect", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Quick Connect Add Failed!.
         /// </summary>
@@ -4495,7 +4629,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("QuickConnectAddFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Creating quick connect failed.
         /// </summary>
@@ -4504,7 +4638,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("QuickConnectFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Quick Connect Toolbar.
         /// </summary>
@@ -4513,7 +4647,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("QuickConnectToolbar", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Warn me only when e&amp;xiting mRemoteNG.
         /// </summary>
@@ -4522,7 +4656,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RadioCloseWarnExit", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Warn me only when closing &amp;multiple connections.
         /// </summary>
@@ -4531,7 +4665,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RadioCloseWarnMultiple", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Do &amp;not warn me when closing connections.
         /// </summary>
@@ -4540,7 +4674,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RadioCloseWarnNever", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RAW.
         /// </summary>
@@ -4549,7 +4683,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Raw", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP.
         /// </summary>
@@ -4558,16 +4692,16 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Rdp", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to 16777216 Colours (24-bit).
+        ///   Looks up a localized string similar to 16777216 Colors (24-bit).
         /// </summary>
         internal static string Rdp16777216Colors {
             get {
                 return ResourceManager.GetString("Rdp16777216Colors", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to 256 Colours (8-bit).
         /// </summary>
@@ -4576,34 +4710,34 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Rdp256Colors", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to 32768 Colours (15-bit).
+        ///   Looks up a localized string similar to 32768 Colors (15-bit).
         /// </summary>
         internal static string Rdp32768Colors {
             get {
                 return ResourceManager.GetString("Rdp32768Colors", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to 16777216 Colours (32-bit).
+        ///   Looks up a localized string similar to 16777216 Colors (32-bit).
         /// </summary>
         internal static string Rdp4294967296Colors {
             get {
                 return ResourceManager.GetString("Rdp4294967296Colors", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to 65536 Colours (16-bit).
+        ///   Looks up a localized string similar to 65536 Colors (16-bit).
         /// </summary>
         internal static string Rdp65536Colors {
             get {
                 return ResourceManager.GetString("Rdp65536Colors", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t create RDP control, please check mRemoteNG requirements..
         /// </summary>
@@ -4612,7 +4746,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpControlCreationFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP Disconnect failed, trying to close!.
         /// </summary>
@@ -4621,7 +4755,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpDisconnectFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Internal error code 1..
         /// </summary>
@@ -4630,7 +4764,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpErrorCode1", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Internal error code 2..
         /// </summary>
@@ -4639,7 +4773,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpErrorCode2", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Internal error code 3. This is not a valid state..
         /// </summary>
@@ -4648,7 +4782,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpErrorCode3", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Internal error code 4..
         /// </summary>
@@ -4657,7 +4791,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpErrorCode4", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An unrecoverable error has occurred during client connection..
         /// </summary>
@@ -4666,7 +4800,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpErrorConnection", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to GetError failed (FatalErrors).
         /// </summary>
@@ -4675,7 +4809,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpErrorGetFailure", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An out-of-memory error has occurred..
         /// </summary>
@@ -4684,7 +4818,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpErrorOutOfMemory", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An unknown error has occurred..
         /// </summary>
@@ -4693,7 +4827,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpErrorUnknown", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A window-creation error has occurred..
         /// </summary>
@@ -4702,7 +4836,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpErrorWindowCreation", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Winsock initialization error..
         /// </summary>
@@ -4711,7 +4845,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpErrorWinsock", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP Focus failed!.
         /// </summary>
@@ -4720,25 +4854,34 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpFocusFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Gateway Domain.
+        ///   Looks up a localized string similar to RDP-Gateway.
+        /// </summary>
+        internal static string RDPGateway {
+            get {
+                return ResourceManager.GetString("RDPGateway", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RDP-Gateway Domain.
         /// </summary>
         internal static string RdpGatewayDomain {
             get {
                 return ResourceManager.GetString("RdpGatewayDomain", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Gateway Hostname.
+        ///   Looks up a localized string similar to RDP-Gateway Hostname.
         /// </summary>
         internal static string RdpGatewayHostname {
             get {
                 return ResourceManager.GetString("RdpGatewayHostname", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP Gateway is supported..
         /// </summary>
@@ -4747,7 +4890,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpGatewayIsSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP Gateway is not supported!.
         /// </summary>
@@ -4756,43 +4899,43 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpGatewayNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Remote Desktop Gateway Password.
+        ///   Looks up a localized string similar to RDP-Gateway Password.
         /// </summary>
         internal static string RdpGatewayPassword {
             get {
                 return ResourceManager.GetString("RdpGatewayPassword", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Use Gateway.
+        ///   Looks up a localized string similar to Use RDP Gateway.
         /// </summary>
         internal static string RdpGatewayUsageMethod {
             get {
                 return ResourceManager.GetString("RdpGatewayUsageMethod", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Gateway Credentials.
+        ///   Looks up a localized string similar to RDP-Gateway Credentials.
         /// </summary>
         internal static string RdpGatewayUseConnectionCredentials {
             get {
                 return ResourceManager.GetString("RdpGatewayUseConnectionCredentials", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Gateway Username.
+        ///   Looks up a localized string similar to RDP-Gateway Username.
         /// </summary>
         internal static string RdpGatewayUsername {
             get {
                 return ResourceManager.GetString("RdpGatewayUsername", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP Connection Timeout.
         /// </summary>
@@ -4801,7 +4944,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpOverallConnectionTimeout", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Could not create RDP client. RDP protocol version {0} is not supported on this machine. Please choose an older protocol version..
         /// </summary>
@@ -4810,7 +4953,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpProtocolVersionNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP reconnection count:.
         /// </summary>
@@ -4819,7 +4962,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpReconnectCount", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP SetAuthenticationLevel failed!.
         /// </summary>
@@ -4828,7 +4971,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpSetAuthenticationLevelFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP SetUseConsoleSession failed!.
         /// </summary>
@@ -4837,7 +4980,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpSetConsoleSessionFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP Setting Console switch for RDC {0}..
         /// </summary>
@@ -4846,7 +4989,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpSetConsoleSwitch", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP SetCredentials failed!.
         /// </summary>
@@ -4855,7 +4998,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpSetCredentialsFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP SetEventHandlers failed!.
         /// </summary>
@@ -4864,7 +5007,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpSetEventHandlersFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP SetRDGateway failed!.
         /// </summary>
@@ -4873,7 +5016,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpSetGatewayFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP SetPerformanceFlags failed!.
         /// </summary>
@@ -4882,7 +5025,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpSetPerformanceFlagsFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP SetPort failed!.
         /// </summary>
@@ -4891,7 +5034,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpSetPortFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP SetProps failed!.
         /// </summary>
@@ -4900,7 +5043,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpSetPropsFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP Set Redirection Failed!.
         /// </summary>
@@ -4909,7 +5052,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpSetRedirectionFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP Set Redirect Keys Failed!.
         /// </summary>
@@ -4918,7 +5061,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpSetRedirectKeysFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP SetResolution failed!.
         /// </summary>
@@ -4927,7 +5070,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpSetResolutionFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Bring to this computer.
         /// </summary>
@@ -4936,7 +5079,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpSoundBringToThisComputer", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Leave at remote computer.
         /// </summary>
@@ -4945,7 +5088,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpSoundLeaveAtRemoteComputer", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Alternate Shell.
         /// </summary>
@@ -4954,7 +5097,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RDPStartProgram", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Alternate shell working directory.
         /// </summary>
@@ -4963,7 +5106,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RDPStartProgramWorkDir", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP ToggleFullscreen failed!.
         /// </summary>
@@ -4972,7 +5115,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpToggleFullscreenFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP ToggleSmartSize failed!.
         /// </summary>
@@ -4981,7 +5124,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpToggleSmartSizeFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to RDP Version.
         /// </summary>
@@ -4990,7 +5133,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RdpVersion", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Read only:.
         /// </summary>
@@ -4999,7 +5142,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ReadOnly", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Reconnect.
         /// </summary>
@@ -5008,7 +5151,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Reconnect", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Reconnect All Connections.
         /// </summary>
@@ -5017,7 +5160,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ReconnectAllConnections", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Reconnect to previously opened sessions on startup.
         /// </summary>
@@ -5026,7 +5169,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ReconnectAtStartup", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Redirect.
         /// </summary>
@@ -5035,7 +5178,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Redirect", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Disk Drives.
         /// </summary>
@@ -5044,7 +5187,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RedirectDrives", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Key Combinations.
         /// </summary>
@@ -5053,7 +5196,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RedirectKeys", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Smart Cards.
         /// </summary>
@@ -5062,16 +5205,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RedirectSmartCards", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Refresh.
-        /// </summary>
-        internal static string Refresh {
-            get {
-                return ResourceManager.GetString("Refresh", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Refresh Screen (VNC).
         /// </summary>
@@ -5080,7 +5214,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RefreshScreen", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Release Channel.
         /// </summary>
@@ -5089,7 +5223,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ReleaseChannel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Stable channel includes final releases only.
         ///Preview channel includes Betas &amp; Release Candidates.
@@ -5100,7 +5234,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ReleaseChannelExplanation", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Released under the GNU General Public License (GPL).
         /// </summary>
@@ -5109,7 +5243,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ReleasedUnderGPL", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Remote Desktop Services.
         /// </summary>
@@ -5118,7 +5252,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RemoteDesktopServices", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Remote file.
         /// </summary>
@@ -5127,7 +5261,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RemoteFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Remove All.
         /// </summary>
@@ -5136,7 +5270,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RemoveAll", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Rename.
         /// </summary>
@@ -5145,7 +5279,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Rename", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Rename Tab.
         /// </summary>
@@ -5154,7 +5288,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RenameTab", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Rendering Engine.
         /// </summary>
@@ -5163,7 +5297,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RenderingEngine", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Report a Bug.
         /// </summary>
@@ -5172,7 +5306,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ReportBug", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Reset layout.
         /// </summary>
@@ -5181,7 +5315,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ResetLayout", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resolution.
         /// </summary>
@@ -5190,7 +5324,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Resolution", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Rlogin.
         /// </summary>
@@ -5199,7 +5333,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Rlogin", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Run elevated.
         /// </summary>
@@ -5208,7 +5342,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("RunElevated", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Save.
         /// </summary>
@@ -5217,7 +5351,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Save", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Save All.
         /// </summary>
@@ -5226,7 +5360,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SaveAll", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Save Connection File.
         /// </summary>
@@ -5235,7 +5369,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SaveConnectionFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Save Connection File As....
         /// </summary>
@@ -5244,7 +5378,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SaveConnectionFileAs", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Save connections after every edit.
         /// </summary>
@@ -5253,7 +5387,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SaveConnectionsAfterEveryEdit", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Do you want to save the current connections file before loading another?.
         /// </summary>
@@ -5262,7 +5396,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SaveConnectionsFileBeforeOpeningAnother", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Graphics Interchange Format File (.gif)|*.gif|Joint Photographic Experts Group File (.jpeg)|*.jpeg|Joint Photographic Experts Group File (.jpg)|*.jpg|Portable Network Graphics File (.png)|*.png.
         /// </summary>
@@ -5271,7 +5405,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SaveImageFilter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Screen.
         /// </summary>
@@ -5280,7 +5414,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Screen", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Screenshot.
         /// </summary>
@@ -5289,7 +5423,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Screenshot", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Screenshots.
         /// </summary>
@@ -5298,7 +5432,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Screenshots", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Search.
         /// </summary>
@@ -5307,7 +5441,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SearchPrompt", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Seconds.
         /// </summary>
@@ -5316,7 +5450,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Seconds", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select a panel from the list below or click New to add a new one. Click OK to continue..
         /// </summary>
@@ -5325,7 +5459,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SelectPanel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Send Special Keys (VNC).
         /// </summary>
@@ -5334,7 +5468,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SendSpecialKeys", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Send To....
         /// </summary>
@@ -5343,7 +5477,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SendTo", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Server &apos;{0}&apos; was not accessible..
         /// </summary>
@@ -5352,7 +5486,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ServerNotAccessible", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Server status:.
         /// </summary>
@@ -5361,7 +5495,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ServerStatus", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Set hostname like display name when creating or renaming connections.
         /// </summary>
@@ -5370,7 +5504,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SetHostnameLikeDisplayName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t save settings or dispose SysTray Icon!.
         /// </summary>
@@ -5379,7 +5513,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SettingsCouldNotBeSavedOrTrayDispose", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Show description tooltips in connection tree.
         /// </summary>
@@ -5388,7 +5522,16 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ShowDescriptionTooltips", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show for user.
+        /// </summary>
+        internal static string ShowForUser {
+            get {
+                return ResourceManager.GetString("ShowForUser", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Show full connections file path in window title.
         /// </summary>
@@ -5397,7 +5540,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ShowFullConsFilePath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to &amp;Show Help Text.
         /// </summary>
@@ -5406,7 +5549,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ShowHelpText", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Show/Hide Menu Strip.
         /// </summary>
@@ -5415,7 +5558,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ShowHideMenu", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Show logon information on tab names.
         /// </summary>
@@ -5424,7 +5567,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ShowLogonInfoOnTabs", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Show On Toolbar.
         /// </summary>
@@ -5433,7 +5576,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ShowOnToolbar", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Show on toolbar column.
         /// </summary>
@@ -5442,7 +5585,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ShowOnToolbarColumnHeader", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Show protocols on tab names.
         /// </summary>
@@ -5451,7 +5594,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ShowProtocolOnTabs", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Show Text.
         /// </summary>
@@ -5460,7 +5603,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ShowText", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Show these message types.
         /// </summary>
@@ -5469,7 +5612,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ShowTheseMessageTypes", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Single click on connection opens it.
         /// </summary>
@@ -5478,7 +5621,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SingleClickOnConnectionOpensIt", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Single click on opened connection in Connection Tree switches to opened Connection Tab.
         /// </summary>
@@ -5487,7 +5630,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SingleClickOnOpenConnectionSwitchesToIt", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SmartCard.
         /// </summary>
@@ -5496,7 +5639,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SmartCard", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SmartSize (RDP/VNC).
         /// </summary>
@@ -5505,7 +5648,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SmartSize", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SmartSize Mode.
         /// </summary>
@@ -5514,7 +5657,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SmartSizeMode", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Socks 5.
         /// </summary>
@@ -5523,7 +5666,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Socks5", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Sort.
         /// </summary>
@@ -5532,7 +5675,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Sort", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Ascending (A-Z).
         /// </summary>
@@ -5541,7 +5684,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SortAsc", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Descending (Z-A).
         /// </summary>
@@ -5550,7 +5693,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SortDesc", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Sound quality.
         /// </summary>
@@ -5559,7 +5702,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SoundQuality", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Sounds.
         /// </summary>
@@ -5568,7 +5711,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Sounds", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Please see Help - Getting started - SQL Configuration for more Info!.
         /// </summary>
@@ -5577,7 +5720,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SQLInfo", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SQL Server.
         /// </summary>
@@ -5586,7 +5729,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SQLServer", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SSH background transfer failed!.
         /// </summary>
@@ -5595,7 +5738,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SshBackgroundTransferFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SSH File Transfer.
         /// </summary>
@@ -5604,7 +5747,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SshFileTransfer", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SSH Options.
         /// </summary>
@@ -5613,7 +5756,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SshOptions", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SSH transfer failed..
         /// </summary>
@@ -5622,7 +5765,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SshTransferFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SSH Tunnel.
         /// </summary>
@@ -5631,7 +5774,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SshTunnel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SSH Tunnel connection configuration problem. Connection to: &quot;{0}&quot; via SSH Tunnel: &quot;{1}&quot; not possible. A connection with the name configured as SSH Tunnel and protocol SSH version 1 or SSH2 version 2 cannot be found in the connection tree. Clear SSH Tunnel configuration or specify existing SSH connection..
         /// </summary>
@@ -5640,7 +5783,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SshTunnelConfigProblem", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SSH tunnel connection failed. Connection to: &quot;{0}&quot; via SSH Tunnel: &quot;{1}&quot; not possible. Putty process terminated. Check for any problems with the connection configured as SSH Tunnel..
         /// </summary>
@@ -5649,7 +5792,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SshTunnelFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SSH tunnel configuration problem. Connection to: &quot;{0}&quot; via SSH Tunnel: &quot;{1}&quot; not possible. Connection configured as SSH Tunnel found in tree, but protocol is not derived from putty. Make sure connection configured as SSH Tunnel is using SSH protocol..
         /// </summary>
@@ -5658,7 +5801,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SshTunnelIsNotPutty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SSH tunnel connection problem. Connection to: &quot;{0}&quot; via SSH Tunnel: &quot;{1}&quot; not possible. SSH connection failed. Check for any problems with the connection configured as SSH Tunnel..
         /// </summary>
@@ -5667,7 +5810,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SshTunnelNotConnected", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SSH tunnel initialization problem. Connection to: &quot;{0}&quot; via SSH Tunnel: &quot;{1}&quot; not possible. SSH connection could not be initialized. Check for any problems with the connection configured as SSH Tunnel..
         /// </summary>
@@ -5676,7 +5819,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SshTunnelNotInitialized", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SSH tunnel connection timed out. Connection to: &quot;{0}&quot; via SSH Tunnel: &quot;{1}&quot; not possible. Local tunnel port did not become available in time. Check for any problems with the connection configured as SSH Tunnel..
         /// </summary>
@@ -5685,7 +5828,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SshTunnelPortNotReadyInTime", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SSH version 1.
         /// </summary>
@@ -5694,7 +5837,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SshV1", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SSH version 2.
         /// </summary>
@@ -5703,7 +5846,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SshV2", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Stack trace.
         /// </summary>
@@ -5712,7 +5855,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("StackTrace", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Start Chat (VNC).
         /// </summary>
@@ -5721,7 +5864,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("StartChat", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Start minimized.
         /// </summary>
@@ -5730,7 +5873,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("StartMinimized", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Startup/Exit.
         /// </summary>
@@ -5739,7 +5882,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("StartupExit", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Status.
         /// </summary>
@@ -5748,7 +5891,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Status", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Backup.
         /// </summary>
@@ -5757,7 +5900,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("strBackup", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Browse....
         /// </summary>
@@ -5766,7 +5909,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("strBrowse", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Connection Backup Frequency.
         /// </summary>
@@ -5775,7 +5918,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("strConnectionBackupFrequency", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Maximum number of backups.
         /// </summary>
@@ -5784,7 +5927,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("strConnectionsBackupMaxCount", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Location of connection file backup.
         /// </summary>
@@ -5793,7 +5936,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("strConnectionsBackupPath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Support Forum.
         /// </summary>
@@ -5802,7 +5945,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SupportForum", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Switch to Notifications panel on:.
         /// </summary>
@@ -5811,7 +5954,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("SwitchToErrorsAndInfos", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Tabs &amp;&amp; Panels.
         /// </summary>
@@ -5820,7 +5963,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TabsAndPanels", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Security.
         /// </summary>
@@ -5829,7 +5972,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TabSecurity", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Telnet.
         /// </summary>
@@ -5838,7 +5981,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Telnet", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Test connection.
         /// </summary>
@@ -5847,7 +5990,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TestConnection", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Testing connection.
         /// </summary>
@@ -5856,7 +5999,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TestingConnection", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Test Proxy.
         /// </summary>
@@ -5865,7 +6008,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TestProxy", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Test Settings.
         /// </summary>
@@ -5874,7 +6017,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TestSettings", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The following:.
         /// </summary>
@@ -5883,7 +6026,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TheFollowing", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Theme.
         /// </summary>
@@ -5892,7 +6035,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Theme", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Timeout [seconds].
         /// </summary>
@@ -5901,7 +6044,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TimeoutInSeconds", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Title.
         /// </summary>
@@ -5910,7 +6053,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Title", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Error ({0}).
         /// </summary>
@@ -5919,7 +6062,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TitleError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Information ({0}).
         /// </summary>
@@ -5928,7 +6071,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TitleInformation", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to mRemoteNG password.
         /// </summary>
@@ -5937,7 +6080,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TitlePassword", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to mRemoteNG password for {0}.
         /// </summary>
@@ -5946,7 +6089,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TitlePasswordWithName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Select Panel.
         /// </summary>
@@ -5955,7 +6098,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TitleSelectPanel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Warning ({0}).
         /// </summary>
@@ -5964,7 +6107,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TitleWarning", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Track active connection in the connection tree.
         /// </summary>
@@ -5973,7 +6116,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TrackActiveConnectionInConnectionTree", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Transfer.
         /// </summary>
@@ -5982,7 +6125,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Transfer", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Transfer File (SSH).
         /// </summary>
@@ -5991,7 +6134,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TransferFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Try to integrate.
         /// </summary>
@@ -6000,7 +6143,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("TryToIntegrate", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Ultra VNC Repeater.
         /// </summary>
@@ -6009,7 +6152,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UltraVncRepeater", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to UltraVNC SingleClick port:.
         /// </summary>
@@ -6018,7 +6161,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UltraVNCSCListeningPort", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to UltraVNC SingleClick.
         /// </summary>
@@ -6027,7 +6170,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UltraVNCSingleClick", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Uncheck the properties you want not to be saved!.
         /// </summary>
@@ -6036,7 +6179,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UncheckProperties", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An unhandled exception has occurred.
         /// </summary>
@@ -6045,7 +6188,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UnhandledExceptionOccured", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to mRemoteNG requires an update.
         /// </summary>
@@ -6054,7 +6197,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UpdateAvailable", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to mRemoteNG can periodically connect to the mRemoteNG website to check for updates..
         /// </summary>
@@ -6063,7 +6206,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UpdateCheck", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The update information could not be downloaded..
         /// </summary>
@@ -6072,7 +6215,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UpdateCheckCompleteFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Download complete!
         ///mRemoteNG will now quit and begin with the installation..
@@ -6082,7 +6225,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UpdateDownloadComplete", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The update could not be downloaded..
         /// </summary>
@@ -6091,7 +6234,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UpdateDownloadCompleteFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The update download could not be initiated..
         /// </summary>
@@ -6100,7 +6243,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UpdateDownloadFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Every {0} days.
         /// </summary>
@@ -6109,7 +6252,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UpdateFrequencyCustom", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The change log could not be downloaded..
         /// </summary>
@@ -6118,7 +6261,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UpdateGetChangeLogFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Download Completed!.
         /// </summary>
@@ -6127,7 +6270,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UpdatePortableDownloadComplete", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Updates.
         /// </summary>
@@ -6136,7 +6279,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Updates", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use Console Session.
         /// </summary>
@@ -6145,7 +6288,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UseConsoleSession", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use CredSSP.
         /// </summary>
@@ -6154,29 +6297,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UseCredSsp", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to UseRestrictedAdmin.
-        /// </summary>
-        internal static string UseRestrictedAdmin
-        {
-            get
-            {
-                return ResourceManager.GetString("UseRestrictedAdmin", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to UseRestrictedAdmin.
-        /// </summary>
-        internal static string UseRCG
-        {
-            get
-            {
-                return ResourceManager.GetString("UseRCG", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use default.
         /// </summary>
@@ -6185,7 +6306,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UseDefault", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use a different username and password.
         /// </summary>
@@ -6194,7 +6315,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UseDifferentUsernameAndPassword", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use enhanced mode.
         /// </summary>
@@ -6203,7 +6324,16 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UseEnhancedMode", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use External Credential Provider.
+        /// </summary>
+        internal static string UseExternalCredentialProvider {
+            get {
+                return ResourceManager.GetString("UseExternalCredentialProvider", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to User.
         /// </summary>
@@ -6212,7 +6342,25 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("User", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use Remote Credential Guard.
+        /// </summary>
+        internal static string UseRCG {
+            get {
+                return ResourceManager.GetString("UseRCG", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use Restricted Admin.
+        /// </summary>
+        internal static string UseRestrictedAdmin {
+            get {
+                return ResourceManager.GetString("UseRestrictedAdmin", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to User Field.
         /// </summary>
@@ -6221,43 +6369,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UserField", resourceCulture);
             }
         }
-
-        internal static string ExternalCredentialProvider
-        {
-            get
-            {
-                return ResourceManager.GetString("ExternalCredentialProvider", resourceCulture);
-            }
-        }
-        internal static string PropertyDescriptionExternalCredentialProvider
-        {
-            get
-            {
-                return ResourceManager.GetString("PropertyDescriptionExternalCredentialProvider", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Username.
-        /// </summary>
-        internal static string UserViaAPI
-        {
-            get
-            {
-                return ResourceManager.GetString("UserViaAPI", resourceCulture);
-            }
-        }
-        /// <summary>
-        ///   Looks up a localized string similar to Enter your username..
-        /// </summary>
-        internal static string PropertyDescriptionUserViaAPI
-        {
-            get
-            {
-                return ResourceManager.GetString("PropertyDescriptionUserViaAPI", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Username.
         /// </summary>
@@ -6266,7 +6378,16 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Username", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to API User ID.
+        /// </summary>
+        internal static string UserViaAPI {
+            get {
+                return ResourceManager.GetString("UserViaAPI", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Use the same username and password.
         /// </summary>
@@ -6275,7 +6396,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UseSameUsernameAndPassword", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use a smart card.
         /// </summary>
@@ -6284,15 +6405,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UseSmartCard", resourceCulture);
             }
         }
-
-        internal static string UseExternalCredentialProvider
-        {
-            get
-            {
-                return ResourceManager.GetString("UseExternalCredentialProvider", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use SQL Server to load &amp;&amp; save connections.
         /// </summary>
@@ -6301,7 +6414,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UseSQLServer", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Use VM ID.
         /// </summary>
@@ -6310,7 +6423,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("UseVmId", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Verify:.
         /// </summary>
@@ -6319,7 +6432,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Verify", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Version.
         /// </summary>
@@ -6328,7 +6441,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Version", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to View Only.
         /// </summary>
@@ -6337,7 +6450,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("ViewOnly", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to VM ID.
         /// </summary>
@@ -6346,7 +6459,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("VmId", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to VNC.
         /// </summary>
@@ -6355,7 +6468,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Vnc", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to VNC disconnect failed!.
         /// </summary>
@@ -6364,7 +6477,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("VncConnectionDisconnectFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to VNC Refresh Screen Failed!.
         /// </summary>
@@ -6373,7 +6486,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("VncRefreshFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to VNC SendSpecialKeys failed!.
         /// </summary>
@@ -6382,7 +6495,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("VncSendSpecialKeysFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to VNC Set Event Handlers failed!.
         /// </summary>
@@ -6391,7 +6504,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("VncSetEventHandlersFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to VNC Set Props Failed!.
         /// </summary>
@@ -6400,7 +6513,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("VncSetPropsFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to VNC Toggle SmartSize Failed!.
         /// </summary>
@@ -6409,7 +6522,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("VncToggleSmartSizeFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to VNC Toggle ViewOnly Failed!.
         /// </summary>
@@ -6418,7 +6531,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("VncToggleViewOnlyFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Wait for exit.
         /// </summary>
@@ -6427,7 +6540,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("WaitForExit", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Warn me if authentication fails.
         /// </summary>
@@ -6436,7 +6549,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("WarnIfAuthFails", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Warnings.
         /// </summary>
@@ -6445,7 +6558,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Warnings", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Website.
         /// </summary>
@@ -6454,16 +6567,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Website", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to WebView2 creation failed with exception.
-        /// </summary>
-        internal static string WebView2InitializationFailed {
-            get {
-                return ResourceManager.GetString("WebView2InitializationFailed", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Weekly.
         /// </summary>
@@ -6472,7 +6576,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Weekly", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Windows.
         /// </summary>
@@ -6481,7 +6585,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("Windows", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Working directory.
         /// </summary>
@@ -6490,7 +6594,7 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("WorkingDirColumnHeader", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Working directory:.
         /// </summary>
@@ -6499,159 +6603,13 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("WorkingDirectory", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Yes.
         /// </summary>
         internal static string Yes {
             get {
                 return ResourceManager.GetString("Yes", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Yes.
-        /// </summary>
-        internal static string ACLPermissionsHidden
-        {
-            get
-            {
-                return ResourceManager.GetString("ACLPermissionsHidden", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Yes.
-        /// </summary>
-        internal static string ACLPermissionsReadOnly
-        {
-            get
-            {
-                return ResourceManager.GetString("ACLPermissionsReadOnly", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Yes.
-        /// </summary>
-        internal static string ACLPermissionsWriteAllow
-        {
-            get
-            {
-                return ResourceManager.GetString("ACLPermissionsWriteAllow", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to lblACL.
-        /// </summary>
-        internal static string lblACL
-        {
-            get
-            {
-                return ResourceManager.GetString("lblACL", resourceCulture);
-            }
-        }
-        /// <summary>
-        ///   Looks up a localized string similar to lblBackupEnable.
-        /// </summary>
-        internal static string lblBackupEnable
-        {
-            get
-            {
-                return ResourceManager.GetString("lblBackupEnable", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to lblBackupType.
-        /// </summary>
-        internal static string lblBackupType
-        {
-            get
-            {
-                return ResourceManager.GetString("lblBackupType", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to lblConnectionsBackupPath.
-        /// </summary>
-        internal static string lblConnectionsBackupFrequency
-        {
-            get
-            {
-                return ResourceManager.GetString("lblConnectionsBackupFrequency", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to lblConnectionsBackupMaxCount.
-        /// </summary>
-        internal static string lblConnectionsBackupMaxCount
-        {
-            get
-            {
-                return ResourceManager.GetString("lblConnectionsBackupMaxCount", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to lblBackupNameFormat.
-        /// </summary>
-        internal static string lblBackupNameFormat
-        {
-            get
-            {
-                return ResourceManager.GetString("lblBackupNameFormat", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to lblConnectionsBackupPath.
-        /// </summary>
-        internal static string lblConnectionsBackupPath
-        {
-            get
-            {
-                return ResourceManager.GetString("lblConnectionsBackupPath", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to PageСontrolInOptionsMenu.
-        /// </summary>
-        internal static string PageСontrolInOptionsMenu
-        {
-            get
-            {
-                return ResourceManager.GetString("PageСontrolInOptionsMenu", resourceCulture);
-            }
-        }
-        /// <summary>
-        ///   Looks up a localized string similar to ShowForUser.
-        /// </summary>
-        internal static string ShowForUser
-        {
-            get
-            {
-                return ResourceManager.GetString("ShowForUser", resourceCulture);
-            }
-        }
-
-
-        internal static string ECPNone
-        {
-            get
-            {
-                return ResourceManager.GetString("ECPNone", resourceCulture);
-            }
-        }
-        internal static string ECPDelineaSecretServer
-        {
-            get
-            {
-                return ResourceManager.GetString("ECPDelineaSecretServer", resourceCulture);
             }
         }
     }

--- a/mRemoteNG/mRemoteNG.csproj
+++ b/mRemoteNG/mRemoteNG.csproj
@@ -97,6 +97,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="Language\Language.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Language.resx</DependentUpon>
+    </Compile>
     <Compile Update="Properties\OptionsBackupPage.Designer.cs">
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <AutoGen>True</AutoGen>
@@ -466,6 +471,14 @@
     <Resource Include="UI\Font\HandelGotDBol.ttf">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Resource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Language\Language.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <CustomToolNamespace>mRemoteNG.Resources.Language</CustomToolNamespace>
+      <LastGenOutput>Language.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
In the VS project, set the "Custom Tool" properties on Language.resx so that the Language.Designer.cs file is auto-generated.

This avoids the need to manually regenerate the Language.Designer.cs file.

Note that in VS the file Language.Designer.cs will appear under Language.resx but the actual file locations have not changed.

## Motivation and Context
Saves time when adding/removing items in Language.resx

## How Has This Been Tested?
local build

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/476010/216367489-dbcca6f4-e016-4b59-9ea1-9479825e6f2b.png)

![image](https://user-images.githubusercontent.com/476010/216367586-b66d7e4f-5c41-4432-82b6-ac8d2fecfdae.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [ ] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
