### PR TITLE
Configuration via windows registry (updates and credentials)

### DIFF
--- a/mRemoteNG/App/Info/WindowsRegistryInfo.cs
+++ b/mRemoteNG/App/Info/WindowsRegistryInfo.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Win32;
+using System.Runtime.Versioning;
+
+namespace mRemoteNG.App.Info
+{
+    [SupportedOSPlatform("windows")]
+    public static class WindowsRegistryInfo
+    {
+        #region general parameters
+        public const RegistryHive Hive = RegistryHive.LocalMachine;
+        public const string RootKey = "SOFTWARE\\mRemoteNG";
+        #endregion
+
+        #region subkey location parameters
+
+        // Updates
+        public const string UpdateSubkey        = RootKey + "\\Updates"; // Registry subkey for general update settings
+        public const string UpdateOptionsSubkey = RootKey + "\\Updates\\Options"; // Registry subkey for update options within the update settings
+        #endregion
+    }
+}

--- a/mRemoteNG/App/Info/WindowsRegistryInfo.cs
+++ b/mRemoteNG/App/Info/WindowsRegistryInfo.cs
@@ -12,6 +12,9 @@ namespace mRemoteNG.App.Info
         #endregion
 
         #region subkey location parameters
+        // Credential
+        public const string CredentialSubkey = RootKey + "\\Credentials"; // Registry subkey for general credential settings
+        public const string CredentialOptionsSubkey = RootKey + "\\Credentials\\Options"; // Registry subkey for credential options within the credential settings
 
         // Updates
         public const string UpdateSubkey        = RootKey + "\\Updates"; // Registry subkey for general update settings

--- a/mRemoteNG/Config/Settings/Registry/CommonRegistrySettings.cs
+++ b/mRemoteNG/Config/Settings/Registry/CommonRegistrySettings.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.Win32;
+using System.Runtime.Versioning;
+using mRemoteNG.App.Info;
+using mRemoteNG.Tools.WindowsRegistry;
+
+namespace mRemoteNG.Config.Settings.Registry
+{
+    [SupportedOSPlatform("windows")]
+    /// Static utility class that provides access to and management of registry settings on the local machine.
+    /// It abstracts complex registry operations and centralizes the handling of various registry keys.
+    /// Benefits: Simplified code, enhances maintainability, and ensures consistency. #ReadOnly
+    public static class CommonRegistrySettings
+    {
+        private static readonly IRegistryAdvancedRead _WindowsRegistry = new WindowsRegistryAdvanced();
+        private static readonly RegistryHive _Hive = WindowsRegistryInfo.Hive;
+
+        private const string __Update = WindowsRegistryInfo.UpdateSubkey;
+        private const string __Credential = WindowsRegistryInfo.CredentialSubkey;
+
+        #region general update registry settings
+        /// <summary>
+        /// Indicates whether searching for updates is allowed. If false, there is no way to update directly from mRemoteNG.
+        /// </summary>
+        /// <remarks>
+        /// Default value is true, which allows check for updates.
+        /// If the registry key is set to true, no action will be taken because the key is not needed.
+        /// </remarks>
+        public static bool AllowCheckForUpdates { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Update, nameof(AllowCheckForUpdates), true);
+
+        /// <summary>
+        /// Indicates whether automatic search for updates is allowed.
+        /// </summary>
+        /// <remarks>
+        /// Default value is true, which allows check for updates automaticaly.
+        /// If the registry key is set to true, no action will be taken because the key is not needed.
+        /// Important: If AllowCheckForUpdates is false, the default for this value (AllowCheckForUpdatesAutomatical) is also false, manual update checks are disabled.
+        /// </remarks>
+        public static bool AllowCheckForUpdatesAutomatical { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Update, nameof(AllowCheckForUpdatesAutomatical), AllowCheckForUpdates);
+
+        /// <summary>
+        /// Indicates whether a manual search for updates is allowed.
+        /// </summary>
+        /// <remarks>
+        /// The default value is true, enabling the manual check for updates.
+        /// If the registry key is set to true, no action will be taken because the key is not needed.
+        /// Important: If AllowCheckForUpdates is false, the default for this value (AllowCheckForUpdatesManual) is also false, manual update checks are disabled.
+        /// </remarks>
+        public static bool AllowCheckForUpdatesManual { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Update, nameof(AllowCheckForUpdatesManual), AllowCheckForUpdates);
+
+        /// <summary>
+        /// Specifies whether a question about checking for updates is displayed at startup.
+        /// </summary>
+        /// <remarks>
+        /// Important: If the registry entry is set to true, a popup will appear every time you start
+        /// </remarks>
+        public static bool CheckForUpdatesAsked { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Update, nameof(CheckForUpdatesAsked));
+        #endregion
+
+
+        
+    }
+}

--- a/mRemoteNG/Config/Settings/Registry/CommonRegistrySettings.cs
+++ b/mRemoteNG/Config/Settings/Registry/CommonRegistrySettings.cs
@@ -15,7 +15,7 @@ namespace mRemoteNG.Config.Settings.Registry
         private static readonly RegistryHive _Hive = WindowsRegistryInfo.Hive;
 
         private const string __Update = WindowsRegistryInfo.UpdateSubkey;
-        private const string __Credential = WindowsRegistryInfo.CredentialSubkey;
+        //private const string __Credential = WindowsRegistryInfo.CredentialSubkey;
 
         #region general update registry settings
         /// <summary>

--- a/mRemoteNG/Config/Settings/Registry/CommonRegistrySettings.cs
+++ b/mRemoteNG/Config/Settings/Registry/CommonRegistrySettings.cs
@@ -15,7 +15,7 @@ namespace mRemoteNG.Config.Settings.Registry
         private static readonly RegistryHive _Hive = WindowsRegistryInfo.Hive;
 
         private const string __Update = WindowsRegistryInfo.UpdateSubkey;
-        //private const string __Credential = WindowsRegistryInfo.CredentialSubkey;
+        private const string __Credential = WindowsRegistryInfo.CredentialSubkey;
 
         #region general update registry settings
         /// <summary>
@@ -23,7 +23,6 @@ namespace mRemoteNG.Config.Settings.Registry
         /// </summary>
         /// <remarks>
         /// Default value is true, which allows check for updates.
-        /// If the registry key is set to true, no action will be taken because the key is not needed.
         /// </remarks>
         public static bool AllowCheckForUpdates { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Update, nameof(AllowCheckForUpdates), true);
 
@@ -32,8 +31,6 @@ namespace mRemoteNG.Config.Settings.Registry
         /// </summary>
         /// <remarks>
         /// Default value is true, which allows check for updates automaticaly.
-        /// If the registry key is set to true, no action will be taken because the key is not needed.
-        /// Important: If AllowCheckForUpdates is false, the default for this value (AllowCheckForUpdatesAutomatical) is also false, manual update checks are disabled.
         /// </remarks>
         public static bool AllowCheckForUpdatesAutomatical { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Update, nameof(AllowCheckForUpdatesAutomatical), AllowCheckForUpdates);
 
@@ -42,21 +39,40 @@ namespace mRemoteNG.Config.Settings.Registry
         /// </summary>
         /// <remarks>
         /// The default value is true, enabling the manual check for updates.
-        /// If the registry key is set to true, no action will be taken because the key is not needed.
-        /// Important: If AllowCheckForUpdates is false, the default for this value (AllowCheckForUpdatesManual) is also false, manual update checks are disabled.
         /// </remarks>
         public static bool AllowCheckForUpdatesManual { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Update, nameof(AllowCheckForUpdatesManual), AllowCheckForUpdates);
 
         /// <summary>
         /// Specifies whether a question about checking for updates is displayed at startup.
         /// </summary>
-        /// <remarks>
-        /// Important: If the registry entry is set to true, a popup will appear every time you start
-        /// </remarks>
         public static bool AllowPromptForUpdatesPreference { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Update, nameof(AllowPromptForUpdatesPreference), AllowCheckForUpdates);
         #endregion
 
+        #region general credential registry settings
+        /// <summary>
+        /// Setting that indicates whether exporting passwords is allowed.
+        /// </summary>
+        public static bool AllowExportPasswords { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Credential, nameof(AllowExportPasswords), true);
 
-        
+        /// <summary>
+        /// Setting that indicates whether exporting usernames is allowed.
+        /// </summary>
+        public static bool AllowExportUsernames { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Credential, nameof(AllowExportUsernames), true);
+
+        /// <summary>
+        /// Setting that indicates whether saving passwords is allowed.
+        /// </summary>
+        public static bool AllowSavePasswords { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Credential, nameof(AllowSavePasswords), true);
+
+        /// <summary>
+        /// Setting that indicates whether saving usernames is allowed.
+        /// </summary>
+        public static bool AllowSaveUsernames { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Credential, nameof(AllowSaveUsernames), true);
+
+        /// <summary>
+        /// Setting that indicates whether modifying credential settings is allowed.
+        /// </summary>
+        public static bool AllowModifyCredentialSettings { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Credential, nameof(AllowModifyCredentialSettings), true);
+        #endregion
     }
 }

--- a/mRemoteNG/Config/Settings/Registry/CommonRegistrySettings.cs
+++ b/mRemoteNG/Config/Settings/Registry/CommonRegistrySettings.cs
@@ -53,7 +53,7 @@ namespace mRemoteNG.Config.Settings.Registry
         /// <remarks>
         /// Important: If the registry entry is set to true, a popup will appear every time you start
         /// </remarks>
-        public static bool CheckForUpdatesAsked { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Update, nameof(CheckForUpdatesAsked));
+        public static bool AllowPromptForUpdatesPreference { get; } = _WindowsRegistry.GetBoolValue(_Hive, __Update, nameof(AllowPromptForUpdatesPreference), AllowCheckForUpdates);
         #endregion
 
 

--- a/mRemoteNG/Config/Settings/Registry/OptRegistryCredentialsPage.cs
+++ b/mRemoteNG/Config/Settings/Registry/OptRegistryCredentialsPage.cs
@@ -1,0 +1,77 @@
+﻿using System.Runtime.Versioning;
+using Microsoft.Win32;
+using mRemoteNG.App.Info;
+using mRemoteNG.Tools.WindowsRegistry;
+
+namespace mRemoteNG.Config.Settings.Registry
+{
+    [SupportedOSPlatform("windows")]
+    /// Static utility class that provides access to and management of registry settings on the local machine.
+    /// It abstracts complex registry operations and centralizes the handling of various registry keys.
+    /// Benefits: Simplified code, enhances maintainability, and ensures consistency. #ReadOnly
+    public sealed partial class OptRegistryCredentialsPage : WindowsRegistryAdvanced
+    {
+        #region option page credential registry settings
+        /// <summary>
+        /// Specifies the radio button is set to none, windows or custom on the credentials page.
+        /// </summary>
+        /// <remarks>
+        /// When set to noinfo or windows, WindowsCredentials and CustomCredentials are not evaluated and disabled.
+        /// </remarks>
+        public WindowsRegistryKeyString UseCredentials { get; }
+
+        /// <summary>
+        /// Specifies the user set via API as the default username.
+        /// </summary>
+        /// <remarks>
+        /// Only avaiable if UseCredentials is set to custom!
+        /// </remarks>
+        public WindowsRegistryKeyString UserViaAPIDefault { get; }
+
+        /// <summary>
+        /// Specifies the default username.
+        /// </summary>
+        /// <remarks>
+        /// Only avaiable if UseCredentials is set to custom!
+        /// </remarks>
+        public WindowsRegistryKeyString DefaultUsername { get; }
+
+        /// <summary>
+        /// Specifies the default password.
+        /// </summary>
+        /// <remarks>
+        /// Only avaiable if UseCredentials is set to custom!
+        /// </remarks>
+        //public WindowsRegistryKeyString DefaultPassword { get; }
+
+        /// <summary>
+        /// Specifies the default domain.
+        /// </summary>
+        /// <remarks>
+        /// Only avaiable if UseCredentials is set to custom!
+        /// </remarks>
+        public WindowsRegistryKeyString DefaultDomain { get; }
+        #endregion
+
+        public OptRegistryCredentialsPage()
+        {
+            RegistryHive hive = WindowsRegistryInfo.Hive;
+            string subKey = WindowsRegistryInfo.CredentialOptionsSubkey;
+
+            UseCredentials = GetStringValidated(hive, subKey, nameof(UseCredentials),
+                new string[] {
+                    "noinfo",
+                    "windows",
+                    "custom"
+                }, true
+             );
+
+            UserViaAPIDefault = GetString(hive, subKey, nameof(UserViaAPIDefault), null);
+            DefaultUsername = GetString(hive, subKey, nameof(DefaultUsername), null);
+            //Currently not supported, but needed for configuration...
+            //DefaultPassword = GetPassword(hive, subKey, nameof(DefaultPassword));
+
+            DefaultDomain = GetString(hive, subKey, nameof(DefaultDomain), null);
+        }
+    }
+}

--- a/mRemoteNG/Config/Settings/Registry/OptRegistryUpdatesPage.cs
+++ b/mRemoteNG/Config/Settings/Registry/OptRegistryUpdatesPage.cs
@@ -53,9 +53,9 @@ namespace mRemoteNG.Config.Settings.Registry
         /// Specifies the authentication password for the proxy.
         /// </summary>
         /// <remarks>
-        /// Please only store encrypted passwords in the registry by using the password generator on the 'Credentials' options page.
+        /// Please only store encrypted passwords in the registry.
         /// </remarks>
