### PR TITLE
Update find_vstool.ps1

### DIFF
--- a/Tools/find_vstool.ps1
+++ b/Tools/find_vstool.ps1
@@ -19,9 +19,12 @@ function EditBinCertificateIsValid() {
         "3BDA323E552DB1FDE5F4FBEE75D6D5B2B187EEDC",
         "98ED99A67886D020C564923B7DF25E9AC019DF26",
         "108E2BA23632620C427C570B6D9DB51AC31387FE",
-        "5EAD300DC7E4D637948ECB0ED829A072BD152E17"
+        "5EAD300DC7E4D637948ECB0ED829A072BD152E17",
+        "97221B97098F37A135DCC212E2B41E452BCE51F2"
     )
     $file_signature = Get-AuthenticodeSignature -FilePath $Path
+    write-host "Path: $Path"
+    Write-Host "file_signature.SignerCertificate.Thumbprint: $($file_signature.SignerCertificate.Thumbprint)"
     if (($file_signature.Status -ne "Valid") -or ($valid_microsoft_cert_thumbprints -notcontains $file_signature.SignerCertificate.Thumbprint)) {
         Write-Warning "Could not validate the signature of $Path"
         return $false
@@ -36,8 +39,7 @@ function ToolCanBeExecuted {
         [string]
         $Path
     )
-    $null = & $Path
-    Write-Output ($LASTEXITCODE -gt 0)
+    $env:PATHEXT.Contains((Get-Item $Path).Extension.ToUpper())
 }
 
 $rootSearchPaths = @(


### PR DESCRIPTION
## Description
The path to visual studio varies by variation of vs. The find_vstool.ps1 script can determine the tool path but it is currently broken and needs to be fixed by:
- add vs2022 cert thumbprint
- fix function which tests if a file is executable

## Motivation and Context
allows the find_vstool.ps1 to be used in appveyor and local build, if needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [ ] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
