### PR TITLE
Build installer in Debug mode #2342

### DIFF
--- a/Tools/postbuild_installer.ps1
+++ b/Tools/postbuild_installer.ps1
@@ -40,4 +40,4 @@ Format-Table -AutoSize -Wrap -InputObject @{
 
 & "$PSScriptRoot\sign_binaries.ps1" -TargetDir $TargetDir -CertificatePath $CertificatePath -CertificatePassword $CertificatePassword -ConfigurationName $ConfigurationName -Exclude $ExcludeFromSigning -SolutionDir $SolutionDir
 & "$PSScriptRoot\verify_binary_signatures.ps1" -TargetDir $TargetDir -ConfigurationName $ConfigurationName -CertificatePath $CertificatePath -SolutionDir $SolutionDir
-& "$PSScriptRoot\rename_and_copy_installer.ps1" -SolutionDir $SolutionDir
+& "$PSScriptRoot\rename_and_copy_installer.ps1" -SolutionDir $SolutionDir -BuildConfiguration $ConfigurationName.Trim()

--- a/Tools/rename_and_copy_installer.ps1
+++ b/Tools/rename_and_copy_installer.ps1
@@ -1,13 +1,15 @@
 ﻿param (
     [string]
-    $SolutionDir
+    $SolutionDir,
+    [string]
+    $BuildConfiguration
 )
 
 
-$targetVersionedFile = "$SolutionDir\mRemoteNG\bin\x64\Release\mRemoteNG.exe"
+$targetVersionedFile = "$SolutionDir\mRemoteNG\bin\x64\$BuildConfiguration\mRemoteNG.exe"
 $version = &"$SolutionDir\Tools\exes\sigcheck.exe" /accepteula -q -n $targetVersionedFile
-$src = $SolutionDir + "mRemoteNGInstaller\Installer\bin\Release\en-US\mRemoteNG-Installer.msi"
-$dst = $SolutionDir + "mRemoteNG\bin\x64\Release\mRemoteNG-Installer-" + $version + ".msi"
+$src = $SolutionDir + "mRemoteNGInstaller\Installer\bin\$BuildConfiguration\en-US\mRemoteNG-Installer.msi"
+$dst = $SolutionDir + "mRemoteNG\bin\x64\$BuildConfiguration\mRemoteNG-Installer-" + $version + ".msi"
 
 # Copy file
 Copy-Item $src -Destination $dst -Force

--- a/mRemoteNG.sln
+++ b/mRemoteNG.sln
@@ -24,6 +24,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExternalConnectors", "Exter
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug Installer|x64 = Debug Installer|x64
 		Debug Portable|x64 = Debug Portable|x64
 		Debug|x64 = Debug|x64
 		Release Installer|x64 = Release Installer|x64
@@ -31,6 +32,8 @@ Global
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4934A491-40BC-4E5B-9166-EA1169A220F6}.Debug Installer|x64.ActiveCfg = Debug|x64
+		{4934A491-40BC-4E5B-9166-EA1169A220F6}.Debug Installer|x64.Build.0 = Debug|x64
 		{4934A491-40BC-4E5B-9166-EA1169A220F6}.Debug Portable|x64.ActiveCfg = Debug Portable|x64
 		{4934A491-40BC-4E5B-9166-EA1169A220F6}.Debug Portable|x64.Build.0 = Debug Portable|x64
 		{4934A491-40BC-4E5B-9166-EA1169A220F6}.Debug|x64.ActiveCfg = Debug|x64
@@ -41,6 +44,7 @@ Global
 		{4934A491-40BC-4E5B-9166-EA1169A220F6}.Release Portable|x64.Build.0 = Release Portable|x64
 		{4934A491-40BC-4E5B-9166-EA1169A220F6}.Release|x64.ActiveCfg = Release|x64
 		{4934A491-40BC-4E5B-9166-EA1169A220F6}.Release|x64.Build.0 = Release|x64
+		{1453B37F-8621-499E-B0B2-6091F76DC0BB}.Debug Installer|x64.ActiveCfg = Debug|x64
 		{1453B37F-8621-499E-B0B2-6091F76DC0BB}.Debug Portable|x64.ActiveCfg = Debug Portable|x64
 		{1453B37F-8621-499E-B0B2-6091F76DC0BB}.Debug|x64.ActiveCfg = Debug|x64
 		{1453B37F-8621-499E-B0B2-6091F76DC0BB}.Release Installer|x64.ActiveCfg = Release|x64
@@ -48,23 +52,30 @@ Global
 		{1453B37F-8621-499E-B0B2-6091F76DC0BB}.Release Portable|x64.Build.0 = Release Portable|x64
 		{1453B37F-8621-499E-B0B2-6091F76DC0BB}.Release|x64.ActiveCfg = Release|x64
 		{1453B37F-8621-499E-B0B2-6091F76DC0BB}.Release|x64.Build.0 = Release|x64
