### PR TITLE
improve speed for the display of the options page

### DIFF
--- a/mRemoteNG/App/Windows.cs
+++ b/mRemoteNG/App/Windows.cs
@@ -1,7 +1,10 @@
-﻿using System;
+﻿#region Usings
+using System;
+using mRemoteNG.Resources.Language;
 using mRemoteNG.UI;
 using mRemoteNG.UI.Forms;
 using mRemoteNG.UI.Window;
+#endregion
 
 namespace mRemoteNG.App
 {
@@ -39,11 +42,8 @@ namespace mRemoteNG.App
                         _adimportForm.Show(dockPanel);
                         break;
                     case WindowType.Options:
-                        using (var optionsForm = new FrmOptions())
-                        {
-                            optionsForm.ShowDialog(dockPanel);
-                        }
-
+                        FrmMain.OptionsForm.SetActivatedPage(Language.StartupExit);
+                        FrmMain.OptionsForm.Visible = true;
                         break;
                     case WindowType.SSHTransfer:
                         if (SshtransferForm == null || SshtransferForm.IsDisposed)

--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Win32;
+﻿#region Usings
+using Microsoft.Win32;
 using mRemoteNG.App;
 using mRemoteNG.App.Info;
 using mRemoteNG.App.Initialization;
@@ -30,9 +31,8 @@ using System.Windows.Forms;
 using mRemoteNG.UI.Panels;
 using WeifenLuo.WinFormsUI.Docking;
 using mRemoteNG.UI.Controls;
-
 using mRemoteNG.Resources.Language;
-
+#endregion
 
 // ReSharper disable MemberCanBePrivate.Global
 
@@ -54,6 +54,7 @@ namespace mRemoteNG.UI.Forms
         private readonly IList<IMessageWriter> _messageWriters = new List<IMessageWriter>();
         private readonly ThemeManager _themeManager;
         private readonly FileBackupPruner _backupPruner = new FileBackupPruner();
+        public static FrmOptions OptionsForm;
 
         internal FullscreenHandler Fullscreen { get; set; }
 
@@ -64,11 +65,12 @@ namespace mRemoteNG.UI.Forms
         {
             _showFullPathInTitle = Properties.OptionsAppearancePage.Default.ShowCompleteConsPathInTitle;
             InitializeComponent();
+
             Screen targetScreen = (Screen.AllScreens.Length > 1) ? Screen.AllScreens[1] : Screen.AllScreens[0];
 
             Rectangle viewport = targetScreen.WorkingArea;
             
-            // normaly it should be screens[1] however due DPI apply 1 size "same" as default with 100%
+            // normally it should be screens[1] however due DPI apply 1 size "same" as default with 100%
             this.Left = viewport.Left + (targetScreen.Bounds.Size.Width / 2) - (this.Width / 2);
             this.Top = viewport.Top + (targetScreen.Bounds.Size.Height / 2) - (this.Height / 2);
 
@@ -81,7 +83,7 @@ namespace mRemoteNG.UI.Forms
 
             _advancedWindowMenu = new AdvancedWindowMenu(this);
         }
-   
+
         #region Properties
 
         public FormWindowState PreviousWindowState { get; set; }
@@ -216,6 +218,8 @@ namespace mRemoteNG.UI.Forms
                 Fullscreen.Value = true;
             }
 
+            OptionsForm = new FrmOptions();
+            
             if (!Properties.OptionsTabsPanelsPage.Default.CreateEmptyPanelOnStartUp) return;
             var panelName = !string.IsNullOrEmpty(Properties.OptionsTabsPanelsPage.Default.StartUpPanelName) ? Properties.OptionsTabsPanelsPage.Default.StartUpPanelName : Language.NewPanel;
 
@@ -356,10 +360,8 @@ namespace mRemoteNG.UI.Forms
 
             if (CTaskDialog.CommandButtonResult != 1) return;
 
-            using (var optionsForm = new FrmOptions(Language.Updates))
-            {
-                optionsForm.ShowDialog(this);
-            }
+            OptionsForm.SetActivatedPage(Language.Updates);
+            OptionsForm.ShowDialog(this);
         }
 
         private async Task CheckForUpdates()

--- a/mRemoteNG/UI/Forms/frmOptions.Designer.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.Designer.cs
@@ -30,16 +30,15 @@ namespace mRemoteNG.UI.Forms
         /// </summary>
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmOptions));
             this.pnlBottom = new System.Windows.Forms.Panel();
