### PR TITLE
Handle case where COM object becomes separated from RCW

### DIFF
--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs
@@ -51,9 +51,34 @@ namespace mRemoteNG.Connection.Protocol.RDP
 
         public virtual bool SmartSize
         {
-            get => _rdpClient.AdvancedSettings2.SmartSizing;
-            protected set => _rdpClient.AdvancedSettings2.SmartSizing = value;
+            get
+            {
+                try
+                {
+                    return _rdpClient.AdvancedSettings2.SmartSizing;
+                }
+                catch (System.Runtime.InteropServices.InvalidComObjectException)
+                {
+                    // The COM object is separated from its RCW, try reacquiring the RCW or recreating the COM object
+                    _rdpClient = new MsRdpClient6NotSafeForScripting();
+                    return _rdpClient.AdvancedSettings2.SmartSizing;
+                }
+            }
+            protected set
+            {
+                try
+                {
+                    _rdpClient.AdvancedSettings2.SmartSizing = value;
+                }
+                catch (System.Runtime.InteropServices.InvalidComObjectException)
+                {
+                    // The COM object is separated from its RCW, try reacquiring the RCW or recreating the COM object
+                    _rdpClient = new MsRdpClient6NotSafeForScripting();
+                    _rdpClient.AdvancedSettings2.SmartSizing = value;
+                }
+            }
         }
+
 
         public virtual bool Fullscreen
         {

--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs
@@ -79,7 +79,6 @@ namespace mRemoteNG.Connection.Protocol.RDP
             }
         }
 
-
         public virtual bool Fullscreen
         {
             get => _rdpClient.FullScreen;


### PR DESCRIPTION

## Description
This resolves an issue where an exception is thrown when resizing the application or moving it around the screen after disconnecting from (or while connected) to an RDP session via "Fit to Panel"

I'm not sure if this is the best solution, because it causes the app to flicker when dragging it around and releasing (or resizing), but it does get rid of the exception. Feel free to modify if you have a better solution.

## Motivation and Context

Attempts to handle the following exception:
```
COM object that has been separated from its underlying RCW cannot be used.

   at System.StubHelpers.StubHelpers.GetCOMIPFromRCW(Object objSrc, IntPtr pCPCMD, IntPtr& ppTarget, Boolean& pfNeedsRelease)
   at MSTSCLib.IMsRdpClient6.get_AdvancedSettings2()
   at mRemoteNG.Connection.Protocol.RDP.RdpProtocol.get_SmartSize() in C:\Git\MremoteNG\mRemoteNG\Connection\Protocol\RDP\RdpProtocol.cs:line 54
   at mRemoteNG.Connection.Protocol.RDP.RdpProtocol8.DoResizeClient() in C:\Git\MremoteNG\mRemoteNG\Connection\Protocol\RDP\RdpProtocol8.cs:line 91
   at mRemoteNG.Connection.Protocol.RDP.RdpProtocol8.ResizeEnd(Object sender, EventArgs e) in C:\Git\MremoteNG\mRemoteNG\Connection\Protocol\RDP\RdpProtocol8.cs:line 71
   at System.Windows.Forms.Form.OnResizeEnd(EventArgs e)
   at System.Windows.Forms.Form.WmExitSizeMove(Message& m)
   at System.Windows.Forms.Form.WndProc(Message& m)
   at mRemoteNG.UI.Forms.FrmMain.WndProc(Message& m) in C:\Git\MremoteNG\mRemoteNG\UI\Forms\frmMain.cs:line 599
   at System.Windows.Forms.Control.ControlNativeWindow.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, WM msg, IntPtr wparam, IntPtr lparam)
```

There is no open issue because this is only an issue in the latest dev branch

## How Has This Been Tested?
1. Connect to RDP session using "Fit to Panel"
1. Disconnect
2. Restore main program window down (so it's not maximized) and move mRemoteNG window around and let go (or resize) and you will get an exception. If there's no exception, it's fixed

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Updated translation
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- --- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ✅ I have read the **CONTRIBUTING** document.
- ✅ My code follows the code style of this project.
- ✅ All Tests within VisualStudio are passing
- ✅ This pull request does not target the master branch.
- [ N/A] I have updated the changelog file accordingly, if necessary.
- [ N/A] I have updated the documentation accordingly, if necessary.