+		{5423D985-CB48-4344-B47F-E8C6D60C8B04}.Debug Installer|x64.ActiveCfg = Debug|x64
+		{5423D985-CB48-4344-B47F-E8C6D60C8B04}.Debug Installer|x64.Build.0 = Debug|x64
 		{5423D985-CB48-4344-B47F-E8C6D60C8B04}.Debug Portable|x64.ActiveCfg = Debug Portable|x64
 		{5423D985-CB48-4344-B47F-E8C6D60C8B04}.Debug|x64.ActiveCfg = Debug|x64
 		{5423D985-CB48-4344-B47F-E8C6D60C8B04}.Release Installer|x64.ActiveCfg = Release|x64
 		{5423D985-CB48-4344-B47F-E8C6D60C8B04}.Release Installer|x64.Build.0 = Release|x64
 		{5423D985-CB48-4344-B47F-E8C6D60C8B04}.Release Portable|x64.ActiveCfg = Release Portable|x64
 		{5423D985-CB48-4344-B47F-E8C6D60C8B04}.Release|x64.ActiveCfg = Release|x64
+		{F0168B9F-6815-40DF-BA53-46CEE7683B68}.Debug Installer|x64.ActiveCfg = Debug|x64
+		{F0168B9F-6815-40DF-BA53-46CEE7683B68}.Debug Installer|x64.Build.0 = Debug|x64
 		{F0168B9F-6815-40DF-BA53-46CEE7683B68}.Debug Portable|x64.ActiveCfg = Debug Portable|x64
 		{F0168B9F-6815-40DF-BA53-46CEE7683B68}.Debug|x64.ActiveCfg = Debug|x64
 		{F0168B9F-6815-40DF-BA53-46CEE7683B68}.Release Installer|x64.ActiveCfg = Release|x64
 		{F0168B9F-6815-40DF-BA53-46CEE7683B68}.Release Installer|x64.Build.0 = Release|x64
 		{F0168B9F-6815-40DF-BA53-46CEE7683B68}.Release Portable|x64.ActiveCfg = Release Portable|x64
 		{F0168B9F-6815-40DF-BA53-46CEE7683B68}.Release|x64.ActiveCfg = Release|x64
+		{16AA21E2-D6B7-427D-AB7D-AA8C611B724E}.Debug Installer|x64.ActiveCfg = Debug|x64
 		{16AA21E2-D6B7-427D-AB7D-AA8C611B724E}.Debug Portable|x64.ActiveCfg = Debug Portable|x64
 		{16AA21E2-D6B7-427D-AB7D-AA8C611B724E}.Debug|x64.ActiveCfg = Debug|x64
 		{16AA21E2-D6B7-427D-AB7D-AA8C611B724E}.Release Installer|x64.ActiveCfg = Release|x64
 		{16AA21E2-D6B7-427D-AB7D-AA8C611B724E}.Release Portable|x64.ActiveCfg = Release Portable|x64
 		{16AA21E2-D6B7-427D-AB7D-AA8C611B724E}.Release|x64.ActiveCfg = Release|x64
+		{A56A2029-79B8-492A-ABE5-D2BFE05801BD}.Debug Installer|x64.ActiveCfg = Debug|x64
+		{A56A2029-79B8-492A-ABE5-D2BFE05801BD}.Debug Installer|x64.Build.0 = Debug|x64
 		{A56A2029-79B8-492A-ABE5-D2BFE05801BD}.Debug Portable|x64.ActiveCfg = Debug Portable|x64
 		{A56A2029-79B8-492A-ABE5-D2BFE05801BD}.Debug Portable|x64.Build.0 = Debug Portable|x64
 		{A56A2029-79B8-492A-ABE5-D2BFE05801BD}.Debug|x64.ActiveCfg = Debug|x64

--- a/mRemoteNGInstaller/Installer/Installer.wixproj
+++ b/mRemoteNGInstaller/Installer/Installer.wixproj
@@ -74,6 +74,16 @@
       <Name>WixNetFxExtension</Name>
     </WixExtension>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CustomActions\CustomActions.csproj">
+      <Name>CustomActions</Name>
+      <Project>{5423d985-cb48-4344-b47f-e8c6d60c8b04}</Project>
+      <Private>True</Private>
+      <DoNotHarvest>True</DoNotHarvest>
+      <RefProjectOutputGroups>Binaries;Content;Satellites</RefProjectOutputGroups>
+      <RefTargetDir>INSTALLFOLDER</RefTargetDir>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(WixTargetsPath)" />
   <!--
 	To modify your build process, add your task inside one of the targets below and uncomment it.


### PR DESCRIPTION
## Description
1. Add CustomActions project as project reference in Installer project
2. By default building in Debug mode does not build the installer so a new build configuration was introduced: Debug Installer similar to existing Release Installer that builds the Installer and required projects in Debug mode.
3. Fix hardcodings in pwsh scripts by passing the BuildConfiguration, see details in my comment [here](https://github.com/mRemoteNG/mRemoteNG/issues/2327#issuecomment-1411616191)

## Motivation and Context
#2342 - Enables developers to create the installer in debug mode

## How Has This Been Tested?
Built project with both configurations: `Debug Installer` and `Release Installer` and checked that proper installer was created in 
`mRemoteNGInstaller\Installer\bin\`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
- [x ] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing - not required
- [x ] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary. - not required
- [ ] I have updated the documentation accordingly, if necessary. - not required