-            this.btnApply = new MrngButton();
-            this.btnCancel = new MrngButton();
-            this.btnOK = new MrngButton();
+            this.btnApply = new mRemoteNG.UI.Controls.MrngButton();
+            this.btnCancel = new mRemoteNG.UI.Controls.MrngButton();
+            this.btnOK = new mRemoteNG.UI.Controls.MrngButton();
             this.splitter1 = new System.Windows.Forms.Splitter();
             this.splitter2 = new System.Windows.Forms.Splitter();
             this.pnlMain = new System.Windows.Forms.Panel();
             this.lstOptionPages = new mRemoteNG.UI.Controls.MrngListView();
-            this.PageName = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
+            this.PageName = new BrightIdeasSoftware.OLVColumn();
             this.pnlBottom.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.lstOptionPages)).BeginInit();
             this.SuspendLayout();
@@ -57,18 +56,18 @@ namespace mRemoteNG.UI.Forms
             // 
             // btnApply
             // 
-            this.btnApply._mice = MrngButton.MouseState.OUT;
+            this.btnApply._mice = mRemoteNG.UI.Controls.MrngButton.MouseState.OUT;
             this.btnApply.Location = new System.Drawing.Point(677, 5);
             this.btnApply.Name = "btnApply";
             this.btnApply.Size = new System.Drawing.Size(75, 23);
             this.btnApply.TabIndex = 2;
             this.btnApply.Text = "Apply";
             this.btnApply.UseVisualStyleBackColor = true;
-            this.btnApply.Click += new System.EventHandler(this.BtnOK_Click);
+            this.btnApply.Click += new System.EventHandler(this.BtnApply_Click);
             // 
             // btnCancel
             // 
-            this.btnCancel._mice = MrngButton.MouseState.OUT;
+            this.btnCancel._mice = mRemoteNG.UI.Controls.MrngButton.MouseState.OUT;
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.btnCancel.Location = new System.Drawing.Point(596, 5);
             this.btnCancel.Name = "btnCancel";
@@ -80,7 +79,7 @@ namespace mRemoteNG.UI.Forms
             // 
             // btnOK
             // 
-            this.btnOK._mice = MrngButton.MouseState.OUT;
+            this.btnOK._mice = mRemoteNG.UI.Controls.MrngButton.MouseState.OUT;
             this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.btnOK.Location = new System.Drawing.Point(515, 5);
             this.btnOK.Name = "btnOK";
@@ -123,13 +122,11 @@ namespace mRemoteNG.UI.Forms
             this.lstOptionPages.CellEditUseWholeCell = false;
             this.lstOptionPages.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.PageName});
-            this.lstOptionPages.Cursor = System.Windows.Forms.Cursors.Default;
             this.lstOptionPages.DecorateLines = true;
             this.lstOptionPages.Dock = System.Windows.Forms.DockStyle.Left;
-            this.lstOptionPages.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lstOptionPages.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
             this.lstOptionPages.FullRowSelect = true;
             this.lstOptionPages.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
-            this.lstOptionPages.HideSelection = false;
             this.lstOptionPages.LabelWrap = false;
             this.lstOptionPages.Location = new System.Drawing.Point(0, 0);
             this.lstOptionPages.MultiSelect = false;
@@ -162,7 +159,7 @@ namespace mRemoteNG.UI.Forms
             this.Controls.Add(this.lstOptionPages);
             this.Controls.Add(this.splitter1);
             this.Controls.Add(this.pnlBottom);
-            this.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
@@ -170,6 +167,7 @@ namespace mRemoteNG.UI.Forms
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "mRemoteNG Options";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FrmOptions_FormClosing);
             this.Load += new System.EventHandler(this.FrmOptions_Load);
             this.pnlBottom.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.lstOptionPages)).EndInit();


### PR DESCRIPTION
## Description
Rather than create the options page on demand, instantiate the options page immediately upon app start though in the background using idle time. The options page will now be created once at the start of the application with the visibility toggled as needed.

## Motivation and Context
Creation and display of the options page is very slow.

## How Has This Been Tested?
Tested:
- initial options page loading
- saving options
- operation of ok, cancel, apply and 'x' closing of the window

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [ ] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
