### PR TITLE
Fix putty registry watcher

### DIFF
--- a/mRemoteNG/Config/Putty/PuttySessionsRegistryProvider.cs
+++ b/mRemoteNG/Config/Putty/PuttySessionsRegistryProvider.cs
@@ -112,8 +112,6 @@ namespace mRemoteNG.Config.Putty
             try
             {
                 var keyName = string.Join("\\", CurrentUserSid, PuttySessionsKey).Replace("\\", "\\\\");
-
-                if (Registry.Users.OpenSubKey(string.Join("\\\\", CurrentUserSid, PuttySessionsKey)) == null) return;
                 var sessionsKey = Registry.Users.OpenSubKey(keyName);
                 if (sessionsKey == null)
                 {

--- a/mRemoteNG/Config/Putty/PuttySessionsRegistryProvider.cs
+++ b/mRemoteNG/Config/Putty/PuttySessionsRegistryProvider.cs
@@ -111,12 +111,15 @@ namespace mRemoteNG.Config.Putty
 
             try
             {
-                var key = string.Join("\\", CurrentUserSid, PuttySessionsKey).Replace("\\", "\\\\");
+                var keyName = string.Join("\\", CurrentUserSid, PuttySessionsKey).Replace("\\", "\\\\");
 
                 if (Registry.Users.OpenSubKey(string.Join("\\\\", CurrentUserSid, PuttySessionsKey)) == null) return;
-
-                var query = new WqlEventQuery(
-                    $"SELECT * FROM RegistryTreeChangeEvent WHERE Hive = \'HKEY_USERS\' AND RootPath = \'{key}\'");
+                var sessionsKey = Registry.Users.OpenSubKey(keyName);
+                if (sessionsKey == null)
+                {
+                    Registry.Users.CreateSubKey(keyName);
+                }
+                var query = new WqlEventQuery($"SELECT * FROM RegistryTreeChangeEvent WHERE Hive = \'HKEY_USERS\' AND RootPath = \'{keyName}\'");
                 _eventWatcher = new ManagementEventWatcher(query);
                 _eventWatcher.EventArrived += OnManagementEventArrived;
                 _eventWatcher.Start();


### PR DESCRIPTION
## Description
If no putty sessions exist then the registry path does not exist and the eventwatcher fails to run. 
Before running the eventwatcher, create the registry path if it does not exist.

## Motivation and Context
Resolves a startup exception.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [ ] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