-        public string ProxyAuthPass { get; }
+        //public string ProxyAuthPass { get; }
 
         public OptRegistryUpdatesPage()
         {

--- a/mRemoteNG/Config/Settings/Registry/OptRegistryUpdatesPage.cs
+++ b/mRemoteNG/Config/Settings/Registry/OptRegistryUpdatesPage.cs
@@ -1,0 +1,86 @@
+﻿using System.Runtime.Versioning;
+using Microsoft.Win32;
+using mRemoteNG.App.Info;
+using mRemoteNG.Tools.WindowsRegistry;
+
+namespace mRemoteNG.Config.Settings.Registry
+{
+    [SupportedOSPlatform("windows")]
+    /// Static utility class that provides access to and management of registry settings on the local machine.
+    /// It abstracts complex registry operations and centralizes the handling of various registry keys.
+    /// Benefits: Simplified code, enhances maintainability, and ensures consistency. #ReadOnly
+    public sealed partial class OptRegistryUpdatesPage : WindowsRegistryAdvanced
+    {
+        /// <summary>
+        /// Specifies the number of days between update checks.
+        /// </summary>
+        public WindowsRegistryKeyInteger CheckForUpdatesFrequencyDays { get; }
+
+        /// <summary>
+        /// Specifies the update channel for updates.
+        /// </summary>
+        /// <remarks>
+        /// The update channel should be one of the predefined values: Stable, Preview, Nightly.
+        /// </remarks>
+        public WindowsRegistryKeyString UpdateChannel { get; }
+
+        /// <summary>
+        /// Indicates whether proxy usage for updates is enabled.
+        /// </summary>
+        public WindowsRegistryKeyBoolean UseProxyForUpdates { get; }
+
+        /// <summary>
+        /// Specifies the proxy address for updates.
+        /// </summary>
+        public WindowsRegistryKeyString ProxyAddress { get; }
+
+        /// <summary>
+        /// Specifies the proxy port for updates.
+        /// </summary>
+        public WindowsRegistryKeyInteger ProxyPort { get; }
+
+        /// <summary>
+        /// Indicates whether proxy authentication is enabled.
+        /// </summary>
+        public WindowsRegistryKeyBoolean UseProxyAuthentication { get; }
+
+        /// <summary>
+        /// Specifies the authentication username for the proxy.
+        /// </summary>
+        public WindowsRegistryKeyString ProxyAuthUser { get; }
+
+        /// <summary>
+        /// Specifies the authentication password for the proxy.
+        /// </summary>
+        /// <remarks>
+        /// Please only store encrypted passwords in the registry by using the password generator on the 'Credentials' options page.
+        /// </remarks>
+        public string ProxyAuthPass { get; }
+
+        public OptRegistryUpdatesPage()
+        {
+            RegistryHive hive = WindowsRegistryInfo.Hive;
+            string subKey = WindowsRegistryInfo.UpdateOptionsSubkey;
+
+            CheckForUpdatesFrequencyDays = GetInteger(hive, subKey, nameof(CheckForUpdatesFrequencyDays));
+
+            UpdateChannel = GetStringValidated(hive, subKey, nameof(UpdateChannel),
+                new string[] {
+                    UpdateChannelInfo.STABLE,
+                    UpdateChannelInfo.PREVIEW,
+                    UpdateChannelInfo.NIGHTLY
+                }
+                ,true
+            );
+
+            UseProxyForUpdates = GetBoolean(hive, subKey, nameof(UseProxyForUpdates));
+            ProxyAddress = GetString(hive, subKey, nameof(ProxyAddress), null);
+            ProxyPort = GetInteger(hive, subKey, nameof(ProxyPort));
+
+            UseProxyAuthentication = GetBoolean(hive, subKey, nameof(UseProxyAuthentication));
+            ProxyAuthUser = GetString(hive, subKey, nameof(ProxyAuthUser), null);
+            //Currently not supported:
+            //ProxyAuthPass = GetPassword(Hive, _SubKey, nameof(ProxyAuthPass));
+        }
+    }
+}

--- a/mRemoteNG/Config/Settings/Registry/OptRegistryUpdatesPage.cs
+++ b/mRemoteNG/Config/Settings/Registry/OptRegistryUpdatesPage.cs
@@ -52,9 +52,6 @@ namespace mRemoteNG.Config.Settings.Registry
         /// <summary>
         /// Specifies the authentication password for the proxy.
         /// </summary>
-        /// <remarks>
-        /// Please only store encrypted passwords in the registry.
-        /// </remarks>
         //public string ProxyAuthPass { get; }
 
         public OptRegistryUpdatesPage()

--- a/mRemoteNG/Language/Language.Designer.cs
+++ b/mRemoteNG/Language/Language.Designer.cs
@@ -3388,6 +3388,15 @@ namespace mRemoteNG.Resources.Language {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to *Some settings are determined by your company. For further information, please contact your administrator.
+        /// </summary>
+        internal static string OptionsAdminInfo {
+            get {
+                return ResourceManager.GetString("OptionsAdminInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to mRemoteNG Options.
         /// </summary>
         internal static string OptionsPageTitle {

--- a/mRemoteNG/Language/Language.de.resx
+++ b/mRemoteNG/Language/Language.de.resx
@@ -2047,4 +2047,7 @@ Nightly umfasst Alphas, Betas und Release Candidates.</value>
     <value>Maximale Anmeldeversuche erreicht. Verbindung erneut initiieren.</value>
     <comment>C# to Powershell transfer issue with encoding possible</comment>
   </data>
+  <data name="OptionsAdminInfo" xml:space="preserve">
+    <value>*Einige Einstellungen werden von Ihrem Unternehmen festgelegt. Für weitere Informationen wenden Sie sich an Ihren Systemadministrator.</value>
+  </data>
 </root>

--- a/mRemoteNG/Language/Language.resx
+++ b/mRemoteNG/Language/Language.resx
@@ -2362,4 +2362,7 @@ Nightly Channel includes Alphas, Betas &amp; Release Candidates.</value>
   <data name="FilterSecureCRT" xml:space="preserve">
     <value>SecureCRT (*.xml)</value>
   </data>
+  <data name="OptionsAdminInfo" xml:space="preserve">
+    <value>*Some settings are determined by your company. For further information, please contact your administrator</value>
+  </data>
 </root>

--- a/mRemoteNG/Security/SaveFilter.cs
+++ b/mRemoteNG/Security/SaveFilter.cs
@@ -1,12 +1,16 @@
+﻿using mRemoteNG.Config.Settings.Registry;
+using System.Runtime.Versioning;
+
 namespace mRemoteNG.Security
 {
+    [SupportedOSPlatform("windows")]
     public class SaveFilter
     {
         public SaveFilter(bool disableEverything = false)
         {
             if (disableEverything) return;
-            SaveUsername = true;
-            SavePassword = true;
+            SaveUsername = CommonRegistrySettings.AllowSaveUsernames;
+            SavePassword = CommonRegistrySettings.AllowSavePasswords;
             SaveDomain = true;
             SaveCredentialId = true;
             SaveInheritance = true;

--- a/mRemoteNG/Tools/WindowsRegistry/IRegistry.cs
+++ b/mRemoteNG/Tools/WindowsRegistry/IRegistry.cs
@@ -15,7 +15,9 @@ namespace mRemoteNG.Tools.WindowsRegistry
         string[] GetSubKeyNames(RegistryHive hive, string path);
         string GetPropertyValue(WindowsRegistryKey key);
         string GetPropertyValue(RegistryHive hive, string path, string name);
+
         bool GetBoolValue(RegistryHive hive, string path, string propertyName, bool defaultValue = false);
+        int GetDwordValue(RegistryHive hive, string path, string propertyName, int defaultValue = 0);
 
         WindowsRegistryKey GetWindowsRegistryKey(RegistryHive hive, string path, string name);
         WindowsRegistryKey GetWindowsRegistryKey(WindowsRegistryKey key);

--- a/mRemoteNG/Tools/WindowsRegistry/IRegistryAdvanced.cs
+++ b/mRemoteNG/Tools/WindowsRegistry/IRegistryAdvanced.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Versioning;
-using static mRemoteNG.Config.Settings.Registry.RegistryController;
 
 namespace mRemoteNG.Tools.WindowsRegistry
 {
@@ -16,6 +15,9 @@ namespace mRemoteNG.Tools.WindowsRegistry
         string[] GetSubKeyNames(RegistryHive hive, string path);
         string GetPropertyValue(WindowsRegistryKey key);
         string GetPropertyValue(RegistryHive hive, string path, string name);
+
+        bool GetBoolValue(RegistryHive hive, string path, string propertyName, bool defaultValue = false);
+        int GetDwordValue(RegistryHive hive, string path, string propertyName, int defaultValue = 0);
 
         WindowsRegistryKey GetWindowsRegistryKey(RegistryHive hive, string path, string name);
         WindowsRegistryKey GetWindowsRegistryKey(WindowsRegistryKey key);

--- a/mRemoteNG/Tools/WindowsRegistry/IRegistryAdvanced.cs
+++ b/mRemoteNG/Tools/WindowsRegistry/IRegistryAdvanced.cs
@@ -2,41 +2,52 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Versioning;
+using static mRemoteNG.Config.Settings.Registry.RegistryController;
 
 namespace mRemoteNG.Tools.WindowsRegistry
 {
     [SupportedOSPlatform("windows")]
     /// <summary>
-    /// Interface for the Registry class providing methods for interacting with the Windows Registry.
+    /// Interface for the RegistryWorker class providing functionality to interact with the Windows Registry to retrieve registry settings.
     /// </summary>
-    public interface IRegistry
+    public interface IRegistryAdvanced
     {
-        #region registry reader
+        #region WindowsRegistry reader
         string[] GetSubKeyNames(RegistryHive hive, string path);
         string GetPropertyValue(WindowsRegistryKey key);
         string GetPropertyValue(RegistryHive hive, string path, string name);
-        bool GetBoolValue(RegistryHive hive, string path, string propertyName, bool defaultValue = false);
 
         WindowsRegistryKey GetWindowsRegistryKey(RegistryHive hive, string path, string name);
         WindowsRegistryKey GetWindowsRegistryKey(WindowsRegistryKey key);
 
         List<WindowsRegistryKey> GetRegistryEntries(RegistryHive hive, string path);
         List<WindowsRegistryKey> GetRegistryEntryiesRecursive(RegistryHive hive, string path);
-
         #endregion
 
-        #region registry writer
+        #region WindowsRegistry writer 
         void SetRegistryValue(WindowsRegistryKey key);
         void SetRegistryValue(RegistryHive hive, string path, string name, object value, RegistryValueKind valueKind);
         void DeleteRegistryKey(RegistryHive hive, string path, bool ignoreNotFound = false);
-
         #endregion
 
-        #region registry tools
+        #region WindowsRegistry tools
         RegistryHive ConvertStringToRegistryHive(string hiveString);
         RegistryValueKind ConvertStringToRegistryValueKind(string valueType);
         RegistryValueKind ConvertTypeToRegistryValueKind(Type valueType);
         Type ConvertRegistryValueKindToType(RegistryValueKind valueKind);
+        #endregion
+
+        #region WindowsRegistryAdvanced GetInteger
+        WindowsRegistryKeyInteger GetInteger(RegistryHive hive, string path, string propertyName, int? defaultValue = null);
+        #endregion
+
+        #region WindowsRegistryAdvanced GetString
+        WindowsRegistryKeyString GetString(RegistryHive hive, string path, string propertyName, string defaultValue = null);
+        WindowsRegistryKeyString GetStringValidated(RegistryHive hive, string path, string propertyName, string[] allowedValues, bool caseSensitive = false, string defaultValue = null);
+        #endregion
+
+        #region WindowsRegistryAdvanced GetBoolean
+        WindowsRegistryKeyBoolean GetBoolean(RegistryHive hive, string path, string propertyName, bool? defaultValue = null);
         #endregion
     }
 }

--- a/mRemoteNG/Tools/WindowsRegistry/IRegistryAdvancedRead.cs
+++ b/mRemoteNG/Tools/WindowsRegistry/IRegistryAdvancedRead.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Versioning;
-using static mRemoteNG.Config.Settings.Registry.RegistryController;
 
 namespace mRemoteNG.Tools.WindowsRegistry
 {
@@ -16,6 +15,9 @@ namespace mRemoteNG.Tools.WindowsRegistry
         string[] GetSubKeyNames(RegistryHive hive, string path);
         string GetPropertyValue(WindowsRegistryKey key);
         string GetPropertyValue(RegistryHive hive, string path, string name);
+
+        bool GetBoolValue(RegistryHive hive, string path, string propertyName, bool defaultValue = false);
+        int GetDwordValue(RegistryHive hive, string path, string propertyName, int defaultValue = 0);
 
         WindowsRegistryKey GetWindowsRegistryKey(RegistryHive hive, string path, string name);
         WindowsRegistryKey GetWindowsRegistryKey(WindowsRegistryKey key);

--- a/mRemoteNG/Tools/WindowsRegistry/IRegistryAdvancedRead.cs
+++ b/mRemoteNG/Tools/WindowsRegistry/IRegistryAdvancedRead.cs
@@ -2,21 +2,20 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Versioning;
+using static mRemoteNG.Config.Settings.Registry.RegistryController;
 
 namespace mRemoteNG.Tools.WindowsRegistry
 {
     [SupportedOSPlatform("windows")]
     /// <summary>
-    /// Interface for the Registry class providing methods for interacting with read actions in the Windows Registry.
+    /// Interface for the RegistryWorker class providing functionality to interact with the Windows Registry to retrieve registry settings.
     /// </summary>
-    public interface IRegistryRead
+    public interface IRegistryAdvancedRead
     {
-        #region registry reader
+        #region WindowsRegistry reader
         string[] GetSubKeyNames(RegistryHive hive, string path);
-
         string GetPropertyValue(WindowsRegistryKey key);
         string GetPropertyValue(RegistryHive hive, string path, string name);
-        bool GetBoolValue(RegistryHive hive, string path, string propertyName, bool defaultValue = false);
 
         WindowsRegistryKey GetWindowsRegistryKey(RegistryHive hive, string path, string name);
         WindowsRegistryKey GetWindowsRegistryKey(WindowsRegistryKey key);
@@ -25,11 +24,24 @@ namespace mRemoteNG.Tools.WindowsRegistry
         List<WindowsRegistryKey> GetRegistryEntryiesRecursive(RegistryHive hive, string path);
         #endregion
 
-        #region registry tools
+        #region WindowsRegistry tools
         RegistryHive ConvertStringToRegistryHive(string hiveString);
         RegistryValueKind ConvertStringToRegistryValueKind(string valueType);
         RegistryValueKind ConvertTypeToRegistryValueKind(Type valueType);
         Type ConvertRegistryValueKindToType(RegistryValueKind valueKind);
+        #endregion
+
+        #region WindowsRegistryAdvanced GetInteger
+        WindowsRegistryKeyInteger GetInteger(RegistryHive hive, string path, string propertyName, int? defaultValue = null);
+        #endregion
+
+        #region WindowsRegistryAdvanced GetString
+        WindowsRegistryKeyString GetString(RegistryHive hive, string path, string propertyName, string defaultValue = null);
+        WindowsRegistryKeyString GetStringValidated(RegistryHive hive, string path, string propertyName, string[] allowedValues, bool caseSensitive = false, string defaultValue = null);
+        #endregion
+
+        #region WindowsRegistryAdvanced GetBoolean
+        WindowsRegistryKeyBoolean GetBoolean(RegistryHive hive, string path, string propertyName, bool? defaultValue = null);
         #endregion
     }
 }

--- a/mRemoteNG/Tools/WindowsRegistry/IRegistryRead.cs
+++ b/mRemoteNG/Tools/WindowsRegistry/IRegistryRead.cs
@@ -13,10 +13,11 @@ namespace mRemoteNG.Tools.WindowsRegistry
     {
         #region registry reader
         string[] GetSubKeyNames(RegistryHive hive, string path);
-
         string GetPropertyValue(WindowsRegistryKey key);
         string GetPropertyValue(RegistryHive hive, string path, string name);
+
         bool GetBoolValue(RegistryHive hive, string path, string propertyName, bool defaultValue = false);
+        int GetDwordValue(RegistryHive hive, string path, string propertyName, int defaultValue = 0);
 
         WindowsRegistryKey GetWindowsRegistryKey(RegistryHive hive, string path, string name);
         WindowsRegistryKey GetWindowsRegistryKey(WindowsRegistryKey key);

--- a/mRemoteNG/Tools/WindowsRegistry/IRegistryWrite.cs
+++ b/mRemoteNG/Tools/WindowsRegistry/IRegistryWrite.cs
@@ -1,9 +1,13 @@
 ﻿using Microsoft.Win32;
+using System;
 using System.Runtime.Versioning;
 
 namespace mRemoteNG.Tools.WindowsRegistry
 {
     [SupportedOSPlatform("windows")]
+    /// <summary>
+    /// Interface for the Registry class providing methods for interacting with write actions in the Windows Registry.
+    /// </summary>
     public interface IRegistryWrite
     {
         #region registry writer
@@ -12,9 +16,11 @@ namespace mRemoteNG.Tools.WindowsRegistry
 
         #endregion
 
-        #region converter
+        #region registry tools
         RegistryHive ConvertStringToRegistryHive(string hiveString);
         RegistryValueKind ConvertStringToRegistryValueKind(string valueType);
-        #endregion}
+        RegistryValueKind ConvertTypeToRegistryValueKind(Type valueType);
+        Type ConvertRegistryValueKindToType(RegistryValueKind valueKind);
+        #endregion
     }
 }

--- a/mRemoteNG/Tools/WindowsRegistry/WindowsRegistry.cs
+++ b/mRemoteNG/Tools/WindowsRegistry/WindowsRegistry.cs
@@ -100,6 +100,26 @@ namespace mRemoteNG.Tools.WindowsRegistry
             return defaultValue;
         }
 
+        // <summary>
+        /// Retrieves a DWORD value from the Windows Registry, with an optional default value.
+        /// </summary>
+        /// <param name="hive">The Registry hive to access.</param>
+        /// <param name="path">The Registry path containing the key.</param>
+        /// <param name="propertyName">The name of the Registry property.</param>
+        /// <param name="defaultValue">The default value to return if the property is not found or cannot be parsed.</param>
+        /// <returns>The DWORD value from the Registry, or the specified default value.</returns>
+        public int GetDwordValue(RegistryHive hive, string path, string propertyName, int defaultValue = 0)
+        {
+            var value = GetPropertyValue(hive, path, propertyName);
+
+            if (int.TryParse(value, out int intValue))
+            {
+                return intValue;
+            }
+
+            return defaultValue;
+        }
+
         /// <summary>
         /// Retrieves a WindowsRegistryKey object for a specific registry hive, path, and value name.
         /// </summary>

--- a/mRemoteNG/Tools/WindowsRegistry/WindowsRegistryAdvanced.cs
+++ b/mRemoteNG/Tools/WindowsRegistry/WindowsRegistryAdvanced.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.Win32;
+using mRemoteNG.App.Info;
+using mRemoteNG.Security.SymmetricEncryption;
+using System.Runtime.Versioning;
+
+namespace mRemoteNG.Tools.WindowsRegistry
+{
+    [SupportedOSPlatform("windows")]
+    /// <summary>
+    /// Extends the functionality of interacting with the Windows Registry, building upon the base WindowsRegistry class.
+    /// </summary>
+    public class WindowsRegistryAdvanced : WindowsRegistry , IRegistryAdvanced, IRegistryAdvancedRead
+    {
+        #region dword methods
+        /// <summary>
+        /// Retrieves a DWORD (32-bit integer) value from the Windows Registry based on the specified registry information.
+        /// </summary>
+        /// <param name="hive">The registry hive.</param>
+        /// <param name="path">The path to the registry key.</param>
+        /// <param name="propertyName">The name of the registry property.</param>
+        /// <param name="defaultValue">Optional default value to be used if the registry key is not present (default is null).</param>
+        /// <returns>A WindowsRegistryKeyInteger instance representing the retrieved DWORD value.</returns>
+        public WindowsRegistryKeyInteger GetInteger(RegistryHive hive, string path, string propertyName, int? defaultValue = null)
+        {
+            // Retrieve the Windows Registry key
+            var key = GetWindowsRegistryKey(hive, path, propertyName);
+
+            // Create a WindowsRegistryKeyInteger instance and initialize it from the retrieved key
+            WindowsRegistryKeyInteger IntKey = new();
+            IntKey.ConvertFromWindowsRegistryKey(key);
+
+            return IntKey;
+        }
+        #endregion
+
+        #region string methods
+        /// <summary>
+        /// Retrieves a string value from the Windows Registry based on the specified registry information.
+        /// </summary>
+        /// <param name="hive">The registry hive.</param>
+        /// <param name="path">The path to the registry key.</param>
+        /// <param name="propertyName">The name of the registry property.</param>
+        /// <param name="defaultValue">Optional default value to be used if the registry key is not present (default is null).</param>
+        /// <returns>A WindowsRegistryKeyString instance representing the retrieved string value.</returns>
+        public WindowsRegistryKeyString GetString(RegistryHive hive, string path, string propertyName, string defaultValue = null)
+        {
+            // Retrieve the Windows Registry key
+            var key = GetWindowsRegistryKey(hive, path, propertyName);
+
+            // Create a WindowsRegistryKeyString instance and initialize it from the retrieved key
+            WindowsRegistryKeyString StrKey = new();
+            StrKey.ConvertFromWindowsRegistryKey(key, defaultValue);
+
+            return StrKey;
+        }
+
+        /// <summary>
+        /// Retrieves a string value from the Windows Registry based on the specified registry information and validates it against a set of allowed values.
+        /// </summary>
+        /// <param name="hive">The registry hive.</param>
+        /// <param name="path">The path to the registry key.</param>
+        /// <param name="propertyName">The name of the registry property.</param>
+        /// <param name="allowedValues">An array of valid values against which the retrieved string is validated.</param>
+        /// <param name="caseSensitive">Optional parameter indicating whether the validation is case-sensitive (default is false).</param>
+        /// <returns>A WindowsRegistryKeyString instance representing the retrieved and validated string value.</returns>
+        public WindowsRegistryKeyString GetStringValidated(RegistryHive hive, string path, string propertyName, string[] allowedValues, bool caseSensitive = false, string defaultValue = null)
+        {
+            // Retrieve the Windows Registry key
+            var key = GetWindowsRegistryKey(hive, path, propertyName);
+
+            // Create a WindowsRegistryKeyString instance and initialize it from the retrieved key
+            WindowsRegistryKeyString StrKey = new();
+            StrKey.AllowedValues = allowedValues;
+            StrKey.IsCaseSensitiveValidation = caseSensitive;
+            StrKey.ConvertFromWindowsRegistryKey(key, defaultValue);
+
+            return StrKey;
+        }
+
+        /*public WindowsRegistryKeySecureString GetSecureString(RegistryHive hive, string path, string propertyName)
+        {
+            // Retrieve the Windows Registry key, the key should be encrypted
+            var key = GetWindowsRegistryKey(hive, path, propertyName);
+
+            // Create a WindowsRegistryKeyBoolean instance and initialize it from the retrieved key
+            WindowsRegistryKeySecureString secureKey = new (); // class not exsists
+            secureKey.ConvertFromWindowsRegistryKey(key); // no default possible!
+            return secureKey
+        }*/
+
+        #endregion
+
+        #region bool methods
+        /// <summary>
+        /// Retrieves a boolean value from the Windows Registry based on the specified registry information.
+        /// </summary>
+        /// <param name="hive">The registry hive.</param>
+        /// <param name="path">The path to the registry key.</param>
+        /// <param name="propertyName">The name of the registry property.</param>
+        /// <param name="defaultValue">An optional default value to use if the registry key is not present or if the value is not a valid boolean.</param>
+        /// <returns>A WindowsRegistryKeyBoolean instance representing the retrieved boolean value.</returns>
+        public WindowsRegistryKeyBoolean GetBoolean(RegistryHive hive, string path, string propertyName, bool? defaultValue = null)
+        {
+            // Retrieve the Windows Registry key
+            var key = GetWindowsRegistryKey(hive, path, propertyName);
+
+            // Create a WindowsRegistryKeyBoolean instance and initialize it from the retrieved key
+            WindowsRegistryKeyBoolean boolKey = new ();
+            boolKey.ConvertFromWindowsRegistryKey(key, defaultValue);
+
+            return boolKey;
+        }
+
+        #endregion
+    }
+}

--- a/mRemoteNG/Tools/WindowsRegistry/WindowsRegistryKey.cs
+++ b/mRemoteNG/Tools/WindowsRegistry/WindowsRegistryKey.cs
@@ -6,9 +6,8 @@ using Microsoft.Win32;
 namespace mRemoteNG.Tools.WindowsRegistry
 {
     /// <summary>
-    /// This class provides a convenient way to work with Windows Registry keys
-    /// by encapsulating information about a registry key, including its path,
-    /// name, value, and registry hive/type.
+    /// Represents a Windows Registry key with a default string value, providing a flexible abstraction for registry operations.
+    /// This class can be extended by inherited classes to customize behavior for specific data types.
     /// </summary>
     [SupportedOSPlatform("windows")]
     public class WindowsRegistryKey
@@ -56,42 +55,22 @@ namespace mRemoteNG.Tools.WindowsRegistry
         private string _Name { get; set; }
         #endregion
 
-        #region Property valueKind
-        public RegistryValueKind ValueKind
+        #region Property value
+        public virtual string Value
         {
-            get { return _ValueKind; }
-            set {
-                if (value == 0)
-                    throw new ArgumentNullException("ValueKind unknown.");
-
-                _ValueKind = value;
-
-                // Check if Type is uninitialized (null)
-                if (_Type == null)
-                    // Initialize Type if it's uninitialized
-                    _Type = ConvertRegistryValueKindToType(value); 
+            get => _value;
+            set
+            {
+                _value = value;
+                UpdateIsProvidedState();
             }
         }
-        private RegistryValueKind _ValueKind;
+        private string _value;
         #endregion
 
-        #region Property type
-        public Type Type
-        {
-            get { return _Type; }
-            set {
-                _Type = value;
-               
-                // Check if ValueKind is uninitialized(0)
-                if (_ValueKind == 0)
-                    // Initialize ValueKind if it's uninitialized
-                    _ValueKind = ConvertTypeToRegistryValueKind(value); 
-            }
-        }
-        private Type _Type;
-        #endregion
+        public RegistryValueKind ValueKind { get; set; } = RegistryValueKind.Unknown;
 
-        public string Value { get; set; }
+        public bool IsKeyPresent { get; set; } = false;
         #endregion
 
         #region public methods
@@ -118,94 +97,20 @@ namespace mRemoteNG.Tools.WindowsRegistry
         }
         #endregion
 
-        #region private methods
-        /// <summary>
-        /// Converts a .NET data type to the corresponding RegistryValueKind.
-        /// </summary>
-        /// <param name="valueType">The .NET data type to convert.</param>
-        /// <returns>The corresponding RegistryValueKind.</returns>
-        private RegistryValueKind ConvertTypeToRegistryValueKind(Type valueType)
+        #region protected methods
+        protected void UpdateIsProvidedState()
         {
-            switch (Type.GetTypeCode(valueType))
-            {
-                case TypeCode.String:
-                    return RegistryValueKind.String;
-                case TypeCode.Int32:
-                    return RegistryValueKind.DWord;
-                case TypeCode.Int64:
-                    return RegistryValueKind.QWord;
-                case TypeCode.Boolean:
-                    return RegistryValueKind.DWord;
-                case TypeCode.Byte:
-                    return RegistryValueKind.Binary;
-                /*
-                case TypeCode.Single:
-                    return RegistryValueKind;
-                case TypeCode.Double:
-                    return RegistryValueKind.String;
-                case TypeCode.DateTime:
-                    return RegistryValueKind.String; // DateTime can be stored as a string or other types
-                case TypeCode.Char:
-                    return RegistryValueKind.String; // Char can be stored as a string or other types
-                case TypeCode.Decimal:
-                     return RegistryValueKind.String; // Decimal can be stored as a string or other types
-                */
-                default:
-                    return RegistryValueKind.String; // Default to String for unsupported types
-            }
+            // Key is present when RegistryKey value is not null
+            IsKeyPresent = Value != null;
         }
 
-        /// <summary>
-        /// Converts a RegistryValueKind enumeration value to its corresponding .NET Type.
-        /// </summary>
-        /// <param name="valueKind">The RegistryValueKind value to be converted.</param>
-        /// <returns>The .NET Type that corresponds to the given RegistryValueKind.</returns>
-        private Type ConvertRegistryValueKindToType(RegistryValueKind valueKind)
-        {
-            switch (valueKind)
-            {
-                case RegistryValueKind.String:
-                case RegistryValueKind.ExpandString:
-                    return typeof(string);
-                case RegistryValueKind.DWord:
-                    return typeof(int);
-                case RegistryValueKind.QWord:
-                    return typeof(long);
-                case RegistryValueKind.Binary:
-                    return typeof(byte[]);
-                case RegistryValueKind.MultiString:
-                    return typeof(string[]);
-                case RegistryValueKind.Unknown:
-                default:
-                    return typeof(object);
-            }
-        }
+        protected bool IsHiveSet() => Hive != 0;
 
-        private bool IsHiveSet()
-        {
-            return Hive != 0;
-        }
+        protected bool IsValueKindSet() => ValueKind != 0;
 
-        private bool IsValueKindSet()
-        {
-            return ValueKind != 0;
-        }
+        protected bool IsPathSet() => Path != null;
 
-        private bool IsPathSet()
-        {
-            return Path != null; ;
-            //return !string.IsNullOrEmpty(Path);
-        }
-
-        private bool IsNameSet()
-        {
-            return Name != null;
-        }
-
-        private bool IsValueSet()
-        {
-            return !string.IsNullOrEmpty(Value);
-        }
+        protected bool IsNameSet() => Name != null;
         #endregion
     }
 }

--- a/mRemoteNG/Tools/WindowsRegistry/WindowsRegistryKeyBoolean.cs
+++ b/mRemoteNG/Tools/WindowsRegistry/WindowsRegistryKeyBoolean.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Runtime.Versioning;
+
+namespace mRemoteNG.Tools.WindowsRegistry
+{
+    /// <summary>
+    /// Represents a boolean Windows Registry key, extending the base class WindowsRegistryKey.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public class WindowsRegistryKeyBoolean : WindowsRegistryKey
+    {
+        /// <summary>
+        /// Gets or sets the default boolean value for a Windows Registry key.
+        /// </summary>
+        /// <remarks>
+        /// The default value is initially set to `false`.
+        /// </remarks>
+        public bool DefaultValue { get; private set; } = false;
+
+        /// <summary>
+        /// Gets or sets the boolean value for a Windows Registry key.
+        /// </summary>
+        public new bool Value
+        {
+            get => BoolValue;
+            private set
+            {
+                BoolValue = value;
+                UpdateIsProvidedState();
+            }
+        }
+        private bool BoolValue;
+
+        /// <summary>
+        /// Converts and initializes a WindowsRegistryKeyBoolean from a base WindowsRegistryKey, with an optional default value.
+        /// </summary>
+        /// <param name="baseKey">The base WindowsRegistryKey to convert from.</param>
+        /// <param name="defaultValue">Optional default value to set for the WindowsRegistryKeyBoolean.</param>
+        public void ConvertFromWindowsRegistryKey(WindowsRegistryKey baseKey, bool? defaultValue = null)
+        {
+            SetDefaultValue(defaultValue);
+            FromBaseKey(baseKey);
+        }
+
+        private void FromBaseKey(WindowsRegistryKey baseKey)
+        {
+            if (baseKey == null)
+                throw new ArgumentNullException(nameof(baseKey));
+
+            Hive = baseKey.Hive;
+            Path = baseKey.Path;
+            Name = baseKey.Name;
+            ValueKind = baseKey.ValueKind;
+            IsKeyPresent = baseKey.IsKeyPresent;
+
+            ConvertToBool(baseKey.Value);
+        }
+
+        private void SetDefaultValue(bool? defaultValue)
+        {
+            if (defaultValue.HasValue)
+                DefaultValue = (bool)defaultValue;
+        }
+
+        private void ConvertToBool(string newValue)
+        {
+            if (IsKeyPresent && bool.TryParse(newValue, out bool boolValue))
+                BoolValue = boolValue;
+            else if (IsKeyPresent && int.TryParse(newValue, out int intValue))
+                BoolValue = intValue == 1;
+            else
+                BoolValue = DefaultValue;
+        }
+    }
+}

--- a/mRemoteNG/Tools/WindowsRegistry/WindowsRegistryKeyInteger.cs
+++ b/mRemoteNG/Tools/WindowsRegistry/WindowsRegistryKeyInteger.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Runtime.Versioning;
+
+namespace mRemoteNG.Tools.WindowsRegistry
+{
+    /// <summary>
+    /// Represents a integer Windows Registry key, extending the base class WindowsRegistryKey.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public class WindowsRegistryKeyInteger : WindowsRegistryKey
+    {
+        /// <summary>
+        /// Gets or sets the default integer value for a Windows Registry key.
+        /// </summary>
+        /// <remarks>
+        /// The default value is initially set to `-1`.
+        /// </remarks>
+        public int DefaultValue { get; private set; } = -1;
+
+
+        /// <summary>
+        /// Gets or sets the integer value for a Windows Registry key.
+        /// </summary>
+        public new int Value
+        {
+            get => IntegerValue;
+            private set
+            {
+                IntegerValue = value;
+                UpdateIsProvidedState();
+            }
+        }
+        private int IntegerValue;
+
+        /// <summary>
+        /// Converts and initializes a WindowsRegistryKeyInteger from a base WindowsRegistryKey, with an optional default value.
+        /// </summary>
+        /// <param name="baseKey">The base WindowsRegistryKey to convert from.</param>
+        /// <param name="defaultValue">Optional default value to set for the WindowsRegistryKeyBoolean.</param>
+        public void ConvertFromWindowsRegistryKey(WindowsRegistryKey baseKey, int? defaultValue = null)
+        {
+            SetDefaultValue(defaultValue);
+            FromBaseKey(baseKey);
+        }
+
+        private void FromBaseKey(WindowsRegistryKey baseKey)
+        {
+            if (baseKey == null)
+                throw new ArgumentNullException(nameof(baseKey));
+
+            Hive = baseKey.Hive;
+            Path = baseKey.Path;
+            Name = baseKey.Name;
+            ValueKind = baseKey.ValueKind;
+            IsKeyPresent = baseKey.IsKeyPresent;
+
+            ConvertToInteger(baseKey.Value);
+        }
+
+        private void SetDefaultValue (int? defaultValue)
+        {
+            if (defaultValue.HasValue)
+                DefaultValue = (int)defaultValue;
+        }
+
+        private void ConvertToInteger(string newValue)
+        {
+            if (ValueKind != RegistryValueKind.DWord)
+                IsKeyPresent = false;
+
+            if (IsKeyPresent && int.TryParse(newValue.ToString(), out int intValue))
+                IntegerValue = intValue;
+            else
+                IntegerValue = DefaultValue;
+        }
+    }
+}

--- a/mRemoteNG/Tools/WindowsRegistry/WindowsRegistryKeyString.cs
+++ b/mRemoteNG/Tools/WindowsRegistry/WindowsRegistryKeyString.cs
@@ -1,0 +1,121 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Linq;
+using System.Runtime.Versioning;
+
+namespace mRemoteNG.Tools.WindowsRegistry
+{
+    /// <summary>
+    /// Represents a string Windows Registry key, extending the base class WindowsRegistryKey, can be evaluated with a value set.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public class WindowsRegistryKeyString : WindowsRegistryKey
+    {
+        /// <summary>
+        /// Gets or sets the default integer value for a Windows Registry key.
+        /// </summary>
+        public string DefaultValue { get; private set; }
+
+        /// <summary>
+        /// Gets or sets an array of allowed values for validation.
+        /// </summary>
+        public string[] AllowedValues { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean flag indicating whether validation is case-sensitive.
+        /// </summary>
+        public bool IsCaseSensitiveValidation { get; set; } = false;
+
+        /// <summary>
+        /// Gets a boolean indicating whether the value is valid based on the validation rules.
+        /// </summary>
+        public bool IsValid { get; private set; } = false;
+
+
+        public new string Value
+        {
+            get => StringValue;
+            private set
+            {
+                StringValue = value;
+                UpdateIsProvidedState();
+                Validate();
+            }
+        }
+        private string StringValue;
+
+        /// <summary>
+        /// Converts and initializes a WindowsRegistryKeyString from a base WindowsRegistryKey, with an optional default value.
+        /// </summary>
+        /// <param name="baseKey">The base WindowsRegistryKey to convert from.</param>
+        /// <param name="defaultValue">Optional default value to set for the WindowsRegistryKeyBoolean.</param>
+        public void ConvertFromWindowsRegistryKey(WindowsRegistryKey baseKey, string defaultValue = null)
+        {
+            SetDefaultValue(defaultValue);
+            FromBaseKey(baseKey);
+            Validate();
+        }
+
+        private void FromBaseKey(WindowsRegistryKey baseKey)
+        {
+            if (baseKey == null)
+                throw new ArgumentNullException(nameof(baseKey));
+
+            Hive = baseKey.Hive;
+            Path = baseKey.Path;
+            Name = baseKey.Name;
+            ValueKind = baseKey.ValueKind;
+            IsKeyPresent = baseKey.IsKeyPresent;
+
+            ConvertToString(baseKey.Value);
+        }
+
+        private void SetDefaultValue (string defaultValue)
+        {
+            DefaultValue = defaultValue;
+        }
+        private void ConvertToString(string newValue)
+        {
+            if (IsKeyPresent && newValue != null)
+                StringValue = newValue;
+            else
+                StringValue = DefaultValue;
+        }
+
+        /// <summary>
+        /// Validates a Windows Registry key value against a set of allowed values, considering case sensitivity.
+        /// </summary>
+        /// <param name="allowedValues">Array of allowed values.</param>
+        /// <param name="caseSensitive">Optional parameter to specify case sensitivity in validation.</param>
+        public void Validate(string[] allowedValues = null, bool? caseSensitive = null)
+        {
+            // Key must be present to evaluate
+            if (!IsKeyPresent)
+                return;
+
+            if (caseSensitive.HasValue)
+                IsCaseSensitiveValidation = caseSensitive.Value;
+
+            if (allowedValues != null && allowedValues.Length >= 1)
+                AllowedValues = allowedValues;
+
+            // AllowedValues array cannot be null or empty.
+            if (AllowedValues == null || AllowedValues.Length == 0 || !IsKeyPresent)
+                return;
+
+            if (IsKeyPresent && AllowedValues.Any(v =>
+               IsCaseSensitiveValidation ? v == Value : v.Equals(Value, StringComparison.OrdinalIgnoreCase)))
+            {
+                // Set to true when the value is found in the valid values
+                IsValid = true; 
+            }
+            else
+            {
+                // Set to false when the value is not found in the valid values
+                IsValid = false;
+                StringValue = DefaultValue;
+            }
+        }
+
+    }
+}

--- a/mRemoteNG/UI/Forms/FrmExport.Designer.cs
+++ b/mRemoteNG/UI/Forms/FrmExport.Designer.cs
@@ -1,5 +1,6 @@
 ﻿
 using System.Windows.Forms;
+using mRemoteNG.Config.Settings.Registry;
 using mRemoteNG.UI.Controls;
 
 namespace mRemoteNG.UI.Forms
@@ -72,27 +73,33 @@ namespace mRemoteNG.UI.Forms
             // 
             this.chkUsername._mice = MrngCheckBox.MouseState.HOVER;
             this.chkUsername.AutoSize = true;
-            this.chkUsername.Checked = true;
-            this.chkUsername.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkUsername.Checked = CommonRegistrySettings.AllowExportUsernames;
+            this.chkUsername.CheckState = CommonRegistrySettings.AllowExportUsernames ?
+                              System.Windows.Forms.CheckState.Checked :
+                              System.Windows.Forms.CheckState.Unchecked;
             this.chkUsername.Location = new System.Drawing.Point(15, 32);
             this.chkUsername.Name = "chkUsername";
             this.chkUsername.Size = new System.Drawing.Size(77, 17);
             this.chkUsername.TabIndex = 0;
             this.chkUsername.Text = "Username";
             this.chkUsername.UseVisualStyleBackColor = true;
+            this.chkUsername.Enabled = CommonRegistrySettings.AllowExportUsernames;
             // 
             // chkPassword
             // 
             this.chkPassword._mice = MrngCheckBox.MouseState.HOVER;
             this.chkPassword.AutoSize = true;
-            this.chkPassword.Checked = true;
-            this.chkPassword.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkPassword.Checked = CommonRegistrySettings.AllowExportPasswords;
+            this.chkPassword.CheckState = CommonRegistrySettings.AllowExportPasswords ?
+                              System.Windows.Forms.CheckState.Checked :
+                              System.Windows.Forms.CheckState.Unchecked;
             this.chkPassword.Location = new System.Drawing.Point(15, 55);
             this.chkPassword.Name = "chkPassword";
             this.chkPassword.Size = new System.Drawing.Size(75, 17);
             this.chkPassword.TabIndex = 1;
             this.chkPassword.Text = "Password";
             this.chkPassword.UseVisualStyleBackColor = true;
+            this.chkPassword.Enabled = CommonRegistrySettings.AllowExportPasswords;
             // 
             // chkDomain
             // 

--- a/mRemoteNG/UI/Forms/OptionsPages/CredentialsPage.Designer.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/CredentialsPage.Designer.cs
@@ -29,6 +29,9 @@
         private void InitializeComponent()
         {
             pnlDefaultCredentials = new System.Windows.Forms.Panel();
+            pnlCredentialsSettingsPanel = new System.Windows.Forms.Panel();
+            lblDefaultCredentials = new Controls.MrngLabel();
+            radCredentialsWindows = new Controls.MrngRadioButton();
             tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             txtCredentialsUserViaAPI = new Controls.MrngTextBox();
             txtCredentialsUsername = new Controls.MrngTextBox();
@@ -38,25 +41,60 @@
             lblCredentialsUsername = new Controls.MrngLabel();
             lblCredentialsPassword = new Controls.MrngLabel();
             lblCredentialsDomain = new Controls.MrngLabel();
-            radCredentialsCustom = new Controls.MrngRadioButton();
-            lblDefaultCredentials = new Controls.MrngLabel();
             radCredentialsNoInfo = new Controls.MrngRadioButton();
-            radCredentialsWindows = new Controls.MrngRadioButton();
+            radCredentialsCustom = new Controls.MrngRadioButton();
+            lblCredentialsAdminInfo = new System.Windows.Forms.Label();
+            lblCredentialsGeneratorHelp = new Controls.MrngLabel();
+            btnCredentialsGenerator = new System.Windows.Forms.Button();
+            lblCredentialsGenerator = new Controls.MrngLabel();
+            txtCredentialsGeneratorPsswd = new System.Windows.Forms.TextBox();
             pnlDefaultCredentials.SuspendLayout();
+            pnlCredentialsSettingsPanel.SuspendLayout();
             tableLayoutPanel1.SuspendLayout();
             SuspendLayout();
             // 
             // pnlDefaultCredentials
             // 
-            pnlDefaultCredentials.Controls.Add(tableLayoutPanel1);
-            pnlDefaultCredentials.Controls.Add(radCredentialsCustom);
-            pnlDefaultCredentials.Controls.Add(lblDefaultCredentials);
-            pnlDefaultCredentials.Controls.Add(radCredentialsNoInfo);
-            pnlDefaultCredentials.Controls.Add(radCredentialsWindows);
-            pnlDefaultCredentials.Location = new System.Drawing.Point(3, 3);
+            pnlDefaultCredentials.Controls.Add(pnlCredentialsSettingsPanel);
+            pnlDefaultCredentials.Controls.Add(lblCredentialsAdminInfo);
+            pnlDefaultCredentials.Dock = System.Windows.Forms.DockStyle.Top;
+            pnlDefaultCredentials.Location = new System.Drawing.Point(0, 0);
             pnlDefaultCredentials.Name = "pnlDefaultCredentials";
-            pnlDefaultCredentials.Size = new System.Drawing.Size(604, 200);
+            pnlDefaultCredentials.Size = new System.Drawing.Size(610, 416);
             pnlDefaultCredentials.TabIndex = 0;
+            // 
+            // pnlCredentialsSettingsPanel
+            // 
+            pnlCredentialsSettingsPanel.Controls.Add(lblDefaultCredentials);
+            pnlCredentialsSettingsPanel.Controls.Add(radCredentialsWindows);
+            pnlCredentialsSettingsPanel.Controls.Add(tableLayoutPanel1);
+            pnlCredentialsSettingsPanel.Controls.Add(radCredentialsNoInfo);
+            pnlCredentialsSettingsPanel.Controls.Add(radCredentialsCustom);
+            pnlCredentialsSettingsPanel.Dock = System.Windows.Forms.DockStyle.Top;
+            pnlCredentialsSettingsPanel.Location = new System.Drawing.Point(0, 30);
+            pnlCredentialsSettingsPanel.Name = "pnlCredentialsSettingsPanel";
+            pnlCredentialsSettingsPanel.Size = new System.Drawing.Size(610, 214);
+            pnlCredentialsSettingsPanel.TabIndex = 0;
+            // 
+            // lblDefaultCredentials
+            // 
+            lblDefaultCredentials.AutoSize = true;
+            lblDefaultCredentials.Location = new System.Drawing.Point(3, 0);
+            lblDefaultCredentials.Name = "lblDefaultCredentials";
+            lblDefaultCredentials.Size = new System.Drawing.Size(279, 13);
+            lblDefaultCredentials.TabIndex = 0;
+            lblDefaultCredentials.Text = "For empty Username, Password or Domain fields use:";
+            // 
+            // radCredentialsWindows
+            // 
+            radCredentialsWindows.AutoSize = true;
+            radCredentialsWindows.BackColor = System.Drawing.Color.Transparent;
+            radCredentialsWindows.Location = new System.Drawing.Point(6, 39);
+            radCredentialsWindows.Name = "radCredentialsWindows";
+            radCredentialsWindows.Size = new System.Drawing.Size(252, 17);
+            radCredentialsWindows.TabIndex = 2;
+            radCredentialsWindows.Text = "my current credentials (windows logon info)";
+            radCredentialsWindows.UseVisualStyleBackColor = false;
             // 
             // tableLayoutPanel1
             // 
@@ -71,7 +109,7 @@
             tableLayoutPanel1.Controls.Add(lblCredentialsUsername, 0, 1);
             tableLayoutPanel1.Controls.Add(lblCredentialsPassword, 0, 2);
             tableLayoutPanel1.Controls.Add(lblCredentialsDomain, 0, 3);
-            tableLayoutPanel1.Location = new System.Drawing.Point(23, 85);
+            tableLayoutPanel1.Location = new System.Drawing.Point(26, 85);
             tableLayoutPanel1.Name = "tableLayoutPanel1";
             tableLayoutPanel1.RowCount = 3;
             tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 26F));
@@ -113,7 +151,6 @@
             txtCredentialsPassword.Name = "txtCredentialsPassword";
             txtCredentialsPassword.Size = new System.Drawing.Size(166, 22);
             txtCredentialsPassword.TabIndex = 7;
-            txtCredentialsPassword.UseSystemPasswordChar = true;
             // 
             // txtCredentialsDomain
             // 
@@ -170,33 +207,12 @@
             lblCredentialsDomain.Text = "Domain:";
             lblCredentialsDomain.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
-            // radCredentialsCustom
-            // 
-            radCredentialsCustom.AutoSize = true;
-            radCredentialsCustom.BackColor = System.Drawing.Color.Transparent;
-            radCredentialsCustom.Location = new System.Drawing.Point(3, 62);
-            radCredentialsCustom.Name = "radCredentialsCustom";
-            radCredentialsCustom.Size = new System.Drawing.Size(98, 17);
-            radCredentialsCustom.TabIndex = 3;
-            radCredentialsCustom.Text = "the following:";
-            radCredentialsCustom.UseVisualStyleBackColor = false;
-            radCredentialsCustom.CheckedChanged += radCredentialsCustom_CheckedChanged;
-            // 
-            // lblDefaultCredentials
-            // 
-            lblDefaultCredentials.AutoSize = true;
-            lblDefaultCredentials.Location = new System.Drawing.Point(0, 0);
-            lblDefaultCredentials.Name = "lblDefaultCredentials";
-            lblDefaultCredentials.Size = new System.Drawing.Size(279, 13);
-            lblDefaultCredentials.TabIndex = 0;
-            lblDefaultCredentials.Text = "For empty Username, Password or Domain fields use:";
-            // 
             // radCredentialsNoInfo
             // 
             radCredentialsNoInfo.AutoSize = true;
             radCredentialsNoInfo.BackColor = System.Drawing.Color.Transparent;
             radCredentialsNoInfo.Checked = true;
-            radCredentialsNoInfo.Location = new System.Drawing.Point(3, 16);
+            radCredentialsNoInfo.Location = new System.Drawing.Point(6, 16);
             radCredentialsNoInfo.Name = "radCredentialsNoInfo";
             radCredentialsNoInfo.Size = new System.Drawing.Size(103, 17);
             radCredentialsNoInfo.TabIndex = 1;
@@ -204,16 +220,58 @@
             radCredentialsNoInfo.Text = "no information";
             radCredentialsNoInfo.UseVisualStyleBackColor = false;
             // 
-            // radCredentialsWindows
+            // radCredentialsCustom
             // 
-            radCredentialsWindows.AutoSize = true;
-            radCredentialsWindows.BackColor = System.Drawing.Color.Transparent;
-            radCredentialsWindows.Location = new System.Drawing.Point(3, 39);
-            radCredentialsWindows.Name = "radCredentialsWindows";
-            radCredentialsWindows.Size = new System.Drawing.Size(252, 17);
-            radCredentialsWindows.TabIndex = 2;
-            radCredentialsWindows.Text = "my current credentials (windows logon info)";
-            radCredentialsWindows.UseVisualStyleBackColor = false;
+            radCredentialsCustom.AutoSize = true;
+            radCredentialsCustom.BackColor = System.Drawing.Color.Transparent;
+            radCredentialsCustom.Location = new System.Drawing.Point(6, 62);
+            radCredentialsCustom.Name = "radCredentialsCustom";
+            radCredentialsCustom.Size = new System.Drawing.Size(98, 17);
+            radCredentialsCustom.TabIndex = 3;
+            radCredentialsCustom.Text = "the following:";
+            radCredentialsCustom.UseVisualStyleBackColor = false;
+            radCredentialsCustom.CheckedChanged += radCredentialsCustom_CheckedChanged;
+            // 
+            // lblCredentialsAdminInfo
+            // 
+            lblCredentialsAdminInfo.BackColor = System.Drawing.SystemColors.ControlLight;
+            lblCredentialsAdminInfo.Dock = System.Windows.Forms.DockStyle.Top;
+            lblCredentialsAdminInfo.ForeColor = System.Drawing.SystemColors.ControlText;
+            lblCredentialsAdminInfo.Location = new System.Drawing.Point(0, 0);
+            lblCredentialsAdminInfo.Name = "lblCredentialsAdminInfo";
+            lblCredentialsAdminInfo.Padding = new System.Windows.Forms.Padding(0, 2, 0, 0);
+            lblCredentialsAdminInfo.Size = new System.Drawing.Size(610, 30);
+            lblCredentialsAdminInfo.TabIndex = 0;
+            lblCredentialsAdminInfo.Text = "Some settings are configured by your Administrator. Please contact your administrator for more information.";
+            lblCredentialsAdminInfo.Visible = false;
+            // 
+            // lblCredentialsGeneratorHelp
+            // 
+            lblCredentialsGeneratorHelp.Location = new System.Drawing.Point(0, 0);
+            lblCredentialsGeneratorHelp.Name = "lblCredentialsGeneratorHelp";
+            lblCredentialsGeneratorHelp.Size = new System.Drawing.Size(100, 23);
+            lblCredentialsGeneratorHelp.TabIndex = 0;
+            // 
+            // btnCredentialsGenerator
+            // 
+            btnCredentialsGenerator.Location = new System.Drawing.Point(0, 0);
+            btnCredentialsGenerator.Name = "btnCredentialsGenerator";
+            btnCredentialsGenerator.Size = new System.Drawing.Size(75, 23);
+            btnCredentialsGenerator.TabIndex = 0;
+            // 
+            // lblCredentialsGenerator
+            // 
+            lblCredentialsGenerator.Location = new System.Drawing.Point(0, 0);
+            lblCredentialsGenerator.Name = "lblCredentialsGenerator";
+            lblCredentialsGenerator.Size = new System.Drawing.Size(100, 23);
+            lblCredentialsGenerator.TabIndex = 0;
+            // 
+            // txtCredentialsGeneratorPsswd
+            // 
+            txtCredentialsGeneratorPsswd.Location = new System.Drawing.Point(0, 0);
+            txtCredentialsGeneratorPsswd.Name = "txtCredentialsGeneratorPsswd";
+            txtCredentialsGeneratorPsswd.Size = new System.Drawing.Size(100, 23);
+            txtCredentialsGeneratorPsswd.TabIndex = 0;
             // 
             // CredentialsPage
             // 
@@ -224,7 +282,8 @@
             Name = "CredentialsPage";
             Size = new System.Drawing.Size(610, 490);
             pnlDefaultCredentials.ResumeLayout(false);
-            pnlDefaultCredentials.PerformLayout();
+            pnlCredentialsSettingsPanel.ResumeLayout(false);
+            pnlCredentialsSettingsPanel.PerformLayout();
             tableLayoutPanel1.ResumeLayout(false);
             tableLayoutPanel1.PerformLayout();
             ResumeLayout(false);
@@ -245,5 +304,11 @@
         internal Controls.MrngTextBox txtCredentialsUsername;
         internal Controls.MrngLabel lblCredentialsDomain;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        internal System.Windows.Forms.Label lblCredentialsAdminInfo;
+        internal System.Windows.Forms.Panel pnlCredentialsSettingsPanel;
+        internal Controls.MrngLabel lblCredentialsGenerator;
+        internal System.Windows.Forms.TextBox txtCredentialsGeneratorPsswd;
+        internal System.Windows.Forms.Button btnCredentialsGenerator;
+        internal Controls.MrngLabel lblCredentialsGeneratorHelp;
     }
 }

--- a/mRemoteNG/UI/Forms/OptionsPages/CredentialsPage.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/CredentialsPage.cs
@@ -4,12 +4,19 @@ using mRemoteNG.Properties;
 using mRemoteNG.Security.SymmetricEncryption;
 using mRemoteNG.Resources.Language;
 using System.Runtime.Versioning;
+using mRemoteNG.Config.Settings.Registry;
 
 namespace mRemoteNG.UI.Forms.OptionsPages
 {
     [SupportedOSPlatform("windows")]
     public sealed partial class CredentialsPage : OptionsPage
     {
+        #region Private Fields
+        private readonly OptRegistryCredentialsPage _RegistrySettings = new();
+        private bool _pageEnabled = true;
+
+        #endregion
+
         public CredentialsPage()
         {
             InitializeComponent();
@@ -33,10 +40,13 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             lblCredentialsUsername.Text = Language.Username;
             lblCredentialsPassword.Text = Language.Password;
             lblCredentialsDomain.Text = Language.Domain;
+            lblCredentialsAdminInfo.Text = Language.OptionsAdminInfo;
         }
 
         public override void LoadSettings()
         {
+            if (!_pageEnabled) { return; }
+
             // ReSharper disable once SwitchStatementMissingSomeCases
             switch (Properties.OptionsCredentialsPage.Default.EmptyCredentials)
             {
@@ -80,16 +90,134 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             Properties.OptionsCredentialsPage.Default.UserViaAPIDefault = txtCredentialsUserViaAPI.Text;
         }
 
+        public override void LoadRegistrySettings()
+        {
+            if (!CommonRegistrySettings.AllowModifyCredentialSettings)
+            {
+                DisablePage();
+                return;
+            }
+
+            if (_RegistrySettings.UseCredentials.IsKeyPresent)
+            {
+                Properties.OptionsCredentialsPage.Default.EmptyCredentials = _RegistrySettings.UseCredentials.Value;
+
+                switch (Properties.OptionsCredentialsPage.Default.EmptyCredentials)
+                {
+                    case "noinfo":
+                        DisableControl(radCredentialsWindows);
+                        DisableControl(radCredentialsCustom);
+                        break;
+                    case "windows":
+                        DisableControl(radCredentialsNoInfo);
+                        DisableControl(radCredentialsCustom);
+                        break;
+                    case "custom":
+                        DisableControl(radCredentialsNoInfo);
+                        DisableControl(radCredentialsWindows);
+                        break;
+                }
+            }
+
+            if (_RegistrySettings.UseCredentials.Value != "custom") { return; }
+
+
+            if (!CommonRegistrySettings.AllowSaveUsernames)
+            {
+                Properties.OptionsCredentialsPage.Default.DefaultUsername = "";
+                DisableControl(txtCredentialsUsername);
+            }
+            else if (_RegistrySettings.DefaultUsername.IsKeyPresent)
+            {
+                Properties.OptionsCredentialsPage.Default.DefaultUsername = _RegistrySettings.DefaultUsername.Value;
+                DisableControl(txtCredentialsUsername);
+            }
+
+            if (!CommonRegistrySettings.AllowSavePasswords)
+            {
+                Properties.OptionsCredentialsPage.Default.DefaultPassword = "";
+                DisableControl(txtCredentialsPassword);
+            }
+            //else if (_RegistrySettings.DefaultPassword.IsKeyPresent)
+            //{
+            //    Properties.OptionsCredentialsPage.Default.DefaultPassword = _RegistrySettings.DefaultPassword.Value;
+            //    DisableControl(txtCredentialsPassword);
+            //}
+
+            if (_RegistrySettings.DefaultDomain.IsKeyPresent)
+            {
+                Properties.OptionsCredentialsPage.Default.DefaultDomain = _RegistrySettings.DefaultDomain.Value;
+                DisableControl(txtCredentialsDomain);
+            }
+
+            if (!CommonRegistrySettings.AllowSaveUsernames)
+            {
+                Properties.OptionsCredentialsPage.Default.UserViaAPIDefault = "";
+                DisableControl(txtCredentialsUserViaAPI);
+            }
+            else if (_RegistrySettings.UserViaAPIDefault.IsKeyPresent)
+            {
+                Properties.OptionsCredentialsPage.Default.UserViaAPIDefault = _RegistrySettings.UserViaAPIDefault.Value;
+                DisableControl(txtCredentialsUserViaAPI);
+            }
+
+            lblCredentialsAdminInfo.Visible = ShowAdministratorInfo();
+        }
+
+        public override bool ShowAdministratorInfo()
+        {
+            return !CommonRegistrySettings.AllowModifyCredentialSettings
+                || !CommonRegistrySettings.AllowExportPasswords
+                || !CommonRegistrySettings.AllowExportUsernames
+                || !CommonRegistrySettings.AllowSavePasswords
+                || !CommonRegistrySettings.AllowSaveUsernames
+                || _RegistrySettings.DefaultUsername.IsKeyPresent
+                //|| _RegistrySettings.DefaultPassword.IsKeyPresent
+                || _RegistrySettings.DefaultDomain.IsKeyPresent
+                || _RegistrySettings.UserViaAPIDefault.IsKeyPresent;
+        }
+
         private void radCredentialsCustom_CheckedChanged(object sender, EventArgs e)
         {
-            lblCredentialsUsername.Enabled = radCredentialsCustom.Checked;
-            lblCredentialsPassword.Enabled = radCredentialsCustom.Checked;
-            lblCredentialsDomain.Enabled = radCredentialsCustom.Checked;
-            txtCredentialsUsername.Enabled = radCredentialsCustom.Checked;
-            txtCredentialsPassword.Enabled = radCredentialsCustom.Checked;
-            txtCredentialsDomain.Enabled = radCredentialsCustom.Checked;
-            txtCredentialsUserViaAPI.Enabled = radCredentialsCustom.Checked;
-            lblCredentialsUserViaAPI.Enabled = radCredentialsCustom.Checked;
+            if (!_RegistrySettings.DefaultUsername.IsKeyPresent && CommonRegistrySettings.AllowSaveUsernames)
+            {
+                lblCredentialsUsername.Enabled = radCredentialsCustom.Checked;
+                txtCredentialsUsername.Enabled = radCredentialsCustom.Checked;
+            }
+
+            if (/*!_RegistrySettings.DefaultPassword.IsKeyPresent &&*/ CommonRegistrySettings.AllowSavePasswords)
+            {
+                lblCredentialsPassword.Enabled = radCredentialsCustom.Checked;
+                txtCredentialsPassword.Enabled = radCredentialsCustom.Checked;
+            }
+
+            if (!_RegistrySettings.DefaultDomain.IsKeyPresent)
+            {
+                lblCredentialsDomain.Enabled = radCredentialsCustom.Checked;
+                txtCredentialsDomain.Enabled = radCredentialsCustom.Checked;
+            }
+
+            if (!_RegistrySettings.UserViaAPIDefault.IsKeyPresent)
+            {
+                lblCredentialsUserViaAPI.Enabled = radCredentialsCustom.Checked;
+                txtCredentialsUserViaAPI.Enabled = radCredentialsCustom.Checked;
+            }
+        }
+
+        public override void DisablePage()
+        {
+            Properties.OptionsCredentialsPage.Default.EmptyCredentials = "noinfo";
+            //radCredentialsNoInfo.Enabled = false;
+            radCredentialsWindows.Enabled = false;
+            radCredentialsCustom.Enabled = false;
+
+            txtCredentialsUsername.Enabled = false;
+            txtCredentialsPassword.Enabled = false;
+            txtCredentialsDomain.Enabled = false;
+            txtCredentialsUserViaAPI.Enabled = false;
+
+            lblCredentialsAdminInfo.Visible = true;
+            _pageEnabled = false;
         }
     }
 }

--- a/mRemoteNG/UI/Forms/OptionsPages/OptionsPage.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/OptionsPage.cs
@@ -42,6 +42,16 @@ namespace mRemoteNG.UI.Forms.OptionsPages
         public virtual void RevertSettings()
         {
         }
+        public virtual void LoadRegistrySettings()
+        {
+        }
+        public virtual bool ShowAdministratorInfo()
+        {
+            return false;
+        }
+        public virtual void DisablePage()
+        {
+        }
 
         #endregion
 
@@ -65,6 +75,27 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             Name = "OptionsPage";
             ResumeLayout(false);
         }
+
+        /// <summary>
+        /// Disables the specified control by setting its Enabled property to false.
+        /// For TextBox controls, additionally sets the ReadOnly property based on the Enabled state.
+        /// Does nothing if the control is null.
+        /// </summary>
+        /// <param name="control">The control to be disabled.</param>
+        protected static void DisableControl(Control control)
+        {
+            if (control == null) return;
+
+            control.Enabled = false;
+
+            if (control is TextBox)
+            {
+                // If it's a TextBox, set the ReadOnly property
+                ((TextBox)control).ReadOnly = control.Enabled;
+            }
+        }
+
+
     }
 	internal class DropdownList
     {

--- a/mRemoteNG/UI/Forms/OptionsPages/UpdatesPage.Designer.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/UpdatesPage.Designer.cs
@@ -35,9 +35,9 @@ namespace mRemoteNG.UI.Forms.OptionsPages
         {
             lblUpdatesExplanation = new MrngLabel();
             pnlUpdateCheck = new System.Windows.Forms.Panel();
+            cboUpdateCheckFrequency = new MrngComboBox();
             btnUpdateCheckNow = new MrngButton();
             chkCheckForUpdatesOnStartup = new MrngCheckBox();
-            cboUpdateCheckFrequency = new MrngComboBox();
             lblReleaseChannelExplanation = new MrngTextBox();
             cboReleaseChannel = new MrngComboBox();
             pnlProxy = new System.Windows.Forms.Panel();
@@ -55,36 +55,53 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             chkUseProxyAuthentication = new MrngCheckBox();
             btnTestProxy = new MrngButton();
             groupBoxReleaseChannel = new MrngGroupBox();
+            pnlDefaultUpdate = new System.Windows.Forms.Panel();
+            lblUpdateAdminInfo = new System.Windows.Forms.Label();
             pnlUpdateCheck.SuspendLayout();
             pnlProxy.SuspendLayout();
             tblProxyBasic.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)numProxyPort).BeginInit();
             tblProxyAuthentication.SuspendLayout();
             groupBoxReleaseChannel.SuspendLayout();
+            pnlDefaultUpdate.SuspendLayout();
             SuspendLayout();
             // 
             // lblUpdatesExplanation
             // 
-            lblUpdatesExplanation.Location = new System.Drawing.Point(3, 3);
+            lblUpdatesExplanation.Dock = System.Windows.Forms.DockStyle.Top;
+            lblUpdatesExplanation.Location = new System.Drawing.Point(0, 0);
             lblUpdatesExplanation.Name = "lblUpdatesExplanation";
-            lblUpdatesExplanation.Size = new System.Drawing.Size(595, 32);
+            lblUpdatesExplanation.Padding = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            lblUpdatesExplanation.Size = new System.Drawing.Size(610, 38);
             lblUpdatesExplanation.TabIndex = 0;
             lblUpdatesExplanation.Text = "mRemoteNG can periodically connect to the mRemoteNG website to check for updates.";
             // 
             // pnlUpdateCheck
             // 
+            pnlUpdateCheck.Controls.Add(cboUpdateCheckFrequency);
             pnlUpdateCheck.Controls.Add(btnUpdateCheckNow);
             pnlUpdateCheck.Controls.Add(chkCheckForUpdatesOnStartup);
-            pnlUpdateCheck.Controls.Add(cboUpdateCheckFrequency);
-            pnlUpdateCheck.Location = new System.Drawing.Point(3, 25);
+            pnlUpdateCheck.Controls.Add(lblUpdatesExplanation);
+            pnlUpdateCheck.Dock = System.Windows.Forms.DockStyle.Top;
+            pnlUpdateCheck.Location = new System.Drawing.Point(0, 30);
             pnlUpdateCheck.Name = "pnlUpdateCheck";
-            pnlUpdateCheck.Size = new System.Drawing.Size(604, 99);
-            pnlUpdateCheck.TabIndex = 1;
+            pnlUpdateCheck.Size = new System.Drawing.Size(610, 114);
+            pnlUpdateCheck.TabIndex = 0;
+            // 
+            // cboUpdateCheckFrequency
+            // 
+            cboUpdateCheckFrequency._mice = MrngComboBox.MouseState.HOVER;
+            cboUpdateCheckFrequency.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            cboUpdateCheckFrequency.FormattingEnabled = true;
+            cboUpdateCheckFrequency.Location = new System.Drawing.Point(27, 44);
+            cboUpdateCheckFrequency.Name = "cboUpdateCheckFrequency";
+            cboUpdateCheckFrequency.Size = new System.Drawing.Size(120, 21);
+            cboUpdateCheckFrequency.TabIndex = 1;
             // 
             // btnUpdateCheckNow
             // 
             btnUpdateCheckNow._mice = MrngButton.MouseState.OUT;
-            btnUpdateCheckNow.Location = new System.Drawing.Point(5, 63);
+            btnUpdateCheckNow.Location = new System.Drawing.Point(5, 79);
             btnUpdateCheckNow.Name = "btnUpdateCheckNow";
             btnUpdateCheckNow.Size = new System.Drawing.Size(122, 25);
             btnUpdateCheckNow.TabIndex = 2;
@@ -97,23 +114,13 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             chkCheckForUpdatesOnStartup._mice = MrngCheckBox.MouseState.OUT;
             chkCheckForUpdatesOnStartup.AutoSize = true;
             chkCheckForUpdatesOnStartup.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            chkCheckForUpdatesOnStartup.Location = new System.Drawing.Point(6, 11);
+            chkCheckForUpdatesOnStartup.Location = new System.Drawing.Point(9, 21);
             chkCheckForUpdatesOnStartup.Name = "chkCheckForUpdatesOnStartup";
             chkCheckForUpdatesOnStartup.Size = new System.Drawing.Size(120, 17);
             chkCheckForUpdatesOnStartup.TabIndex = 0;
             chkCheckForUpdatesOnStartup.Text = "Check for updates";
             chkCheckForUpdatesOnStartup.UseVisualStyleBackColor = true;
             chkCheckForUpdatesOnStartup.CheckedChanged += chkCheckForUpdatesOnStartup_CheckedChanged;
-            // 
-            // cboUpdateCheckFrequency
-            // 
-            cboUpdateCheckFrequency._mice = MrngComboBox.MouseState.HOVER;
-            cboUpdateCheckFrequency.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            cboUpdateCheckFrequency.FormattingEnabled = true;
-            cboUpdateCheckFrequency.Location = new System.Drawing.Point(6, 34);
-            cboUpdateCheckFrequency.Name = "cboUpdateCheckFrequency";
-            cboUpdateCheckFrequency.Size = new System.Drawing.Size(120, 21);
-            cboUpdateCheckFrequency.TabIndex = 1;
             // 
             // lblReleaseChannelExplanation
             // 
@@ -145,9 +152,10 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             pnlProxy.Controls.Add(chkUseProxyForAutomaticUpdates);
             pnlProxy.Controls.Add(chkUseProxyAuthentication);
             pnlProxy.Controls.Add(btnTestProxy);
-            pnlProxy.Location = new System.Drawing.Point(3, 240);
+            pnlProxy.Dock = System.Windows.Forms.DockStyle.Top;
+            pnlProxy.Location = new System.Drawing.Point(0, 248);
             pnlProxy.Name = "pnlProxy";
-            pnlProxy.Size = new System.Drawing.Size(604, 223);
+            pnlProxy.Size = new System.Drawing.Size(610, 232);
             pnlProxy.TabIndex = 3;
             // 
             // tblProxyBasic
@@ -311,24 +319,47 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             // 
             groupBoxReleaseChannel.Controls.Add(lblReleaseChannelExplanation);
             groupBoxReleaseChannel.Controls.Add(cboReleaseChannel);
-            groupBoxReleaseChannel.Location = new System.Drawing.Point(3, 130);
+            groupBoxReleaseChannel.Dock = System.Windows.Forms.DockStyle.Top;
+            groupBoxReleaseChannel.Location = new System.Drawing.Point(0, 144);
             groupBoxReleaseChannel.Name = "groupBoxReleaseChannel";
-            groupBoxReleaseChannel.Size = new System.Drawing.Size(604, 104);
+            groupBoxReleaseChannel.Size = new System.Drawing.Size(610, 104);
             groupBoxReleaseChannel.TabIndex = 3;
             groupBoxReleaseChannel.TabStop = false;
             groupBoxReleaseChannel.Text = "Release Channel";
+            // 
+            // pnlDefaultUpdate
+            // 
+            pnlDefaultUpdate.Controls.Add(pnlProxy);
+            pnlDefaultUpdate.Controls.Add(groupBoxReleaseChannel);
+            pnlDefaultUpdate.Controls.Add(pnlUpdateCheck);
+            pnlDefaultUpdate.Controls.Add(lblUpdateAdminInfo);
+            pnlDefaultUpdate.Dock = System.Windows.Forms.DockStyle.Top;
+            pnlDefaultUpdate.Location = new System.Drawing.Point(0, 0);
+            pnlDefaultUpdate.Name = "pnlDefaultUpdate";
+            pnlDefaultUpdate.Size = new System.Drawing.Size(610, 483);
+            pnlDefaultUpdate.TabIndex = 4;
+            // 
+            // lblUpdateAdminInfo
+            // 
+            lblUpdateAdminInfo.BackColor = System.Drawing.SystemColors.ControlLight;
+            lblUpdateAdminInfo.Dock = System.Windows.Forms.DockStyle.Top;
+            lblUpdateAdminInfo.ForeColor = System.Drawing.SystemColors.ControlText;
+            lblUpdateAdminInfo.Location = new System.Drawing.Point(0, 0);
+            lblUpdateAdminInfo.Name = "lblUpdateAdminInfo";
+            lblUpdateAdminInfo.Padding = new System.Windows.Forms.Padding(0, 2, 0, 0);
+            lblUpdateAdminInfo.Size = new System.Drawing.Size(610, 30);
+            lblUpdateAdminInfo.TabIndex = 0;
+            lblUpdateAdminInfo.Text = "Some settings are configured by your Administrator. Please contact your administrator for more information.";
+            lblUpdateAdminInfo.Visible = false;
             // 
             // UpdatesPage
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            Controls.Add(groupBoxReleaseChannel);
-            Controls.Add(lblUpdatesExplanation);
-            Controls.Add(pnlUpdateCheck);
-            Controls.Add(pnlProxy);
+            Controls.Add(pnlDefaultUpdate);
             Margin = new System.Windows.Forms.Padding(4);
             Name = "UpdatesPage";
-            Size = new System.Drawing.Size(610, 490);
+            Size = new System.Drawing.Size(610, 496);
             pnlUpdateCheck.ResumeLayout(false);
             pnlUpdateCheck.PerformLayout();
             pnlProxy.ResumeLayout(false);
@@ -340,6 +371,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             tblProxyAuthentication.PerformLayout();
             groupBoxReleaseChannel.ResumeLayout(false);
             groupBoxReleaseChannel.PerformLayout();
+            pnlDefaultUpdate.ResumeLayout(false);
             ResumeLayout(false);
         }
 
@@ -347,7 +379,6 @@ namespace mRemoteNG.UI.Forms.OptionsPages
         internal System.Windows.Forms.Panel pnlUpdateCheck;
         internal MrngButton btnUpdateCheckNow;
         internal MrngCheckBox chkCheckForUpdatesOnStartup;
-        internal MrngComboBox cboUpdateCheckFrequency;
         internal System.Windows.Forms.Panel pnlProxy;
         internal Controls.MrngLabel lblProxyAddress;
         internal Controls.MrngTextBox txtProxyAddress;
@@ -365,5 +396,8 @@ namespace mRemoteNG.UI.Forms.OptionsPages
         private MrngGroupBox groupBoxReleaseChannel;
         private System.Windows.Forms.TableLayoutPanel tblProxyBasic;
         private System.Windows.Forms.TableLayoutPanel tblProxyAuthentication;
+        private System.Windows.Forms.Panel pnlDefaultUpdate;
+        internal System.Windows.Forms.Label lblUpdateAdminInfo;
+        internal MrngComboBox cboUpdateCheckFrequency;
     }
 }

--- a/mRemoteNG/UI/Forms/OptionsPages/UpdatesPage.resx
+++ b/mRemoteNG/UI/Forms/OptionsPages/UpdatesPage.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -57,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="lblUpdateAdminInfo.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
 </root>

--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -348,7 +348,7 @@ namespace mRemoteNG.UI.Forms
         {
             if (!CommonRegistrySettings.AllowCheckForUpdates) return;
             if (!CommonRegistrySettings.AllowCheckForUpdatesAutomatical) return;
-            if (CommonRegistrySettings.CheckForUpdatesAsked) return;
+            if (!CommonRegistrySettings.AllowPromptForUpdatesPreference) return;
 
             if (Properties.OptionsUpdatesPage.Default.CheckForUpdatesAsked) return;
             string[] commandButtons =

--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -33,6 +33,7 @@ using WeifenLuo.WinFormsUI.Docking;
 using mRemoteNG.UI.Controls;
 using mRemoteNG.Resources.Language;
 using System.Runtime.Versioning;
+using mRemoteNG.Config.Settings.Registry;
 #endregion
 
 // ReSharper disable MemberCanBePrivate.Global
@@ -345,6 +346,10 @@ namespace mRemoteNG.UI.Forms
 
         private void PromptForUpdatesPreference()
         {
+            if (!CommonRegistrySettings.AllowCheckForUpdates) return;
+            if (!CommonRegistrySettings.AllowCheckForUpdatesAutomatical) return;
+            if (CommonRegistrySettings.CheckForUpdatesAsked) return;
+
             if (Properties.OptionsUpdatesPage.Default.CheckForUpdatesAsked) return;
             string[] commandButtons =
             {
@@ -368,6 +373,9 @@ namespace mRemoteNG.UI.Forms
 
         private async Task CheckForUpdates()
         {
+            if (!CommonRegistrySettings.AllowCheckForUpdates) return;
+            if (!CommonRegistrySettings.AllowCheckForUpdatesAutomatical) return;
+
             if (!Properties.OptionsUpdatesPage.Default.CheckForUpdatesOnStartup) return;
 
             var nextUpdateCheck =

--- a/mRemoteNG/UI/Forms/frmOptions.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.cs
@@ -206,6 +206,7 @@ namespace mRemoteNG.UI.Forms
 
             if (page == null) return;
             page.ApplyLanguage();
+            page.LoadRegistrySettings();
             page.LoadSettings();
             _optionPages.Add(page);
             lstOptionPages.AddObject(page);

--- a/mRemoteNG/UI/Menu/msMain/HelpMenu.cs
+++ b/mRemoteNG/UI/Menu/msMain/HelpMenu.cs
@@ -6,6 +6,7 @@ using mRemoteNG.App.Info;
 using mRemoteNG.UI.Forms;
 using mRemoteNG.Resources.Language;
 using System.Runtime.Versioning;
+using mRemoteNG.Config.Settings.Registry;
 
 namespace mRemoteNG.UI.Menu
 {
@@ -78,6 +79,8 @@ namespace mRemoteNG.UI.Menu
             _mMenToolsUpdate.Size = new System.Drawing.Size(190, 22);
             _mMenToolsUpdate.Text = Language.CheckForUpdates;
             _mMenToolsUpdate.Click += mMenToolsUpdate_Click;
+            _mMenToolsUpdate.Enabled = CommonRegistrySettings.AllowCheckForUpdates
+                && CommonRegistrySettings.AllowCheckForUpdatesManual;
             // 
             // mMenInfoSep1
             // 

--- a/mRemoteNGDocumentation/index.rst
+++ b/mRemoteNGDocumentation/index.rst
@@ -11,6 +11,8 @@ Welcome to mRemoteNG's documentation!
    protocols.rst
    keyboard_shortcuts.rst
    sql_configuration.rst
+   registry_settings_information.rst
+   registry_settings_guide.rst
    command_line_switches.rst
    themes.rst
 

--- a/mRemoteNGDocumentation/registry/credential_settings.rst
+++ b/mRemoteNGDocumentation/registry/credential_settings.rst
@@ -1,0 +1,185 @@
+.. _credential_settings:
+
+*********************
+Credential Settings
+*********************
+.. versionadded:: v1.77.3
+
+.. warning::
+    Before proceeding with any changes to the Windows Registry, it is imperative that you carefully read and comprehend the 
+    **Modifying the Registry**, **Restricted Registry Settings** and **Disclaimer** 
+    on :doc:`Registry Settings Infromation </registry_settings_information>`.
+    
+
+Common settings
+===============
+These settings are defined for global configuration.
+
+
+AllowExportUsernames
+--------------------
+Determines whether exporting usernames is allowed.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Credentials
+- **Value Name:** AllowExportUsernames
+- **Value Type:** REG_SZ
+- **Values:**
+  
+  - **Enable (default):** true
+  - **Disable:** false
+
+
+AllowExportPasswords
+--------------------
+Determines whether exporting passwords is allowed.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Credentials
+- **Value Name:** AllowExportPasswords
+- **Value Type:** REG_SZ
+- **Values:**
+  
+  - **Enable (default):** true
+  - **Disable:** false
+
+
+AllowSaveUsernames
+------------------
+Determines whether saving usernames is allowed.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Credentials
+- **Value Name:** AllowSaveUsernames
+- **Value Type:** REG_SZ
+- **Values:**
+  
+  - **Enable (default):** true
+  - **Disable:** false
+
+.. note::
+   If 'AllowSaveUsernames' is set to false, stored user names in the connection persist until the connection goes through modification or usage. 
+   Subsequently, stored user names are removed. 
+   Additionally, new connections will not be able to store usernames.
+
+
+AllowSavePasswords
+------------------
+Determines whether saving passwords is allowed.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Credentials
+- **Value Name:** AllowSavePasswords
+- **Value Type:** REG_SZ
+- **Values:**
+  
+  - **Enable (default):** true
+  - **Disable:** false
+
+.. note::
+   If 'AllowSavePasswords' is set to false, stored passwords in the connection persist until the connection goes through modification or usage. 
+   Subsequently, stored passwords are removed.
+   Additionally, new connections will not be able to store passwords.
+
+
+AllowModifyCredentialSettings
+-----------------------------
+Specifies if the 'Credentials' option page is configurable.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Credentials
+- **Value Name:** AllowModifyCredentialSettings
+- **Value Type:** REG_SZ
+- **Values:**
+  
+  - **Enable (default):** true
+  - **Disable:** false
+
+.. note::
+   If 'AllowModifyCredentialSettings' is set to false, 'UseCredentials' is automatically set to 'None' (noinfo).
+
+
+Option Page Settings
+====================
+Configure the options page to modify functionalities as described.
+
+UseCredentials
+--------------
+Specifies the radio button state on the credentials page to prefill empty credential fields:
+- "None" is selected to leave the fields unfilled.
+- "Windows Logon Information" is chosen to autofill with Single Sign-On (SSO) data.
+- "Custom" is opted for utilizing the defined information.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Credentials\\Options
+- **Value Name:** UseCredentials
+- **Value Type:** REG_SZ
+- **Values:**
+  
+  - Radio (1) None: `noinfo`
+  - Radio (2) Windows Logon: `windows`
+  - Radio (3) Custom: `custom`
+
+
+UserViaAPIDefault
+-----------------
+Specifies the user set via API as the default username.
+Important: only used when "UseCredentials" is set to "Custom".
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Credentials\\Options
+- **Value Name:** UserViaAPIDefault
+- **Value Type:** REG_SZ
+
+.. note::
+  Only takes effect if 'UseCredentials' is set to custom.
+
+
+DefaultUsername
+---------------
+Specifies the default username.
+Important: only used when "UseCredentials" is set to "Custom".
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Credentials\\Options
+- **Value Name:** DefaultUsername
+- **Value Type:** REG_SZ
+
+.. note::
+  Only takes effect if 'UseCredentials' is set to custom.
+
+
+DefaultPassword
+---------------
+(currently not supported)
+
+Specifies the default password.
+
+.. warning::
+
+    Do not store decrypted passwords in the registry!
+
+    Storing decrypted passwords in the registry poses a significant security risk and is strongly discouraged. It can expose sensitive information, compromise user credentials, and lead to unauthorized access. Always follow best security practices and avoid storing plaintext passwords in any form, including the registry.
+
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Credentials\\Options
+- **Value Name:** DefaultPassword
+- **Value Type:** REG_SZ
+
+.. note::
+  Only takes effect if 'UseCredentials' is set to custom.
+
+
+DefaultDomain
+-------------
+Specifies the default domain.
+Important: only used when "UseCredentials" is set to "Custom".
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Credentials\\Options
+- **Value Name:** DefaultDomain
+- **Value Type:** REG_SZ
+
+.. note::
+  Only takes effect if 'UseCredentials' is set to custom.

--- a/mRemoteNGDocumentation/registry/updates_settings.rst
+++ b/mRemoteNGDocumentation/registry/updates_settings.rst
@@ -1,0 +1,206 @@
+.. _updates_settings:
+
+******************
+Updates Settings
+******************
+.. versionadded:: v1.77.3
+
+.. warning::
+    Before proceeding with any changes to the Windows Registry, it is imperative that you carefully read and comprehend the 
+    **Modifying the Registry**, **Restricted Registry Settings** and **Disclaimer** 
+    on :doc:`Registry Settings Infromation </registry_settings_information>`.
+    
+
+Common settings
+===============
+These settings are defined for global configuration.
+
+
+AllowCheckForUpdates 
+--------------------
+Allows or disallows checking for updates.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Updates
+- **Value Name:** AllowCheckForUpdates
+- **Value Type:** REG_SZ
+- **Values:**
+  
+  - **Enable (default):** true
+  - **Disable:** false
+
+
+AllowCheckForUpdatesAutomatical
+-------------------------------
+Allows or disallows automatic search for updates.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Updates
+- **Value Name:** AllowCheckForUpdatesAutomatical
+- **Value Type:** REG_SZ
+- **Values:**
+  
+  - **Enable (default):** true
+  - **Disable:** false
+
+.. note::
+   If "AllowCheckForUpdates" is set to false, the automatic update check is already disabled.
+
+
+AllowCheckForUpdatesManual
+--------------------------
+Allows or disallows manual search for updates.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Updates
+- **Value Name:** AllowCheckForUpdatesManual
+- **Value Type:** REG_SZ
+- **Values:**
+  
+  - **Enable (default):** true
+  - **Disable:** false
+
+.. note::
+   If "AllowCheckForUpdates" is set to false, the automatic update check is already disabled.
+
+
+AllowPromptForUpdatesPreference
+-------------------------------
+Controls whether a prompt for checking the updates preferences is displayed at startup.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Updates
+- **Value Name:** AllowPromptForUpdatesPreference
+- **Value Type:** REG_SZ
+- **Values:**
+  
+  - **Enable:** true
+  - **Disable:** false
+
+
+Option Page Settings
+====================
+Configure the options page to modify functionalities as described.
+
+
+CheckForUpdatesFrequencyDays
+----------------------------
+Specifies the number of days between automatic update checks.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Updates\\Options
+- **Value Name:** CheckForUpdatesFrequencyDays
+- **Value Type:** REG_DWORD
+
+.. note::
+   If 'AllowCheckForUpdates' is set to false, the automatic update check is already disabled, and 'CheckForUpdatesFrequencyDays' does not take effect.
+
+
+UpdateChannel
+-------------
+Specifies the preferred update channel. Important note: Values are case-sensitive!
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Updates\\Options
+- **Value Name:** UpdateChannel
+- **Value Type:** REG_SZ
+- **Values:**
+  
+  - Channel: Stable
+  - Channel: Nightly
+  - Channel: Preview
+
+
+UseProxyForUpdates
+------------------
+Indicates whether proxy usage for updates is enabled.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Updates\\Options
+- **Value Name:** UseProxyForUpdates
+- **Value Type:** REG_SZ
+- **Values:**
+  
+  - Enable: true
+  - Disable: false
+
+
+ProxyAddress
+------------
+Specifies the address of the proxy for updates.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Updates\\Options
+- **Value Name:** ProxyAddress
+- **Value Type:** REG_SZ
+
+.. note::
+    If 'UseProxyForUpdates' is disabled, these settings do not take effect.
+
+
+ProxyPort
+---------
+Specifies the port used for proxy connections during updates.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Updates\\Options
+- **Value Name:** ProxyPort
+- **Value Type:** REG_DWORD
+
+.. note::
+    If 'UseProxyForUpdates' is disabled, these settings do not take effect.
+
+
+UseProxyAuthentication
+----------------------
+Indicates whether proxy authentication is enabled.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Updates\\Options
+- **Value Name:** UseProxyAuthentication
+- **Value Type:** REG_SZ
+- **Values:**
+  - Enable Value: true
+  - Disable Value: false
+
+.. note::
+    If 'UseProxyForUpdates' is disabled, these settings do not take effect.
+
+
+ProxyAuthUser
+-------------
+Specifies the authentication username for the proxy.
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Updates\\Options
+- **Value Name:** ProxyAuthUser
+- **Value Type:** REG_SZ
+
+.. note::
+    If 'UseProxyForUpdates' is disabled, these settings do not take effect.
+
+.. note::
+    If 'ProxyAuthUser' is disabled, these settings do not take effect.
+
+ProxyAuthPass 
+-------------
+(currently not supported)
+Represents the authentication password for the proxy.
+
+.. warning::
+
+    Do not store decrypted passwords in the registry!
+
+    Storing decrypted passwords in the registry poses a significant security risk and is strongly discouraged. It can expose sensitive information, compromise user credentials, and lead to unauthorized access. Always follow best security practices and avoid storing plaintext passwords in any form, including the registry.
+
+
+- **Registry Hive:** HKEY_LOCAL_MACHINE
+- **Registry Path:** SOFTWARE\\mRemoteNG\\Updates\\Options
+- **Value Name:** ProxyAuthPass
+- **Value Type:** REG_DWORD
+
+.. note::
+    If 'UseProxyForUpdates' is disabled, these settings do not take effect.
+
+.. note::
+    If 'ProxyAuthUser' is disabled, these settings do not take effect.

--- a/mRemoteNGDocumentation/registry_settings_guide.rst
+++ b/mRemoteNGDocumentation/registry_settings_guide.rst
@@ -17,4 +17,5 @@ Make changes with caution and ensure that you have backups before making any adj
 .. toctree::
    :maxdepth: 4
 
+   registry/credential_settings
    registry/updates_settings

--- a/mRemoteNGDocumentation/registry_settings_guide.rst
+++ b/mRemoteNGDocumentation/registry_settings_guide.rst
@@ -1,0 +1,20 @@
+.. _registry_settings_guide:
+
+****************************
+Registry Settings Guide
+****************************
+
+.. warning::
+    Before proceeding with any changes to the Windows Registry, it is imperative that you carefully read and comprehend the 
+    **Modifying the Registry**, **Restricted Registry Settings** and **Disclaimer** 
+    on :doc:`Registry Settings Infromation </registry_settings_information>`.
+    
+
+The following registry settings are used by mRemoteNG to configure various options and behavior. 
+Please note that incorrect modifications to these settings can impact the functionality of mRemoteNG. 
+Make changes with caution and ensure that you have backups before making any adjustments.
+
+.. toctree::
+   :maxdepth: 4
+
+   registry/updates_settings

--- a/mRemoteNGDocumentation/registry_settings_information.rst
+++ b/mRemoteNGDocumentation/registry_settings_information.rst
@@ -1,0 +1,108 @@
+.. _registry_settings_information:
+
+*****************************
+Registry Settings Information
+*****************************
+
+.. warning::
+    Before proceeding with any changes to the Windows Registry, it is imperative that you carefully read and comprehend the 
+    :ref:`Modifying the Registry <warning_modifying_registry>`, :ref:`Restricted Registry Settings <warning_restricted_registry_setting>`
+    and :ref:`Disclaimer <disclaimer>`.
+    
+
+.. _warning_modifying_registry:
+
+Modifying the Registry
+======================
+
+Making changes to the Windows Registry is a sensitive and advanced operation. Incorrect modifications can lead to system instability, 
+data loss, or even render your operating system unusable. Proceed with caution and follow these guidelines:
+
+1. **Backup Registry:** Before making any changes, create a backup of the Registry. This ensures that you can restore it to a working state if issues arise.
+
+2. **Know What You're Doing:** Only modify the Registry if you understand the implications of your changes. Incorrect values or deletions can affect system functionality and applications.
+
+3. **Documentation:** Document the changes you make. Include details such as the date, purpose, and the specific keys/values altered. This documentation can be crucial for troubleshooting later.
+
+4. **Create System Restore Point:** Create a System Restore Point before proceeding. This provides an additional layer of recovery in case problems occur.
+
+5. **Registry Editor:** Use the built-in Registry Editor (`regedit`) to make changes. Avoid third-party tools unless you are confident in their reliability.
+
+6. **One Change at a Time:** Make one change at a time and test its impact before proceeding to the next. This helps identify the cause if issues arise.
+
+7. **Verify Information:** Double-check the information you find online before applying it to your Registry. Incorrect instructions can lead to problems.
+
+8. **Permissions:** Be cautious with changing permissions. Modifying permissions incorrectly can result in restricted access to important system components.
+
+9. **Seek Professional Help:** If you are uncertain or uncomfortable with Registry modifications, seek assistance from knowledgeable professionals.
+
+10. **Emergency Plan:** Have a plan in case something goes wrong. Know how to restore your Registry from the backup or the System Restore Point.
+
+By acknowledging these warnings and following best practices, you can minimize the risks associated with making changes to the Windows Registry.
+
+
+.. _warning_restricted_registry_setting:
+
+Restricted Registry Settings
+============================
+
+This specific registry setting is intentionally restricted, and users do not have default permissions to modify it. 
+Even if you possess administrative rights on your system, any changes to this registry entry are prohibited by default.
+
+Attempting to alter this registry entry without proper authorization or without following specific instructions from your system 
+administrator may result in adverse effects on system stability, security, or functionality. 
+Any unauthorized changes can lead to unintended consequences, system errors, or even render your operating system inoperable.
+
+If you require adjustments to this registry setting, please consult with your system administrator or IT support. 
+They can provide guidance, assess the implications of any changes, and implement the necessary modifications following established procedures.
+
+Exercise caution, adhere to your organization's policies, and avoid making unauthorized alterations to the Windows Registry, 
+as it can impact the overall integrity and performance of your system.
+
+
+.. _How_to_open_the_Windows_Registry:
+
+How to open the Windows Registry
+================================
+
+The Windows Registry is a crucial component for system configuration. Here's a guide on how to open the Registry on Windows:
+
+**Using Run Dialog:**
+   - Press `Win + R` to open the Run dialog.
+   - Type `regedit` and press Enter.
+   - The Registry Editor will open.
+
+**Create Desktop Shortcut:**
+   - Right-click on the desktop.
+   - Choose "New" -> "Shortcut."
+   - Enter `regedit` as the location and click "Next."
+   - Provide a name for the shortcut and click "Finish."
+
+
+.. _disclaimer:
+
+Disclaimer
+==========
+Any changes made by yourself to the system settings, including but not limited to the Windows Registry, are undertaken at your own risk. 
+mRemoteNG shall not be held liable for any consequences arising from user-initiated modifications.
+
+Please be advised of the following:
+
+1. **User Responsibility:**
+   - You, as the user, are solely responsible for the changes made to system configurations.
+
+2. **No Liability Assumed:**
+   - mRemoteNG do not assume any liability for potential issues, damages, or data loss resulting from user-initiated modifications.
+
+3. **Recommended Best Practices:**
+   - Users are encouraged to adhere to recommended best practices, such as creating backups and seeking professional assistance when necessary.
+
+4. **System Stability:**
+   - Modifications to system settings, including the Windows Registry, can impact system stability. It is essential to exercise caution and fully understand the implications of changes.
+
+5. **Professional Assistance:**
+   - If you are uncertain about specific configurations or require assistance, consider consulting with professional support services.
+
+By proceeding with user-initiated changes, you acknowledge and accept the responsibility for any potential consequences that may arise. This disclaimer applies to all adjustments made independently by users.
+
+Thank you for your understanding and cooperation.

--- a/mRemoteNGTests/Tools/Registry/WindowsRegistryAdvancedTests.cs
+++ b/mRemoteNGTests/Tools/Registry/WindowsRegistryAdvancedTests.cs
@@ -113,6 +113,13 @@ namespace mRemoteNGTests.Tools.Registry
                 Assert.That(key.IsKeyPresent, Is.EqualTo(false));
             });
         }
+
+        [Test]
+        public void GetDwordValue_returnIntegerValue()
+        {
+            int value = GetDwordValue(_TestHive, _TestRootKey, "TestInteger");
+            Assert.That(value, Is.EqualTo(4711));
+        }
         #endregion
 
         #region GetString()

--- a/mRemoteNGTests/Tools/Registry/WindowsRegistryAdvancedTests.cs
+++ b/mRemoteNGTests/Tools/Registry/WindowsRegistryAdvancedTests.cs
@@ -1,0 +1,181 @@
+﻿using Microsoft.Win32;
+using mRemoteNG.Tools.WindowsRegistry;
+using NUnit.Framework;
+
+namespace mRemoteNGTests.Tools.Registry
+{
+    internal class WindowsRegistryAdvancedTests : WindowsRegistryAdvanced
+    {
+        private const string _TestRootKey = @"Software\mRemoteNGTest";
+        private const RegistryHive _TestHive = RegistryHive.CurrentUser;
+
+        [SetUp]
+        public void Setup() 
+        {
+            // GetBoolean && GetBoolValue (GetBoolValue -> Not Advanced but not tested jet)
+            SetRegistryValue(_TestHive, _TestRootKey, "TestBoolAsString", "true", RegistryValueKind.String);
+            SetRegistryValue(_TestHive, _TestRootKey, "TestBoolAsDWord", 0, RegistryValueKind.DWord);
+
+            // GetInteger Tests
+            SetRegistryValue(_TestHive, _TestRootKey, "TestInteger", "4711", RegistryValueKind.DWord);
+
+            // GetString Tests
+            SetRegistryValue(_TestHive, _TestRootKey, "TestString1", "Banane", RegistryValueKind.String);
+            SetRegistryValue(_TestHive, _TestRootKey, "TestString2", "Hund", RegistryValueKind.String);
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            // Delete the registry keys here
+            DeleteRegistryKey(_TestHive, _TestRootKey, true);
+        }
+
+        #region GetBoolean() Tests
+        // Non object returns
+        [Test]
+        public void GetBooleanFromString_ReturnsTrue()
+        {
+            var key = GetBoolean(_TestHive, _TestRootKey, "TestBoolAsString");
+            Assert.That(key.Value, Is.EqualTo(true));
+        }
+
+        
+        [Test]
+        public void GetBooleanFromDword_ReturnsFalse()
+        {
+            var key = GetBoolean(_TestHive, _TestRootKey, "TestBoolAsDWord");
+            Assert.That(key.Value, Is.EqualTo(false));
+        }
+
+        [Test]
+        public void GetBooleanNotProvided_ReturnsDefaultTrue()
+        {
+            var key = GetBoolean(_TestHive, _TestRootKey, "TestBoolNotProvided", true);
+            Assert.Multiple(() =>
+            {
+                Assert.That(key.Value, Is.EqualTo(true), "Value should be the default (true)");
+                Assert.That(key.IsKeyPresent, Is.EqualTo(false), "IsProvided should be false");
+            });
+        }
+        #endregion
+
+        #region GetBoolValue()___No Object, just bool value returns
+        [Test]
+        public void GetBoolValueFromString_ReturnsTrue()
+        {
+            var key = GetBoolValue(_TestHive, _TestRootKey, "TestBoolAsString");
+            Assert.That(key, Is.EqualTo(true));
+        }
+        [Test]
+        public void GetBoolValueFromDword_ReturnsFalse()
+        {
+            var key = GetBoolValue(_TestHive, _TestRootKey, "TestBoolAsDWord", true);
+            Assert.That(key, Is.EqualTo(false));
+        }
+        [Test]
+        public void GetBoolValue_ReturnsDefaultTrue()
+        {
+            var key = GetBoolValue(_TestHive, _TestRootKey, "TestBoolNotProvided", true);
+            Assert.That(key, Is.EqualTo(true));
+        }
+        #endregion
+
+        #region GetInteger()
+        [Test]
+        public void GetInteger()
+        {
+            var key = GetInteger(_TestHive, _TestRootKey, "TestInteger");
+            Assert.Multiple(() =>
+            {
+                Assert.That(key.Value, Is.EqualTo(4711));
+                Assert.That(key.IsKeyPresent, Is.EqualTo(true));
+            });
+        }
+        [Test]
+        public void GetInteger_returnObjectDefault()
+        {
+            var key = GetInteger(_TestHive, _TestRootKey, "TestIntegerNotProvided");
+            Assert.Multiple(() =>
+            {
+                Assert.That(key.Value, Is.EqualTo(-1), "Value should be the default (-1)");
+                Assert.That(key.IsKeyPresent, Is.EqualTo(false));
+            });
+        }
+
+        [Test]
+        public void GetInteger_returnSpecifiedDefault()
+        {
+            var key = GetInteger(_TestHive, _TestRootKey, "TestIntegerNotProvided", 2096);
+            Assert.Multiple(() =>
+            {
+                Assert.That(key.Value, Is.EqualTo(-1), "Value should be the default (-1)");
+                Assert.That(key.IsKeyPresent, Is.EqualTo(false));
+            });
+        }
+        #endregion
+
+        #region GetString()
+        [Test]
+        public void GetString()
+        {
+            var key = GetString(_TestHive, _TestRootKey, "TestString1");
+            Assert.Multiple(() =>
+            {
+                Assert.That(key.Value, Is.EqualTo("Banane"));
+                Assert.That(key.IsKeyPresent, Is.EqualTo(true));
+            });
+        }
+
+        [Test]
+        public void GetString_ReturnsDefault()
+        {
+            var key = GetString(_TestHive, _TestRootKey, "TestStringNotProvided", "Banane");
+            Assert.Multiple(() =>
+            {
+                Assert.That(key.Value, Is.EqualTo("Banane"));
+                Assert.That(key.IsKeyPresent, Is.EqualTo(false));
+            });
+        }
+
+        [Test]
+        public void GetStringValidated_Valid()
+        {
+            string[] fruits = { "Banane", "Erdbeere", "Apfel" };
+            var key = GetStringValidated(_TestHive, _TestRootKey, "TestString1", fruits);
+            Assert.Multiple(() =>
+            {
+                Assert.That(key.Value, Is.EqualTo("Banane"));
+                Assert.That(key.IsKeyPresent, Is.EqualTo(true));
+                Assert.That(key.IsValid, Is.EqualTo(true));
+            });
+        }
+
+        [Test]
+        public void GetStringValidated_NotValidNull()
+        {
+            string[] fruits = { "Banane", "Erdbeere", "Apfel" };
+            var key = GetStringValidated(_TestHive, _TestRootKey, "TestString2", fruits);
+            Assert.Multiple(() =>
+            {
+                Assert.That(key.Value, Is.EqualTo(null));
+                Assert.That(key.IsKeyPresent, Is.EqualTo(true));
+                Assert.That(key.IsValid, Is.EqualTo(false));
+            });
+        }
+
+        [Test]
+        public void GetStringValidated_NotValidDefault()
+        {
+            string[] fruits = { "Banane", "Erdbeere", "Apfel" };
+            var key = GetStringValidated(_TestHive, _TestRootKey, "TestString2", fruits, false, "Banane");
+            Assert.Multiple(() =>
+            {
+                Assert.That(key.Value, Is.EqualTo("Banane"));
+                Assert.That(key.IsKeyPresent, Is.EqualTo(true));
+                Assert.That(key.IsValid, Is.EqualTo(false));
+            });
+        }
+        #endregion
+    }
+}

--- a/mRemoteNGTests/Tools/Registry/WindowsRegistryKeyTests.cs
+++ b/mRemoteNGTests/Tools/Registry/WindowsRegistryKeyTests.cs
@@ -1,0 +1,374 @@
+﻿using Microsoft.Win32;
+using mRemoteNG.Tools.WindowsRegistry;
+using NUnit.Framework;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.Rebar;
+
+namespace mRemoteNGTests.Tools.Registry
+{
+    internal class WindowsRegistryKeyTests
+    {
+        private WindowsRegistryKey CompleteRegistryKey { get; set; }
+        private WindowsRegistryKey PartialRegistryKey { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            CompleteRegistryKey = new WindowsRegistryKey()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.String,
+                Name = "Test",
+                Path = @"SOFTWARE\TEST\TEST\Test",
+                Value = "CompleteRegistryKey"
+            };
+
+            PartialRegistryKey = new WindowsRegistryKey()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.DWord,
+            };
+        }
+
+        #region WindowsRegistryKey() tests
+        [Test]
+        public void WindowsRegistryKeyReadable()
+        {
+            Assert.That(CompleteRegistryKey.IsKeyReadable, Is.EqualTo(true));
+        }
+
+        [Test]
+        public void WindowsRegistryKeyNotReadable()
+        {
+            Assert.That(PartialRegistryKey.IsKeyReadable, Is.EqualTo(false));
+        }
+
+        [Test]
+        public void WindowsRegistryKeyWriteable()
+        {
+            Assert.That(CompleteRegistryKey.IsKeyWritable, Is.EqualTo(true));
+        }
+
+        [Test]
+        public void WindowsRegistryKeyNotWriteable()
+        {
+            Assert.That(PartialRegistryKey.IsKeyWritable, Is.EqualTo(false));
+        }
+
+        [Test]
+        public void WindowsRegistryKeyProvided()
+        {
+            Assert.That(CompleteRegistryKey.IsKeyPresent, Is.EqualTo(true));
+        }
+
+        [Test]
+        public void WindowsRegistryKeyNotProvided()
+        {
+            Assert.That(PartialRegistryKey.IsKeyPresent, Is.EqualTo(false));
+        }
+        #endregion
+
+        #region WindowsRegistryKeyBoolean tests
+        [Test]
+        public void WindowsRegistryKeyBoolean_FromStringTrue()
+        {
+
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.String,
+                Name = "TestBoolString",
+                Path = @"SOFTWARE\Test",
+                Value = "true"
+            };
+
+            WindowsRegistryKeyBoolean boolKey = new ();
+            boolKey.ConvertFromWindowsRegistryKey(TestKey);
+
+            Assert.That(boolKey.IsKeyPresent, Is.EqualTo(true));
+            Assert.That(boolKey.Value, Is.EqualTo(true)); 
+        }
+
+        [Test]
+        public void WindowsRegistryKeyBoolean_FromStringFalse()
+        {
+
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.String,
+                Name = "TestBoolString",
+                Path = @"SOFTWARE\Test",
+                Value = "false"
+            };
+
+            WindowsRegistryKeyBoolean boolKey = new();
+            boolKey.ConvertFromWindowsRegistryKey(TestKey);
+
+            Assert.That(boolKey.IsKeyPresent, Is.EqualTo(true));
+            Assert.That(boolKey.Value, Is.EqualTo(false));
+        }
+
+        [Test]
+        public void WindowsRegistryKeyBoolean_FromDwordTrue()
+        {
+
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.DWord,
+                Name = "TestBoolString",
+                Path = @"SOFTWARE\Test",
+                Value = "1"
+            };
+
+            WindowsRegistryKeyBoolean boolKey = new();
+            boolKey.ConvertFromWindowsRegistryKey(TestKey);
+
+            Assert.That(boolKey.IsKeyPresent, Is.EqualTo(true));
+            Assert.That(boolKey.Value, Is.EqualTo(true));
+        }
+
+        [Test]
+        public void WindowsRegistryKeyBoolean_FromDwordFalse()
+        {
+
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.DWord,
+                Name = "TestBoolString",
+                Path = @"SOFTWARE\Test",
+                Value = "0"
+            };
+
+            WindowsRegistryKeyBoolean boolKey = new();
+            boolKey.ConvertFromWindowsRegistryKey(TestKey);
+
+            Assert.That(boolKey.IsKeyPresent, Is.EqualTo(true));
+            Assert.That(boolKey.Value, Is.EqualTo(false));
+        }
+
+        [Test]
+        public void WindowsRegistryKeyBoolean_ReturnDefault()
+        {
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.DWord,
+                Name = "TestBoolString",
+                Path = @"SOFTWARE\Test",
+                Value = null
+            };
+
+            WindowsRegistryKeyBoolean boolKey = new();
+            boolKey.ConvertFromWindowsRegistryKey(TestKey, true);
+
+            Assert.That(boolKey.IsKeyPresent, Is.EqualTo(false));
+            Assert.That(boolKey.Value, Is.EqualTo(true));
+        }
+        #endregion
+
+        #region WindowsRegistryKeyInteger tests
+        [Test]
+        public void WindowsRegistryKeyInteger()
+        {
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.DWord,
+                Name = "TestIntigerString",
+                Path = @"SOFTWARE\Test",
+                Value = "4711"
+            };
+
+            WindowsRegistryKeyInteger IntKey = new();
+            IntKey.ConvertFromWindowsRegistryKey(TestKey);
+
+            Assert.That(IntKey.IsKeyPresent, Is.EqualTo(true));
+            Assert.That(IntKey.Value, Is.EqualTo(4711));
+        }
+        [Test]
+        public void WindowsRegistryKeyInteger_ReturnDefault()
+        {
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.DWord,
+                Name = "TestIntigerString",
+                Path = @"SOFTWARE\Test",
+                Value = null
+            };
+
+            WindowsRegistryKeyInteger IntKey = new();
+            IntKey.ConvertFromWindowsRegistryKey(TestKey, 2096);
+
+            Assert.That(IntKey.IsKeyPresent, Is.EqualTo(false));
+            Assert.That(IntKey.Value, Is.EqualTo(2096));
+        }
+        #endregion
+
+        #region WindowsRegistryKeyString tests
+        [Test]
+        public void WindowsRegistryKeyString()
+        {
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.DWord,
+                Name = "TestRegString",
+                Path = @"SOFTWARE\Test",
+                Value = "The Big Bang Theory"
+            };
+
+            WindowsRegistryKeyString StrKey = new();
+            StrKey.ConvertFromWindowsRegistryKey(TestKey);
+
+            Assert.That(StrKey.IsKeyPresent, Is.EqualTo(true));
+            Assert.That(StrKey.Value, Is.EqualTo("The Big Bang Theory"));
+        }
+        [Test]
+        public void WindowsRegistryKeyString_ReturnDefault()
+        {
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.DWord,
+                Name = "TestRegString",
+                Path = @"SOFTWARE\Test",
+                Value = null
+            };
+
+            WindowsRegistryKeyString StrKey = new();
+            StrKey.ConvertFromWindowsRegistryKey(TestKey, "South Park");
+
+            Assert.That(StrKey.IsKeyPresent, Is.EqualTo(false));
+            Assert.That(StrKey.Value, Is.EqualTo("South Park"));
+        }
+
+        [Test]
+        public void WindowsRegistryKeyString_ValidateSuccess()
+        {
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.DWord,
+                Name = "TestRegString",
+                Path = @"SOFTWARE\Test",
+                Value = "Big Bang"
+            };
+
+            WindowsRegistryKeyString StrKey = new();
+            StrKey.AllowedValues = new[] { "Big Bang", "Big Bang Theory", "The Big Bang Theory" };
+            StrKey.ConvertFromWindowsRegistryKey(TestKey);
+
+            Assert.That(StrKey.IsKeyPresent, Is.EqualTo(true));
+            Assert.That(StrKey.IsValid, Is.EqualTo(true));
+        }
+
+        [Test]
+        public void WindowsRegistryKeyString_ValidateNotSuccess()
+        {
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.DWord,
+                Name = "TestRegString",
+                Path = @"SOFTWARE\Test",
+                Value = "ig ang"
+            };
+
+            WindowsRegistryKeyString StrKey = new();
+            StrKey.AllowedValues = new[] { "Big Bang", "Big Bang Theory", "The Big Bang Theory" };
+            StrKey.ConvertFromWindowsRegistryKey(TestKey);
+
+            Assert.That(StrKey.IsKeyPresent, Is.EqualTo(true));
+            Assert.That(StrKey.IsValid, Is.EqualTo(false));
+        }
+
+        [Test]
+        public void WindowsRegistryKeyString_ValidateSuccessCase()
+        {
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.DWord,
+                Name = "TestRegString",
+                Path = @"SOFTWARE\Test",
+                Value = "BiG BAng"
+            };
+
+            WindowsRegistryKeyString StrKey = new();
+            StrKey.AllowedValues = new[] { "BiG BAng", "Big Bang Theory", "The Big Bang Theory" };
+            StrKey.IsCaseSensitiveValidation = true;
+            StrKey.ConvertFromWindowsRegistryKey(TestKey);
+
+            Assert.That(StrKey.IsKeyPresent, Is.EqualTo(true));
+            Assert.That(StrKey.IsValid, Is.EqualTo(true));
+        }
+
+        [Test]
+        public void WindowsRegistryKeyString_ValidateNotSuccessCase()
+        {
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.DWord,
+                Name = "TestRegString",
+                Path = @"SOFTWARE\Test",
+                Value = "BiG BAng"
+            };
+
+            WindowsRegistryKeyString StrKey = new();
+            StrKey.AllowedValues = new[] { "Big Bang", "Big Bang Theory", "The Big Bang Theory" };
+            StrKey.IsCaseSensitiveValidation = true;
+            StrKey.ConvertFromWindowsRegistryKey(TestKey);
+
+            Assert.That(StrKey.IsKeyPresent, Is.EqualTo(true));
+            Assert.That(StrKey.IsValid, Is.EqualTo(false));
+        }
+
+        [Test]
+        public void WindowsRegistryKeyString_ValidateNotSuccessReturnNull()
+        {
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.DWord,
+                Name = "TestRegString",
+                Path = @"SOFTWARE\Test",
+                Value = "ig ang"
+            };
+
+            WindowsRegistryKeyString StrKey = new();
+            StrKey.AllowedValues = new[] { "Big Bang", "Big Bang Theory", "The Big Bang Theory" };
+            StrKey.ConvertFromWindowsRegistryKey(TestKey);
+
+            Assert.That(StrKey.IsKeyPresent, Is.EqualTo(true));
+            Assert.That(StrKey.IsValid, Is.EqualTo(false));
+            Assert.That(StrKey.Value, Is.EqualTo(null));
+        }
+
+        [Test]
+        public void WindowsRegistryKeyString_ValidateNotSuccessValidValue()
+        {
+            WindowsRegistryKey TestKey = new()
+            {
+                Hive = RegistryHive.CurrentUser,
+                ValueKind = RegistryValueKind.DWord,
+                Name = "TestRegString",
+                Path = @"SOFTWARE\Test",
+                Value = "ig ang"
+            };
+
+            WindowsRegistryKeyString StrKey = new();
+            StrKey.AllowedValues = new[] { "Big Bang", "Big Bang Theory", "The Big Bang Theory" };
+            StrKey.ConvertFromWindowsRegistryKey(TestKey, "Big Bang Theory");
+
+            Assert.That(StrKey.IsKeyPresent, Is.EqualTo(true));
+            Assert.That(StrKey.IsValid, Is.EqualTo(false));
+            Assert.That(StrKey.Value, Is.EqualTo("Big Bang Theory"));
+        }
+
+        #endregion
+    }
+}

