### PR TITLE
Add 2 missing settings

### DIFF
--- a/mRemoteNG/Properties/Settings.Designer.cs
+++ b/mRemoteNG/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace mRemoteNG.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.3.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -2329,52 +2329,29 @@ namespace mRemoteNG.Properties {
                 this["InhDefaultExternalAddressProvider"] = value;
             }
         }
-
-
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("None")]
-        public string ConDefaultRDGatewayExternalCredentialProvider
-        {
-            get
-            {
-                return ((string)(this["ConDefaultRDGatewayExternalCredentialProvider"]));
-            }
-            set
-            {
-                this["ConDefaultRDGatewayExternalCredentialProvider"] = value;
-            }
-        }
-
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool InhDefaultRDGatewayExternalCredentialProvider
-        {
-            get
-            {
-                return ((bool)(this["InhDefaultRDGatewayExternalCredentialProvider"]));
-            }
-            set
-            {
-                this["InhDefaultRDGatewayExternalCredentialProvider"] = value;
-            }
-        }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string ConDefaultRDGatewayUserViaAPI
-        {
-            get
-            {
+        public string ConDefaultRDGatewayUserViaAPI {
+            get {
                 return ((string)(this["ConDefaultRDGatewayUserViaAPI"]));
             }
-            set
-            {
+            set {
                 this["ConDefaultRDGatewayUserViaAPI"] = value;
             }
         }
-
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("None")]
+        public string ConDefaultRDGatewayExternalCredentialProvider {
+            get {
+                return ((string)(this["ConDefaultRDGatewayExternalCredentialProvider"]));
+            }
+            set {
+                this["ConDefaultRDGatewayExternalCredentialProvider"] = value;
+            }
+        }
     }
 }

--- a/mRemoteNG/Properties/Settings.settings
+++ b/mRemoteNG/Properties/Settings.settings
@@ -566,7 +566,6 @@
     <Setting Name="InhDefaultOpeningCommand" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-
     <Setting Name="ConDefaultExternalCredentialProvider" Type="System.String" Scope="User">
       <Value Profile="(Default)">None</Value>
     </Setting>
@@ -579,7 +578,11 @@
     <Setting Name="InhDefaultExternalAddressProvider" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-
+    <Setting Name="ConDefaultRDGatewayUserViaAPI" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="ConDefaultRDGatewayExternalCredentialProvider" Type="System.String" Scope="User">
+      <Value Profile="(Default)">None</Value>
+    </Setting>
   </Settings>
-
 </SettingsFile>


### PR DESCRIPTION
## Description
Two settings are missing in the settings but do exist in the Designer class.  These settings are used in code so they do need to exist. ConDefaultRDGatewayUserViaAPI
ConDefaultRDGatewayExternalCredentialProvider

## Motivation and Context
These settings are in use and are not in Settings.settings

## How Has This Been Tested?
builds successfully

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [ ] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
