### PR TITLE
Fix misleading version label

### DIFF
--- a/mRemoteNG/UI/Window/UpdateWindow.cs
+++ b/mRemoteNG/UI/Window/UpdateWindow.cs
@@ -66,7 +66,7 @@ namespace mRemoteNG.UI.Window
                 : Language.DownloadAndInstall;
             lblChangeLogLabel.Text = Language.Changelog;
             lblInstalledVersion.Text = Language.Version;
-            lblInstalledVersionLabel.Text = $"{Language.AvailableVersion}:";
+            lblInstalledVersionLabel.Text = $"{Language.Version}:";
             lblLatestVersion.Text = Language.Version;
             lblLatestVersionLabel.Text = $"{Language.AvailableVersion}:";
         }


### PR DESCRIPTION
## Description
Changes made in this PR will change the label of `lblInstalledVersionLabel` to `Version` and leave `lblLatestVersionLabel` unchanged (i.e. making it say `Latest Version`).

## Motivation and Context
Currently, both the `lblInstalledVersionLabel` and the `lblLatestVersionLabel` show the text `Latest version`.

This is quite misleading as one of them displays the currently installed version while the other shows the latest version available on the internet.

## How Has This Been Tested?
No tests have been performed as the only change involved is the text content of a label.

## Screenshots (if appropriate):
![grafik](https://github.com/mRemoteNG/mRemoteNG/assets/7085564/d516544d-5628-4c5f-be68-193fd438cc06)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