--- a/mRemoteNGTests/Tools/Registry/WindowsRegistryTests.cs
+++ b/mRemoteNGTests/Tools/Registry/WindowsRegistryTests.cs
@@ -188,7 +188,7 @@ namespace mRemoteNGTests.Tools.Registry
         [Test]
         public void SetRegistryValueThrowAccessDenied()
         {
-            Assert.Throws<UnauthorizedAccessException>(() => _registryWriter.SetRegistryValue(RegistryHive.LocalMachine, @"SOFTWARE\mRemoteNGTest", "TestKey", "A value string", RegistryValueKind.String));
+            Assert.Throws<InvalidOperationException>(() => _registryWriter.SetRegistryValue(RegistryHive.LocalMachine, @"SOFTWARE\mRemoteNGTest", "TestKey", "A value string", RegistryValueKind.String));
         }
         #endregion
     }

--- a/mRemoteNGTests/Tools/Registry/WindowsRegistryTests.cs
+++ b/mRemoteNGTests/Tools/Registry/WindowsRegistryTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Forms;
 using Microsoft.Win32;
 using mRemoteNG.Tools.WindowsRegistry;
 using NUnit.Framework;
@@ -9,14 +10,12 @@ namespace mRemoteNGTests.Tools.Registry
 {
     public class WindowsRegistryTests
     {
-        private IRegistry _registry;
         private IRegistryRead _registryReader;
         private IRegistryWrite _registryWriter;
 
         [SetUp]
         public void Setup()
         {
-            _registry = new WindowsRegistry();
             _registryReader = new WindowsRegistry();
             _registryWriter = new WindowsRegistry();
         }
@@ -28,11 +27,13 @@ namespace mRemoteNGTests.Tools.Registry
             var subKeyNames = _registryReader.GetSubKeyNames(RegistryHive.CurrentUser, "Software");
             Assert.That(subKeyNames, Does.Contain("Microsoft"));
         }
+
         [Test]
         public void GetSubkeyNamesThrowsIfGivenNullKeyPath()
         {
             Assert.Throws<ArgumentNullException>(() => _registryReader.GetSubKeyNames(RegistryHive.CurrentUser, null));
         }
+
         [Test]
         public void GetSubkeyNamesThrowsIfGivenUnknownHive()
         {
@@ -45,13 +46,13 @@ namespace mRemoteNGTests.Tools.Registry
         public void CanGetPropertyValue()
         {
             var keyValue = _registryReader.GetPropertyValue(RegistryHive.ClassesRoot, @".dll\PersistentHandler", "");
-            Assert.That(keyValue.FirstOrDefault(), Is.EqualTo("{098f2470-bae0-11cd-b579-08002b30bfeb}"));
+            Assert.That(keyValue, Is.EqualTo("{098f2470-bae0-11cd-b579-08002b30bfeb}"));
         }
 
         [Test]
         public void CanGetPropertyValueByRegistryKeyObject()
         {
-            WindowsRegistryKey key = new WindowsRegistryKey
+            WindowsRegistryKey key = new()
             {
                 Hive = RegistryHive.ClassesRoot,
                 Path = @".dll\PersistentHandler",
@@ -59,7 +60,7 @@ namespace mRemoteNGTests.Tools.Registry
             };
 
             var keyValue = _registryReader.GetPropertyValue(key);
-            Assert.That(keyValue.FirstOrDefault(), Is.EqualTo("{098f2470-bae0-11cd-b579-08002b30bfeb}"));
+            Assert.That(keyValue, Is.EqualTo("{098f2470-bae0-11cd-b579-08002b30bfeb}"));
         }
         [Test]
         public void GetPropertyValueThrowsIfGivenNullKeyPath()
@@ -85,7 +86,7 @@ namespace mRemoteNGTests.Tools.Registry
         [Test]
         public void CanGetWindowsRegistryKeyByObject()
         {
-            WindowsRegistryKey key = new WindowsRegistryKey
+            WindowsRegistryKey key = new()
             {
                 Hive = RegistryHive.ClassesRoot,
                 Path = @".dll\PersistentHandler",
@@ -107,11 +108,11 @@ namespace mRemoteNGTests.Tools.Registry
         [Test]
         public void GetWindowsRegistryThrowNotReadable()
         {
-            WindowsRegistryKey key = new WindowsRegistryKey
+            WindowsRegistryKey key = new()
             {
                 Hive = RegistryHive.ClassesRoot,
             };
-
+        
             Assert.Throws<InvalidOperationException>(() => _registryReader.GetWindowsRegistryKey(key));
         }
         #endregion
@@ -137,7 +138,7 @@ namespace mRemoteNGTests.Tools.Registry
         public void IsWindowsRegistryKeyValid()
         {
             // Tests property rules of WindowsRegistryKey
-            WindowsRegistryKey key = new WindowsRegistryKey();
+            WindowsRegistryKey key = new();
 
             Assert.Multiple(() =>
             {
@@ -152,26 +153,27 @@ namespace mRemoteNGTests.Tools.Registry
         [Test]
         public void WindowsRegistryKeyThrowHiveNullException()
         {
-            WindowsRegistryKey key = new WindowsRegistryKey();
+            WindowsRegistryKey key = new();
             Assert.Throws<ArgumentNullException>(() => key.Hive = 0, "Expected IsHiveValid to throw ArgumentNullException");
         }
 
         [Test]
-        public void WindowsRegistryKeyThrowValueKindNullException()
+        public void WindowsRegistryKeyValueKindUnknown()
         {
-            WindowsRegistryKey key = new WindowsRegistryKey();
-            Assert.Throws<ArgumentNullException>(() => key.ValueKind = 0, "Expected IsValueKindValid to throw ArgumentNullException");
+            WindowsRegistryKey key = new();
+            Assert.That(key.ValueKind, Is.EqualTo(RegistryValueKind.Unknown));
+
         }
         [Test]
         public void WindowsRegistryKeyThrowPathNullException()
         {
-            WindowsRegistryKey key = new WindowsRegistryKey();
+            WindowsRegistryKey key = new();
             Assert.Throws<ArgumentNullException>(() => key.Path = null, "Expected IsPathValid to throw ArgumentNullException");
         }
         [Test]
         public void WindowsRegistryKeyThrowNameNullException()
         {
-            WindowsRegistryKey key = new WindowsRegistryKey();
+            WindowsRegistryKey key = new();
             Assert.Throws<ArgumentNullException>(() => key.Name = null, "Expected IsNameValid to throw ArgumentNullException");
         }
         #endregion


### PR DESCRIPTION
## Description
- Add registry settings capabilitys
- Add update configuration via registry 
#2546 

- Add credentials configuration via registry 
#738 

- Add Sphinx documentation for registry settings
![image](https://github.com/mRemoteNG/mRemoteNG/assets/145561288/b09e64a9-7f82-4465-94f8-e13f10790a84)

Important:
1) common settings
- On program start common settings are loaded directly
- Common settings are directly applied in different places. The naming indicates what the default is, such as AllowCheckForUpdates. This means that by default, this is allowed via the registry even if there is no entry. If a setting were turned off by default, it would be named Disable...**.... Only the opposite setting would trigger an effect (AllowCheckForUpdates = false).

2) Option page settings
- When loading an options page, the registry settings are loaded first. These override (if set) the loaded settings from the user config. After that, the settings page is filled with the registry or XML information.
- This has the advantage that, at the latest after the second launch of the application, all registry settings are utilized. In essence, the registry settings take effect wherever the settings are used. Since users typically do not have access to HKLM, these settings are protected against changes.

## Motivation and Context
First of all is magaing settings via registry a important thing for adminstrator. Resultent of this functions there can easly create ADMX files to push this settings with windows Group policies from a AD Server from enterprise menagments. 

Furthermore, deploying mRemoteNG through software management tools such as SCCM (System Center Configuration Manager) becomes more feasible and manageable with registry settings.

The reason I begin with Credentials or Updates settings is that some users have expressed a desire for these features, as certain enterprise rules require their implementation.


## How Has This Been Tested?
1) I have tested important aspects, such as reading the registry, using NUnit.Framework. 
2) The settings were also tested by configuring them in the registry, starting the program, and observing the outcomes.


If you want to test, please read the documentation "Registry Settings Information" first. "Registry Settings Information" contains security warnings, disclaimers, and other notes, as mishandling the registry could potentially harm the system.

After reviewing the information page, proceed to the "Registry Settings Guide" for configuring the settings. I can also share the content of the documentation page in this thread, specifically the Registry Settings Guide.


## Screenshots (if appropriate):
Example: Completely disable update functionality:
![image](https://github.com/mRemoteNG/mRemoteNG/assets/145561288/bb41d8cb-3797-41ea-b7eb-4689624218d3)


If a change is made through the registry, an info box will be displayed on the options page:
![image](https://github.com/mRemoteNG/mRemoteNG/assets/145561288/88607fed-6c68-4b8a-b30d-15951aa91d83)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Changed feature (non-breaking change which changes functionality)
- [x] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [x] I have updated the documentation accordingly, if necessary.
