### PR TITLE
fix exception when no putty sessions exist

### DIFF
--- a/mRemoteNG/Config/Putty/AbstractPuttySessionsProvider.cs
+++ b/mRemoteNG/Config/Putty/AbstractPuttySessionsProvider.cs
@@ -25,6 +25,7 @@ namespace mRemoteNG.Config.Putty
         public virtual IEnumerable<PuttySessionInfo> GetSessions()
         {
             var sessionNamesFromProvider = GetSessionNames(true);
+
             foreach (var sessionName in GetSessionNamesToAdd(sessionNamesFromProvider))
             {
                 var sessionInfo = GetSession(sessionName);
@@ -42,6 +43,7 @@ namespace mRemoteNG.Config.Putty
 
         private IEnumerable<string> GetSessionNamesToAdd(IEnumerable<string> sessionNamesFromProvider)
         {
+            if (sessionNamesFromProvider == null) { return Enumerable.Empty<string>(); }
             var currentlyKnownSessionNames = Sessions.Select(session => session.Name);
             var sessionNamesToAdd = sessionNamesFromProvider.Except(currentlyKnownSessionNames);
             return sessionNamesToAdd;
@@ -49,10 +51,10 @@ namespace mRemoteNG.Config.Putty
 
         private IEnumerable<PuttySessionInfo> GetSessionToRemove(IEnumerable<string> sessionNamesFromProvider)
         {
+            if (sessionNamesFromProvider == null) return Enumerable.Empty<PuttySessionInfo>();
             var currentlyKnownSessionNames = Sessions.Select(session => session.Name);
             var normalizedSessionNames =
-                sessionNamesFromProvider.Select(name =>
-                                                    WebUtility.UrlDecode(name));
+                sessionNamesFromProvider.Select(name => WebUtility.UrlDecode(name));
             var sessionNamesToRemove = currentlyKnownSessionNames.Except(normalizedSessionNames);
             return Sessions.Where(session => sessionNamesToRemove.Contains(session.Name));
         }


### PR DESCRIPTION
## Description
When putty is not installed or no sessions exist in the registry, an exception is thrown when starting the eventwatcher. Only start the eventwatcher if sessions registry path exists.

## Motivation and Context
Resolves an exception on startup when putty is not installed or no putty sessions exist.

## How Has This Been Tested?
Tested without putty sessions and with putty sessions.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [ ] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
