### PR TITLE
Fix 2195

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - #2339: Add 2 missing settings
 - #2261: Implement Show/Hide file menu in view menu
 - #2244: Save RCG and RestrictedAdmin fields correctly in connections file
+- #2195: Fix crafted XML File Code Execution vulnerability
 
 ### Added
 - #2285: Support extraction of SSH private keys from external cred prov

--- a/mRemoteNG/Connection/Protocol/PowerShell/Connection.Protocol.PowerShell.cs
+++ b/mRemoteNG/Connection/Protocol/PowerShell/Connection.Protocol.PowerShell.cs
@@ -42,7 +42,7 @@ namespace mRemoteNG.Connection.Protocol.PowerShell
                 };
 
                 _consoleControl.StartProcess(@"C:\Windows\system32\WindowsPowerShell\v1.0\PowerShell.exe",
-                    $@"-NoExit -Command ""$password = ConvertTo-SecureString '{_connectionInfo.Password}' -AsPlainText -Force; $cred = New-Object System.Management.Automation.PSCredential -ArgumentList @('{_connectionInfo.Domain}\{_connectionInfo.Username}', $password); Enter-PSSession -ComputerName {_connectionInfo.Hostname} -Credential $cred""");
+                    $@"-NoExit -Command ""$password = ConvertTo-SecureString ""'{_connectionInfo.Password}'"" -AsPlainText -Force; $cred = New-Object System.Management.Automation.PSCredential -ArgumentList @('{_connectionInfo.Domain}\{_connectionInfo.Username}', $password); Enter-PSSession -ComputerName {_connectionInfo.Hostname} -Credential $cred""");
                 
                 while (!_consoleControl.IsHandleCreated) break;
                 _handle = _consoleControl.Handle;


### PR DESCRIPTION
## Description
Trying to fix arbitrary code execution documented in #2195 by enclosing the vulnerable string with quotation marks. This should force powershell to interpret the input as string and not as code.

## Motivation and Context
Should fix a security vulnerability.

## How Has This Been Tested?
This code has not been tested (don't heave the development environment up and running) and I'm not sure if the double quotation is correct way of escaping the character in C#. Please verify this before merging.

## Notes:
Depending on how the command is passed to the backend it might still be possible to terminate the string section with arbitrary quotation marks in the crafted string. It might be necessary to filter the input for the escaping quotation mark sequence (and thereby limiting real passwords for this use case)

## Screenshots (if appropriate):
n/a

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [ ] *All Tests within VisualStudio are passing [no dev environment available]*
- [X] This pull request does not target the master branch.
- [X] I have updated the changelog file accordingly, if necessary.
- [X] I have updated the documentation accordingly, if necessary.
