### PR TITLE
use pwfile instead of cleartext password for putty connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - #2261: Implement Show/Hide file menu in view menu
 - #2244: Save RCG and RestrictedAdmin fields correctly in connections file
 - #2195: Fix crafted XML File Code Execution vulnerability
+- #304: use pwfile instead of cleartext password for puttyng
 
 ### Added
 - #2285: Support extraction of SSH private keys from external cred prov

--- a/mRemoteNG/Connection/Protocol/PuttyBase.cs
+++ b/mRemoteNG/Connection/Protocol/PuttyBase.cs
@@ -1,5 +1,6 @@
 ﻿using mRemoteNG.App;
 using mRemoteNG.Messages;
+using mRemoteNG.Resources.Language;
 using mRemoteNG.Security.SymmetricEncryption;
 using mRemoteNG.Tools;
 using mRemoteNG.Tools.Cmdline;
@@ -7,15 +8,12 @@ using mRemoteNG.UI;
 using System;
 using System.Diagnostics;
 using System.Drawing;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Windows.Forms;
-using mRemoteNG.Properties;
-using mRemoteNG.Resources.Language;
-using System.IO;
-using System.Runtime.Versioning;
-using System.IO.Pipes;
-using Google.Protobuf.WellKnownTypes;
-using System.Linq;
 
 // ReSharper disable ArrangeAccessorOwnerBody
 


### PR DESCRIPTION
## Description
inspired by #304  -> instead of starting putty with a cleartext password in parameter list, send it through a named pipe.

## Motivation and Context
fix security issue: password should not be visible in cmd logging and EDR tools / taskmanager

## How Has This Been Tested?
tested several connections in serial/parallel execution

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

