### PR TITLE
Fix for #2592 compiler issue

### DIFF
--- a/mRemoteNGTests/App/UpdaterTests.cs
+++ b/mRemoteNGTests/App/UpdaterTests.cs
@@ -9,75 +9,59 @@ namespace mRemoteNGTests.App;
 [TestFixture]
 public class UpdaterTests
 {
+    private readonly Version TestApplicationVersion = new("1.0.0.0");
+
     [Test]
     public void UpdateStableChannel()
     {
-        GeneralAppInfo.ApplicationVersion = "1.0.0.0";
         var CurrentUpdateInfo = UpdateInfo.FromString(Resources.update);
         Assert.That(CurrentUpdateInfo.CheckIfValid(), Is.True);
-        Version v;
-        Version.TryParse(GeneralAppInfo.ApplicationVersion, out v);
-        var IsNewer = CurrentUpdateInfo.Version > v;
+        bool IsNewer = CurrentUpdateInfo.Version > TestApplicationVersion;
         Assert.That(IsNewer, Is.True);
     }
 
     [Test]
     public void UpdateBetaChannel()
     {
-        GeneralAppInfo.ApplicationVersion = "1.0.0.0";
         var CurrentUpdateInfo = UpdateInfo.FromString(Resources.beta_update);
         Assert.That(CurrentUpdateInfo.CheckIfValid(), Is.True);
-        Version v;
-        Version.TryParse(GeneralAppInfo.ApplicationVersion, out v);
-        var IsNewer = CurrentUpdateInfo.Version > v;
+        bool IsNewer = CurrentUpdateInfo.Version > TestApplicationVersion;
         Assert.That(IsNewer, Is.True);
     }
 
     [Test]
     public void UpdateDevChannel()
     {
-        GeneralAppInfo.ApplicationVersion = "1.0.0.0";
         var CurrentUpdateInfo = UpdateInfo.FromString(Resources.dev_update);
         Assert.That(CurrentUpdateInfo.CheckIfValid(), Is.True);
-        Version v;
-        Version.TryParse(GeneralAppInfo.ApplicationVersion, out v);
-        var IsNewer = CurrentUpdateInfo.Version > v;
+        bool IsNewer = CurrentUpdateInfo.Version > TestApplicationVersion;
         Assert.That(IsNewer, Is.True);
     }
 
     [Test]
     public void UpdateStablePortableChannel()
     {
-        GeneralAppInfo.ApplicationVersion = "1.0.0.0";
         var CurrentUpdateInfo = UpdateInfo.FromString(Resources.update_portable);
         Assert.That(CurrentUpdateInfo.CheckIfValid(), Is.True);
-        Version v;
-        Version.TryParse(GeneralAppInfo.ApplicationVersion, out v);
-        var IsNewer = CurrentUpdateInfo.Version > v;
+        bool IsNewer = CurrentUpdateInfo.Version > TestApplicationVersion;
         Assert.That(IsNewer, Is.True);
     }
 
     [Test]
     public void UpdateBetaPortableChannel()
     {
-        GeneralAppInfo.ApplicationVersion = "1.0.0.0";
         var CurrentUpdateInfo = UpdateInfo.FromString(Resources.beta_update_portable);
         Assert.That(CurrentUpdateInfo.CheckIfValid(), Is.True);
-        Version v;
-        Version.TryParse(GeneralAppInfo.ApplicationVersion, out v);
-        var IsNewer = CurrentUpdateInfo.Version > v;
+        bool IsNewer = CurrentUpdateInfo.Version > TestApplicationVersion;
         Assert.That(IsNewer, Is.True);
     }
 
     [Test]
     public void UpdateDevPortableChannel()
     {
-        GeneralAppInfo.ApplicationVersion = "1.0.0.0";
         var CurrentUpdateInfo = UpdateInfo.FromString(Resources.dev_update_portable);
         Assert.That(CurrentUpdateInfo.CheckIfValid(), Is.True);
-        Version v;
-        Version.TryParse(GeneralAppInfo.ApplicationVersion, out v);
-        var IsNewer = CurrentUpdateInfo.Version > v;
+        bool IsNewer = CurrentUpdateInfo.Version > TestApplicationVersion;
         Assert.That(IsNewer, Is.True);
     }
 }


### PR DESCRIPTION
Fix for #2592

## Description
Fixed compilation issues in unit tests caused by attempting to change GeneralAppInfo.ApplicationVersion. Setting the version to 1.0.0.0 is unnecessary for comparison, which can be done using a private version attribute.

## Motivation and Context


## How Has This Been Tested?
Test are running succesfull.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
