### PR TITLE
Add Putty registry import

### DIFF
--- a/mRemoteNG/Config/Import/RegistryImporter.cs
+++ b/mRemoteNG/Config/Import/RegistryImporter.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Runtime.Versioning;
+using Microsoft.Win32;
+using mRemoteNG.App;
+using mRemoteNG.Container;
+
+namespace mRemoteNG.Config.Import
+{
+    [SupportedOSPlatform("windows")]
+    internal class RegistryImporter : IConnectionImporter<string>
+    {
+        public void Import(string regPath, ContainerInfo destinationContainer)
+        {
+            Import(regPath, destinationContainer, false);
+        }
+
+        public static void Import(string regPath, ContainerInfo destinationContainer, bool noop = false)
+        {
+            try
+            {
+                ContainerInfo importedNode = new()
+                {
+                    Name = "Imported from PuTTY",
+                    IsContainer = true
+                };
+
+                using (RegistryKey key = Registry.CurrentUser.OpenSubKey(regPath))
+                {
+                    if (key != null)
+                    {
+                        int i = 0;
+                        foreach (string sub in key.GetSubKeyNames())
+                        {
+                            if (sub.EndsWith("Default%20Settings")) continue;
+                            using RegistryKey subkey = key.OpenSubKey(sub);
+                            string Hostname = subkey.GetValue("HostName") as string;
+
+                            if (!string.IsNullOrEmpty(Hostname))
+                            {
+                                int Port = 22;
+                                string Username = string.Empty;
+
+                                string ProtocolType = subkey.GetValue("Protocol") as string;
+                                Connection.Protocol.ProtocolType Protocol = Connection.Protocol.ProtocolType.SSH2;
+                                if (ProtocolType == "raw")
+                                {
+                                    Protocol = Connection.Protocol.ProtocolType.RAW;
+                                }
+
+                                try
+                                {
+                                    Port = int.Parse(subkey.GetValue("PortNumber") as string);
+                                }
+                                catch { }
+                                try
+                                {
+                                    Username = subkey.GetValue("UserName") as string;
+                                }
+                                catch { }
+
+                                importedNode.AddChild(new Connection.ConnectionInfo()
+                                {
+                                    Name = Hostname,
+                                    Hostname = Hostname,
+                                    Protocol = Protocol,
+                                    Parent = destinationContainer
+                                });
+                                if (Port > 0)
+                                {
+                                    importedNode.Children[i].Port = Port;
+                                }
+                                if (string.IsNullOrEmpty(Username))
+                                {
+                                    importedNode.Children[i].Username = Username;
+                                }
+                                i++;
+                            }
+                        }
+                    }
+                }
+
+                destinationContainer.AddChild(importedNode);
+            }
+            catch (Exception ex)
+            {
+                Runtime.MessageCollector.AddExceptionMessage("Config.Import.Registry.Import() failed.", ex);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
## Description
This adds a new Putty registry import feature to the right-click context menu next to other import routines for the connection list.

## Motivation and Context
This makes for an easy migration for users with multiple connections defined in Putty and allows them to be used directly in mRemoteNG

## How Has This Been Tested?
I tested by importing my connections as defined in the user registry key for Putty sessions.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
