### PR TITLE
Log File Opening Fails on Notification Settings Page

### DIFF
--- a/mRemoteNG/App/ProgramRoot.cs
+++ b/mRemoteNG/App/ProgramRoot.cs
@@ -21,6 +21,12 @@ namespace mRemoteNG.App
         [STAThread]
         public static void Main(string[] args)
         {
+            /*
+             * Temporarily disable LocalSettingsManager initialization at startup
+             * due to unfinished implementation causing build errors.
+             * Uncomment if needed in your local repo.
+             */
+            /*
             /*var settingsManager = new LocalSettingsManager();
 
             // Check if the database exists

--- a/mRemoteNG/UI/Forms/OptionsPages/NotificationsPage.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/NotificationsPage.cs
@@ -155,8 +155,15 @@ namespace mRemoteNG.UI.Forms.OptionsPages
 
         private void buttonOpenLogFile_Click(object sender, System.EventArgs e)
         {
-            if (Path.GetExtension(textBoxLogPath.Text) == ".log")
-                Process.Start(textBoxLogPath.Text);
+            string logFile = textBoxLogPath.Text;
+            bool doesExist = File.Exists(logFile);
+
+            if (doesExist && OpenLogAssociated(logFile))
+                return;
+            else if (doesExist && OpenLogNotepad(logFile))
+                return;
+
+            OpenLogLocation(logFile);
         }
 
         private void chkLogToCurrentDir_CheckedChanged(object sender, System.EventArgs e)
@@ -165,5 +172,71 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             buttonRestoreDefaultLogPath.Enabled = !chkLogToCurrentDir.Checked;
             textBoxLogPath.Text = Logger.DefaultLogPath;
         }
+
+        #region Privat Methods to Open Logfile
+
+        /// <summary>
+        /// Attempts to open a file using the default application associated with its file type.
+        /// </summary>
+        /// <param name="path">The path of the file to be opened.</param>
+        /// <returns>True if the operation was successful; otherwise, false.</returns>
+        private static bool OpenLogAssociated(string path)
+        {
+            try
+            {
+                // Open the file using the default application associated with its file type based on the user's preference
+                Process.Start(path);
+                return true;
+            }
+            catch
+            {
+                // If necessary, the error can be logged here.
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attempts to open a file in Notepad, the default text editor on Windows systems.
+        /// </summary>
+        /// <param name="path">The path of the file to be opened in Notepad.</param>
+        /// <returns>True if the operation was successful; otherwise, false.</returns>
+        private static bool OpenLogNotepad(string path)
+        {
+            try
+            {
+                // Open it in "Notepad" (Windows default editor).
+                // Usually available on all Windows systems
+                Process.Start("notepad.exe", path);
+                return true;
+            }
+            catch
+            {
+                // If necessary, the error can be logged here.
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attempts to open the location of a specified file in Windows Explorer.
+        /// </summary>
+        /// <param name="path">The path of the file whose location needs to be opened.</param>
+        /// <returns>True if the operation was successful; otherwise, false.</returns>
+        private static bool OpenLogLocation(string path)
+        {
+            try
+            {
+                /// when all fails open filelocation to logfile...
+                // Open Windows Explorer to the directory containing the file
+                Process.Start("explorer.exe", $"/select,\"{path}\"");
+                return true;
+            }
+            catch
+            {
+                // If necessary, the error can be logged here.
+                return false;
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
## Description
mRem throws an error when attempting to open the log file on the Notification settings page since the last nightly.

Changes:
- Added my missed comment for outlined LocalSettingsManager
- Fixed a bug that occurred when trying to open the log file on the Notification settings page.
- Removed unnecessary file association when user tries to open the log file on the Notification page. The "choose file" dialog handles the extension as it is fixed on .log
- Implemented fallback to open file explorer to the specified file location if mRem fails to open the log file.

## Motivation and Context

## How Has This Been Tested?
Fully tested. The log file can be opened, and if it fails, a fallback opens File Explorer to the file location.

## Screenshots (if appropriate):
![image](https://github.com/mRemoteNG/mRemoteNG/assets/145561288/edb2a8a5-5686-4553-8c08-c6c68a2bac5f)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
