### PR TITLE
Remember the opened connection file on relaunch

### DIFF
--- a/mRemoteNG/Connection/ConnectionsService.cs
+++ b/mRemoteNG/Connection/ConnectionsService.cs
@@ -152,6 +152,8 @@ namespace mRemoteNG.Connection
 
             IsConnectionsFileLoaded = true;
             ConnectionFileName = connectionFileName;
+            Properties.OptionsConnectionsPage.Default.ConnectionFilePath = connectionFileName;
+
             UsingDatabase = useDatabase;
 
             if (!import)
@@ -308,9 +310,9 @@ namespace mRemoteNG.Connection
                 return GetDefaultStartupConnectionFileName();
             }
             */
-            if (Properties.OptionsConnectionsPage.Default.ConnectrionFilePath != "")
+            if (Properties.OptionsConnectionsPage.Default.ConnectionFilePath != "")
             {
-                return Properties.OptionsConnectionsPage.Default.ConnectrionFilePath;
+                return Properties.OptionsConnectionsPage.Default.ConnectionFilePath;
             }
             else
             {

--- a/mRemoteNG/Properties/OptionsConnectionsPage.Designer.cs
+++ b/mRemoteNG/Properties/OptionsConnectionsPage.Designer.cs
@@ -38,12 +38,12 @@ namespace mRemoteNG.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string ConnectrionFilePath {
+        public string ConnectionFilePath {
             get {
-                return ((string)(this["ConnectrionFilePath"]));
+                return ((string)(this["ConnectionFilePath"]));
             }
             set {
-                this["ConnectrionFilePath"] = value;
+                this["ConnectionFilePath"] = value;
             }
         }
         

--- a/mRemoteNG/Properties/OptionsConnectionsPage.settings
+++ b/mRemoteNG/Properties/OptionsConnectionsPage.settings
@@ -5,7 +5,7 @@
     <Setting Name="AutoSaveEveryMinutes" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
-    <Setting Name="ConnectrionFilePath" Type="System.String" Scope="User">
+    <Setting Name="ConnectionFilePath" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="cbConnectionsPageInOptionMenu" Type="System.Boolean" Scope="User">


### PR DESCRIPTION
## Description
When you open a connection file other than the default and exit the application, the opened file was not remembered, opening the default file again on the next start.

Looks like this was broken with the commenting out of:

https://github.com/mRemoteNG/mRemoteNG/blob/49a1549e5a3846c025daba5bc45c3004cb52230a/mRemoteNG/Connection/ConnectionsService.cs#L301-L310

## Motivation and Context
It has always worked the way as described: once you've opened a connection file, that file was remembered.

## How Has This Been Tested?
1. Open a connection file.
2. Close the application.
3. Launch the application.
4. Verify the previously opened connection file is opened.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing - they don't build, see #2592
- [x] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
