### PR TITLE
set the default theme setting

### DIFF
--- a/mRemoteNG/Properties/OptionsThemePage.Designer.cs
+++ b/mRemoteNG/Properties/OptionsThemePage.Designer.cs
@@ -12,7 +12,7 @@ namespace mRemoteNG.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     internal sealed partial class OptionsThemePage : global::System.Configuration.ApplicationSettingsBase {
         
         private static OptionsThemePage defaultInstance = ((OptionsThemePage)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new OptionsThemePage())));
@@ -37,7 +37,7 @@ namespace mRemoteNG.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        [global::System.Configuration.DefaultSettingValueAttribute("vs2015Light")]
         public string ThemeName {
             get {
                 return ((string)(this["ThemeName"]));

--- a/mRemoteNG/Properties/OptionsThemePage.settings
+++ b/mRemoteNG/Properties/OptionsThemePage.settings
@@ -6,7 +6,7 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="ThemeName" Type="System.String" Scope="User">
-      <Value Profile="(Default)" />
+      <Value Profile="(Default)">vs2015Light</Value>
     </Setting>
     <Setting Name="cbThemePageInOptionMenu" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>


### PR DESCRIPTION
## Description
On the initial start of a fresh install, if the options are opened the theme is then set from an empty string to the default. This causes the user to see the "must restart app" dialog when closing the options.

This only occurs on the initial run of the app. If the app is closed and run again, the theme will have been set.

This issue also forces manual intervention when running the UI unit tests.

## Motivation and Context
The "must restart app" dialog is not needed to be displayed on the first run and the user has only opened the options and has made no changes.

## How Has This Been Tested?
Start the app as a "first run" by deleting the associated %appdata% directory.
%appData%\Local\mRemoteNG

Unfixed:
- Start the app
- Open the Options
- Close the Options
- The restart dialog appears

Fixed:
- Start the app
- Open the Options
- Close the Options
- No restart dialog appears

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [ ] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
