### PR TITLE
Issue 2630

### DIFF
--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsDeserializerMremotengFormat.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsDeserializerMremotengFormat.cs
@@ -113,8 +113,8 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Csv
                 : "";
 
             connectionRecord.Password = headers.Contains("Password")
-                ? connectionCsv[headers.IndexOf("Password")].ConvertToSecureString()
-                : "".ConvertToSecureString();
+                ? connectionCsv[headers.IndexOf("Password")] : "";
+
 
             connectionRecord.Domain = headers.Contains("Domain")
                 ? connectionCsv[headers.IndexOf("Domain")]

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsSerializerMremotengFormat.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsSerializerMremotengFormat.cs
@@ -112,8 +112,8 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Csv
                 sb.Append(FormatForCsv(con.Username));
 
             if (_saveFilter.SavePassword)
-                sb.Append(con.Password?.ConvertToUnsecureString() + ";");
-
+                sb.Append(con.GetPlaintextPassword() + ";");
+            
             if (_saveFilter.SaveDomain)
                 sb.Append(FormatForCsv(con.Domain));
 

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/RemoteDesktopManager/CsvConnectionsDeserializerRdmFormat.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/RemoteDesktopManager/CsvConnectionsDeserializerRdmFormat.cs
@@ -131,7 +131,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Csv.RemoteDesktopMa
                 Hostname = hostString,
                 Port = port,
                 Username = username,
-                Password = password?.ConvertToSecureString(),
+                Password = password,
                 Domain = domain,
                 Icon = connectionType.IconName ?? "mRemoteNG",
                 Description = description,

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Sql/DataTableDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Sql/DataTableDeserializer.cs
@@ -113,7 +113,8 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Sql
             connectionInfo.OpeningCommand = (string)dataRow["OpeningCommand"];
             connectionInfo.Panel = (string)dataRow["Panel"];
             var pw = dataRow["Password"] as string;
-            connectionInfo.Password = DecryptValue(pw ?? "").ConvertToSecureString();
+            //connectionInfo.Password = DecryptValue(pw ?? "");
+            connectionInfo.SetPasswordFromSecureString(DecryptValue(pw ?? ""));
             connectionInfo.Port = (int)dataRow["Port"];
             connectionInfo.PostExtApp = (string)dataRow["PostExtApp"];
             connectionInfo.PreExtApp = (string)dataRow["PreExtApp"];
@@ -121,7 +122,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Sql
             connectionInfo.PuttySession = (string)dataRow["PuttySession"];
             connectionInfo.RDGatewayDomain = (string)dataRow["RDGatewayDomain"];
             connectionInfo.RDGatewayHostname = (string)dataRow["RDGatewayHostname"];
-            connectionInfo.RDGatewayPassword = DecryptValue((string)dataRow["RDGatewayPassword"]);
+            connectionInfo.RDGatewayPassword = DecryptValue((string)dataRow["RDGatewayPassword"]).ConvertToUnsecureString();
             connectionInfo.RDGatewayUsageMethod = (RDGatewayUsageMethod)Enum.Parse(typeof(RDGatewayUsageMethod), (string)dataRow["RDGatewayUsageMethod"]);
             connectionInfo.RDGatewayUseConnectionCredentials = (RDGatewayUseConnectionCredentials)Enum.Parse(typeof(RDGatewayUseConnectionCredentials), (string)dataRow["RDGatewayUseConnectionCredentials"]);
             connectionInfo.RDGatewayUsername = (string)dataRow["RDGatewayUsername"];
@@ -158,7 +159,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Sql
             connectionInfo.VNCCompression = (ProtocolVNC.Compression)Enum.Parse(typeof(ProtocolVNC.Compression), (string)dataRow["VNCCompression"]);
             connectionInfo.VNCEncoding = (ProtocolVNC.Encoding)Enum.Parse(typeof(ProtocolVNC.Encoding), (string)dataRow["VNCEncoding"]);
             connectionInfo.VNCProxyIP = (string)dataRow["VNCProxyIP"];
-            connectionInfo.VNCProxyPassword = DecryptValue((string)dataRow["VNCProxyPassword"]);
+            connectionInfo.VNCProxyPassword = DecryptValue((string)dataRow["VNCProxyPassword"]).ConvertToUnsecureString();
             connectionInfo.VNCProxyPort = (int)dataRow["VNCProxyPort"];
             connectionInfo.VNCProxyType = (ProtocolVNC.ProxyType)Enum.Parse(typeof(ProtocolVNC.ProxyType), (string)dataRow["VNCProxyType"]);
             connectionInfo.VNCProxyUsername = (string)dataRow["VNCProxyUsername"];
@@ -245,16 +246,16 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Sql
             connectionInfo.Inheritance.VNCViewOnly = MiscTools.GetBooleanValue(dataRow["InheritVNCViewOnly"]);
         }
 
-        private string DecryptValue(string cipherText)
+        private SecureString DecryptValue(string cipherText)
         {
             try
             {
-                return _cryptographyProvider.Decrypt(cipherText, _decryptionKey);
+                return _cryptographyProvider.DecryptSecure(cipherText, _decryptionKey);
             }
             catch (EncryptionException)
             {
                 // value may not be encrypted
-                return cipherText;
+                return cipherText.ConvertToSecureString();
             }
         }
 

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Sql/DataTableSerializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Sql/DataTableSerializer.cs
@@ -519,7 +519,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Sql
                     dataRow["InheritVNCViewOnly"].Equals(false);
             }
 
-            bool pwd = dataRow["Password"].Equals(_saveFilter.SavePassword ? _cryptographyProvider.Encrypt(connectionInfo.Password?.ConvertToUnsecureString(), _encryptionKey) : "") &&
+            bool pwd = dataRow["Password"].Equals(_saveFilter.SavePassword ? _cryptographyProvider.Encrypt(connectionInfo.GetPassword(), _encryptionKey) : "") &&
                       dataRow["VNCProxyPassword"].Equals(_cryptographyProvider.Encrypt(connectionInfo.VNCProxyPassword, _encryptionKey)) &&
                       dataRow["RDGatewayPassword"].Equals(_cryptographyProvider.Encrypt(connectionInfo.RDGatewayPassword, _encryptionKey));
             return !(pwd && isFieldNotChange && isInheritanceFieldNotChange);
@@ -575,7 +575,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Sql
             dataRow["OpeningCommand"] = connectionInfo.OpeningCommand;
             dataRow["Panel"] = connectionInfo.Panel;
             dataRow["ParentID"] = connectionInfo.Parent?.ConstantID ?? "";
-            dataRow["Password"] = _saveFilter.SavePassword ? _cryptographyProvider.Encrypt(connectionInfo.Password?.ConvertToUnsecureString(), _encryptionKey) : "";
+            dataRow["Password"] = _saveFilter.SavePassword ? _cryptographyProvider.Encrypt(connectionInfo.GetPassword(), _encryptionKey) : "";
             dataRow["Port"] = connectionInfo.Port;
             dataRow["PositionID"] = _currentNodeIndex;
             dataRow["PostExtApp"] = connectionInfo.PostExtApp;

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer26.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer26.cs
@@ -61,7 +61,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
                 : new XAttribute("Domain", ""));
 
             if (_saveFilter.SavePassword && !connectionInfo.Inheritance.Password)
-                element.Add(new XAttribute("Password", _cryptographyProvider.Encrypt(connectionInfo.Password.ConvertToUnsecureString(), _encryptionKey)));
+                element.Add(new XAttribute("Password", _cryptographyProvider.Encrypt(connectionInfo.GetPassword(), _encryptionKey)));
             else
                 element.Add(new XAttribute("Password", ""));
 

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer27.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer27.cs
@@ -62,7 +62,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
                     : new XAttribute("Domain", ""));
 
                 if (_saveFilter.SavePassword && !connectionInfo.Inheritance.Password)
-                    element.Add(new XAttribute("Password", _cryptographyProvider.Encrypt(connectionInfo.Password.ConvertToUnsecureString(), _encryptionKey)));
+                    element.Add(new XAttribute("Password", _cryptographyProvider.Encrypt(connectionInfo.GetPassword(), _encryptionKey)));
                 else
                     element.Add(new XAttribute("Password", ""));
             }

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer28.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer28.cs
@@ -62,7 +62,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
                     : new XAttribute("Domain", ""));
 
                 if (_saveFilter.SavePassword && !connectionInfo.Inheritance.Password)
-                    element.Add(new XAttribute("Password", _cryptographyProvider.Encrypt(connectionInfo.Password?.ConvertToUnsecureString(), _encryptionKey)));
+                    element.Add(new XAttribute("Password", _cryptographyProvider.Encrypt(connectionInfo.GetPassword(), _encryptionKey)));
                 else
                     element.Add(new XAttribute("Password", ""));
             }

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
@@ -68,7 +68,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
                     bool fullFileEncryptionValue = rootXmlElement.GetAttributeAsBool("FullFileEncryption");
                     if (fullFileEncryptionValue)
                     {
-                        string decryptedContent = _decryptor.Decrypt(rootXmlElement.InnerText);
+                        string decryptedContent = _decryptor.DecryptUnsecure(rootXmlElement.InnerText);
                         rootXmlElement.InnerXml = decryptedContent;
                     }
                 }
@@ -218,7 +218,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
                     {
                         connectionInfo.Username = xmlnode.GetAttributeAsString("Username");
                         //connectionInfo.Password = _decryptor.Decrypt(xmlnode.GetAttributeAsString("Password"));
-                        connectionInfo.Password = _decryptor.Decrypt(xmlnode.GetAttributeAsString("Password")).ConvertToSecureString();
+                        connectionInfo.SetPasswordFromSecureString(_decryptor.Decrypt(xmlnode.GetAttributeAsString("Password")));
                         connectionInfo.Domain = xmlnode.GetAttributeAsString("Domain");
                     }
                 }
@@ -382,7 +382,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
                     connectionInfo.VNCProxyIP = xmlnode.GetAttributeAsString("VNCProxyIP");
                     connectionInfo.VNCProxyPort = xmlnode.GetAttributeAsInt("VNCProxyPort");
                     connectionInfo.VNCProxyUsername = xmlnode.GetAttributeAsString("VNCProxyUsername");
-                    connectionInfo.VNCProxyPassword = _decryptor.Decrypt(xmlnode.GetAttributeAsString("VNCProxyPassword"));
+                    connectionInfo.VNCProxyPassword = _decryptor.DecryptUnsecure(xmlnode.GetAttributeAsString("VNCProxyPassword"));
                     connectionInfo.VNCColors = xmlnode.GetAttributeAsEnum<ProtocolVNC.Colors>("VNCColors");
                     connectionInfo.VNCSmartSizeMode = xmlnode.GetAttributeAsEnum<ProtocolVNC.SmartSizeMode>("VNCSmartSizeMode");
                     connectionInfo.VNCViewOnly = xmlnode.GetAttributeAsBool("VNCViewOnly");
@@ -432,7 +432,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
                     connectionInfo.RDGatewayHostname = xmlnode.GetAttributeAsString("RDGatewayHostname");
                     connectionInfo.RDGatewayUseConnectionCredentials = xmlnode.GetAttributeAsEnum<RDGatewayUseConnectionCredentials>("RDGatewayUseConnectionCredentials");
                     connectionInfo.RDGatewayUsername = xmlnode.GetAttributeAsString("RDGatewayUsername");
-                    connectionInfo.RDGatewayPassword = _decryptor.Decrypt(xmlnode.GetAttributeAsString("RDGatewayPassword"));
+                    connectionInfo.RDGatewayPassword = _decryptor.DecryptUnsecure(xmlnode.GetAttributeAsString("RDGatewayPassword"));
                     connectionInfo.RDGatewayDomain = xmlnode.GetAttributeAsString("RDGatewayDomain");
 
                     // Get inheritance settings

--- a/mRemoteNG/Config/Serializers/MiscSerializers/PuttyConnectionManagerDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/MiscSerializers/PuttyConnectionManagerDeserializer.cs
@@ -134,7 +134,7 @@ namespace mRemoteNG.Config.Serializers.MiscSerializers
 
             XmlNode loginNode = xmlNode.SelectSingleNode("./login");
             connectionInfo.Username = loginNode?.SelectSingleNode("login")?.InnerText;
-            connectionInfo.Password = loginNode?.SelectSingleNode("password")?.InnerText.ConvertToSecureString();
+            connectionInfo.Password = loginNode?.SelectSingleNode("password")?.InnerText;
             // ./prompt
 
             // ./timeout/connectiontimeout

--- a/mRemoteNG/Config/Serializers/MiscSerializers/RemoteDesktopConnectionManagerDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/MiscSerializers/RemoteDesktopConnectionManagerDeserializer.cs
@@ -164,12 +164,12 @@ namespace mRemoteNG.Config.Serializers.MiscSerializers
                 if (_schemaVersion == 1) // Version 2.2 allows clear text passwords
                 {
                     connectionInfo.Password = passwordNode?.Attributes?["storeAsClearText"]?.Value == "True"
-                        ? passwordNode.InnerText.ConvertToSecureString()
-                        : DecryptRdcManPassword(passwordNode?.InnerText).ConvertToSecureString();
+                        ? passwordNode.InnerText
+                        : DecryptRdcManPassword(passwordNode?.InnerText);
                 }
                 else
                 {
-                    connectionInfo.Password = DecryptRdcManPassword(passwordNode?.InnerText).ConvertToSecureString();
+                    connectionInfo.Password = DecryptRdcManPassword(passwordNode?.InnerText);
                 }
 
                 connectionInfo.Domain = logonCredentialsNode.SelectSingleNode("./domain")?.InnerText ?? string.Empty;

--- a/mRemoteNG/Config/Serializers/XmlConnectionsDecryptor.cs
+++ b/mRemoteNG/Config/Serializers/XmlConnectionsDecryptor.cs
@@ -37,12 +37,20 @@ namespace mRemoteNG.Config.Serializers
             _rootNodeInfo = rootNodeInfo;
         }
 
-        public string Decrypt(string plainText)
+        public SecureString Decrypt(string plainText)
+        {
+            return plainText == ""
+                ? "".ConvertToSecureString()
+                : _cryptographyProvider.Decrypt(plainText, _rootNodeInfo.PasswordString.ConvertToSecureString()).ConvertToSecureString();
+        }
+
+        public string DecryptUnsecure(string plainText)
         {
             return plainText == ""
                 ? ""
                 : _cryptographyProvider.Decrypt(plainText, _rootNodeInfo.PasswordString.ConvertToSecureString());
         }
+
 
         public string LegacyFullFileDecrypt(string xml)
         {

--- a/mRemoteNG/Connection/AbstractConnectionRecord.cs
+++ b/mRemoteNG/Connection/AbstractConnectionRecord.cs
@@ -10,6 +10,7 @@ using mRemoteNG.Tools.Attributes;
 using mRemoteNG.Resources.Language;
 using System.Runtime.Versioning;
 using System.Security;
+using mRemoteNG.Security;
 
 namespace mRemoteNG.Connection
 {
@@ -214,10 +215,34 @@ namespace mRemoteNG.Connection
          LocalizedAttributes.LocalizedDescription(nameof(Language.PropertyDescriptionPassword)),
          PasswordPropertyText(true),
          AttributeUsedInAllProtocolsExcept(ProtocolType.Telnet, ProtocolType.Rlogin, ProtocolType.RAW)]
-        public virtual SecureString Password
+        public virtual string Password
         {
-            get => GetPropertyValue("Password", _password);
-            set => SetField(ref _password, value, "Password");
+            get
+            {
+                // ensure the UI shows that a password has been entered
+                return "defaultpassword";
+            }
+            set
+            {
+                // immediately convert a password held in an insecure string to a SecureString
+                SetPasswordFromSecureString(value.ConvertToSecureString());
+                value = string.Empty;
+            }
+        }
+
+        public string GetPlaintextPassword()
+        {
+            if (_password != null)
+                return _password.ConvertToUnsecureString();
+            return string.Empty;
+        }
+
+        public SecureString GetPassword() { return _password; }
+
+        public void SetPasswordFromSecureString(SecureString securePassword)
+        {
+            this._password = securePassword;
+            RaisePropertyChangedEvent(this, new PropertyChangedEventArgs("Password"));
         }
 
         [LocalizedAttributes.LocalizedCategory(nameof(Language.Connection), 2),

--- a/mRemoteNG/Connection/AbstractConnectionRecord.cs
+++ b/mRemoteNG/Connection/AbstractConnectionRecord.cs
@@ -220,7 +220,7 @@ namespace mRemoteNG.Connection
             get
             {
                 // ensure the UI shows that a password has been entered
-                return "defaultpassword";
+                return "ThisPasswordIsNeverUseful_useGetPasswordInstead";
             }
             set
             {
@@ -230,6 +230,10 @@ namespace mRemoteNG.Connection
             }
         }
 
+        /// <summary>
+        /// Access the plaintext password field. Only use this at the point of connection, or for unit tests.
+        /// </summary>
+        /// <returns>The plaintext password not stored in a SecureString</returns>
         public string GetPlaintextPassword()
         {
             if (_password != null)

--- a/mRemoteNG/Connection/Protocol/PowerShell/Connection.Protocol.PowerShell.cs
+++ b/mRemoteNG/Connection/Protocol/PowerShell/Connection.Protocol.PowerShell.cs
@@ -188,7 +188,7 @@ namespace mRemoteNG.Connection.Protocol.PowerShell
 
                 // Setup process for script with arguments
                 //* The -NoProfile parameter would be a valuable addition but should be able to be deactivated.
-                string arguments = $@"-NoExit -Command ""& {{ {psScriptBlock} }}"" -Hostname ""'{_connectionInfo.Hostname}'"" -Username ""'{psUsername}'"" -Password ""'{_connectionInfo.Password}'"" -LoginAttempts {psLoginAttempts}";
+                string arguments = $@"-NoExit -Command ""& {{ {psScriptBlock} }}"" -Hostname ""'{_connectionInfo.Hostname}'"" -Username ""'{psUsername}'"" -Password ""'{_connectionInfo.GetPlaintextPassword()}'"" -LoginAttempts {psLoginAttempts}";
                 string hostname = _connectionInfo.Hostname.Trim().ToLower();
                 bool useLocalHost = hostname == "" || hostname.Equals("localhost");
                 if (useLocalHost)

--- a/mRemoteNG/Connection/Protocol/PuttyBase.cs
+++ b/mRemoteNG/Connection/Protocol/PuttyBase.cs
@@ -102,7 +102,7 @@ namespace mRemoteNG.Connection.Protocol
                     {
 
                         string username = InterfaceControl.Info?.Username ?? "";
-                        string password = InterfaceControl.Info?.Password.ConvertToUnsecureString() ?? "";
+                        string password = InterfaceControl.Info?.GetPlaintextPassword() ?? "";
                         string domain = InterfaceControl.Info?.Domain ?? "";
                         string UserViaAPI = InterfaceControl.Info?.UserViaAPI ?? "";
                         string privatekey = "";

--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs
@@ -426,7 +426,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
                 {
                     case RDGatewayUseConnectionCredentials.Yes:
                         _rdpClient.TransportSettings2.GatewayUsername = connectionInfo.Username;
-                        _rdpClient.TransportSettings2.GatewayPassword = connectionInfo.Password.ConvertToUnsecureString();
+                        _rdpClient.TransportSettings2.GatewayPassword = connectionInfo.GetPlaintextPassword();
                         _rdpClient.TransportSettings2.GatewayDomain = connectionInfo?.Domain;
                         break;
                     case RDGatewayUseConnectionCredentials.SmartCard:
@@ -540,7 +540,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
                 string domain = connectionInfo?.Domain ?? "";
                 string userViaApi = connectionInfo?.UserViaAPI ?? "";
                 string pkey = "";
-                string password = (connectionInfo?.Password?.ConvertToUnsecureString() ?? "");
+                string password = (connectionInfo?.GetPlaintextPassword() ?? "");
 
                 // access secret server api if necessary
                 if (InterfaceControl.Info.ExternalCredentialProvider == ExternalCredentialProvider.DelineaSecretServer)

--- a/mRemoteNG/Connection/Protocol/VNC/Connection.Protocol.VNC.cs
+++ b/mRemoteNG/Connection/Protocol/VNC/Connection.Protocol.VNC.cs
@@ -146,7 +146,7 @@ namespace mRemoteNG.Connection.Protocol.VNC
                 _vnc.ConnectComplete += VNCEvent_Connected;
                 _vnc.ConnectionLost += VNCEvent_Disconnected;
                 FrmMain.ClipboardChanged += VNCEvent_ClipboardChanged;
-                if (!Force.HasFlag(ConnectionInfo.Force.NoCredentials) && _info?.Password?.Length > 0)
+                if (!Force.HasFlag(ConnectionInfo.Force.NoCredentials) && _info?.GetPassword()?.Length > 0)
                 {
                     _vnc.GetPassword = VNCEvent_Authenticate;
                 }
@@ -226,7 +226,7 @@ namespace mRemoteNG.Connection.Protocol.VNC
 
         private string VNCEvent_Authenticate()
         {
-            return _info.Password.ConvertToUnsecureString();
+            return _info.GetPlaintextPassword();
         }
 
         #endregion

--- a/mRemoteNG/Connection/PuttySessionInfo.cs
+++ b/mRemoteNG/Connection/PuttySessionInfo.cs
@@ -43,7 +43,7 @@ namespace mRemoteNG.Connection
 
         [ReadOnly(true)] public override string Username { get; set; }
 
-        [ReadOnly(true), Browsable(false)] public override SecureString Password { get; set; }
+        [ReadOnly(true), Browsable(false)] public override string Password { get; set; }
 
         [ReadOnly(true)] public override ProtocolType Protocol { get; set; }
 

--- a/mRemoteNG/Properties/AssemblyInfo.cs
+++ b/mRemoteNG/Properties/AssemblyInfo.cs
@@ -18,10 +18,10 @@ using System.Resources;
 [assembly: AssemblyCulture("")]
 
 // Version information
-[assembly: AssemblyVersion("1.77.3.2591")]
-[assembly: AssemblyFileVersion("1.77.3.2591")]
+[assembly: AssemblyVersion("1.77.3.2611")]
+[assembly: AssemblyFileVersion("1.77.3.2611")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]
-[assembly: AssemblyInformationalVersion("1.77.3 (Nightly Build 2591)")]
+[assembly: AssemblyInformationalVersion("1.77.3 (Nightly Build 2611)")]
 
 // Logging
 [assembly: log4net.Config.XmlConfigurator(ConfigFile = "log4net.config")]

--- a/mRemoteNG/Security/ICryptographyProvider.cs
+++ b/mRemoteNG/Security/ICryptographyProvider.cs
@@ -13,7 +13,10 @@ namespace mRemoteNG.Security
         int KeyDerivationIterations { get; set; }
 
         string Encrypt(string plainText, SecureString encryptionKey);
+        string Encrypt(SecureString plainText, SecureString encryptionKey);
 
         string Decrypt(string cipherText, SecureString decryptionKey);
+
+        SecureString DecryptSecure(string cipherText, SecureString decryptionKey);
     }
 }

--- a/mRemoteNG/Security/SymmetricEncryption/AeadCryptographyProvider.cs
+++ b/mRemoteNG/Security/SymmetricEncryption/AeadCryptographyProvider.cs
@@ -96,16 +96,21 @@ namespace mRemoteNG.Security.SymmetricEncryption
 
         public string Encrypt(string plainText, SecureString encryptionKey)
         {
+            return Encrypt(plainText.ConvertToSecureString(), encryptionKey);
+        }
+
+        public string Encrypt(SecureString plainText, SecureString encryptionKey)
+        {
             string encryptedText = SimpleEncryptWithPassword(plainText, encryptionKey.ConvertToUnsecureString());
             return encryptedText;
         }
 
-        private string SimpleEncryptWithPassword(string secretMessage, string password, byte[] nonSecretPayload = null)
+        private string SimpleEncryptWithPassword(SecureString secretMessage, string password, byte[] nonSecretPayload = null)
         {
-            if (string.IsNullOrEmpty(secretMessage))
+            if (secretMessage == null || secretMessage.Length == 0)
                 return ""; //throw new ArgumentException(@"Secret Message Required!", nameof(secretMessage));
 
-            byte[] plainText = _encoding.GetBytes(secretMessage);
+            byte[] plainText = _encoding.GetBytes(secretMessage.ConvertToUnsecureString());
             byte[] cipherText = SimpleEncryptWithPassword(plainText, password, nonSecretPayload);
             return Convert.ToBase64String(cipherText);
         }
@@ -257,5 +262,12 @@ namespace mRemoteNG.Security.SymmetricEncryption
             _random.NextBytes(salt);
             return salt;
         }
+
+        public SecureString DecryptSecure(string cipherText, SecureString decryptionKey)
+        {
+            return Decrypt(cipherText, decryptionKey).ConvertToSecureString();
+        }
+
+
     }
 }

--- a/mRemoteNG/Security/SymmetricEncryption/LegacyRijndaelCryptographyProvider.cs
+++ b/mRemoteNG/Security/SymmetricEncryption/LegacyRijndaelCryptographyProvider.cs
@@ -26,10 +26,10 @@ namespace mRemoteNG.Security.SymmetricEncryption
             BlockSizeInBytes = 16;
         }
 
-        public string Encrypt(string strToEncrypt, SecureString strSecret)
+        public string Encrypt(SecureString strToEncrypt, SecureString strSecret)
         {
-            if (string.IsNullOrWhiteSpace(strToEncrypt) || strSecret.Length == 0)
-                return strToEncrypt;
+            if (strToEncrypt == null || strToEncrypt.Length == 0)
+                return string.Empty;
 
             try
             {
@@ -47,7 +47,7 @@ namespace mRemoteNG.Security.SymmetricEncryption
                 ms.Write(aes.IV, 0, BlockSizeInBytes);
 
                 using CryptoStream cs = new(ms, aes.CreateEncryptor(), CryptoStreamMode.Write);
-                byte[] data = Encoding.UTF8.GetBytes(strToEncrypt);
+                byte[] data = Encoding.UTF8.GetBytes(strToEncrypt.ConvertToUnsecureString());
 
                 cs.Write(data, 0, data.Length);
                 cs.FlushFinalBlock();
@@ -61,7 +61,7 @@ namespace mRemoteNG.Security.SymmetricEncryption
                 Runtime.MessageCollector.AddMessage(MessageClass.ErrorMsg, string.Format(Language.ErrorEncryptionFailed, ex.Message));
             }
 
-            return strToEncrypt;
+            return string.Empty;
         }
 
         public string Decrypt(string ciphertextBase64, SecureString password)
@@ -99,6 +99,16 @@ namespace mRemoteNG.Security.SymmetricEncryption
                 //Runtime.MessageCollector.AddMessage(MessageClass.ErrorMsg, string.Format(Language.ErrorDecryptionFailed, ex.Message));
                 throw new EncryptionException(Language.ErrorDecryptionFailed, ex);
             }
+        }
+
+        public SecureString DecryptSecure(string cipherText, SecureString decryptionKey)
+        {
+            return Decrypt(cipherText, decryptionKey).ConvertToSecureString();
+        }
+
+        public string Encrypt(string plainText, SecureString encryptionKey)
+        {
+            return Encrypt(plainText.ConvertToSecureString(), encryptionKey);
         }
     }
 }

--- a/mRemoteNG/Tools/ExternalToolArgumentParser.cs
+++ b/mRemoteNG/Tools/ExternalToolArgumentParser.cs
@@ -187,7 +187,7 @@ namespace mRemoteNG.Tools
                             replacement = Properties.OptionsCredentialsPage.Default.DefaultUsername;
                     break;
                 case "password":
-                    replacement = _connectionInfo.Password.ConvertToUnsecureString();
+                    replacement = _connectionInfo.GetPlaintextPassword();
                     if (string.IsNullOrEmpty(replacement) && Properties.OptionsCredentialsPage.Default.EmptyCredentials == "custom")
                         replacement = new LegacyRijndaelCryptographyProvider().Decrypt(Convert.ToString(Properties.OptionsCredentialsPage.Default.DefaultPassword), Runtime.EncryptionKey);
                     break;

--- a/mRemoteNG/UI/Controls/ConnectionContextMenu.cs
+++ b/mRemoteNG/UI/Controls/ConnectionContextMenu.cs
@@ -833,7 +833,7 @@ namespace mRemoteNG.UI.Controls
                 Windows.Show(WindowType.SSHTransfer);
                 Windows.SshtransferForm.Hostname = _connectionTree.SelectedNode.Hostname;
                 Windows.SshtransferForm.Username = _connectionTree.SelectedNode.Username;
-                Windows.SshtransferForm.Password = _connectionTree.SelectedNode.Password.ConvertToUnsecureString();
+                Windows.SshtransferForm.Password = _connectionTree.SelectedNode.GetPlaintextPassword();
                 Windows.SshtransferForm.Port = Convert.ToString(_connectionTree.SelectedNode.Port);
             }
             catch (Exception ex)

--- a/mRemoteNG/UI/Window/ConnectionWindow.cs
+++ b/mRemoteNG/UI/Window/ConnectionWindow.cs
@@ -470,7 +470,7 @@ namespace mRemoteNG.UI.Window
 
                 Windows.SshtransferForm.Hostname = connectionInfo.Hostname;
                 Windows.SshtransferForm.Username = connectionInfo.Username;
-                Windows.SshtransferForm.Password = connectionInfo.Password.ConvertToUnsecureString();
+                Windows.SshtransferForm.Password = connectionInfo.GetPlaintextPassword();
                 Windows.SshtransferForm.Port = Convert.ToString(connectionInfo.Port);
             }
             catch (Exception ex)

--- a/mRemoteNGTests/Config/CredentialHarvesterTests.cs
+++ b/mRemoteNGTests/Config/CredentialHarvesterTests.cs
@@ -19,7 +19,7 @@ public class CredentialHarvesterTests
     private CredentialHarvester _credentialHarvester;
     private ICryptographyProvider _cryptographyProvider;
     private SecureString _key;
-    private SecureString _password = "mypass".ConvertToSecureString();
+    private string _password = "mypass";
     [SetUp]
     public void Setup()
     {
@@ -52,7 +52,8 @@ public class CredentialHarvesterTests
         var connection = new ConnectionInfo { Username = "myuser", Domain = "somedomain", Password = _password };
         var xdoc = CreateTestData(connection);
         var credentials = _credentialHarvester.Harvest(xdoc, _key);
-        Assert.That(credentials.Single().Password.ConvertToUnsecureString(), Is.EqualTo(connection.Password.ConvertToUnsecureString()));
+        //Assert.That(credentials.Single().Password.ConvertToUnsecureString(), Is.EqualTo(connection.Password.ConvertToUnsecureString()));
+        Assert.That(credentials.Single().Password.ConvertToUnsecureString(), Is.EqualTo(connection.GetPlaintextPassword()));
     }
 
     [Test]

--- a/mRemoteNGTests/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsDeserializerMremotengFormatTests.cs
+++ b/mRemoteNGTests/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsDeserializerMremotengFormatTests.cs
@@ -73,7 +73,7 @@ namespace mRemoteNGTests.Config.Serializers.ConnectionSerializers.Csv
                 Icon = "SomeIcon",
                 Panel = "SomePanel",
                 Username = "SomeUsername",
-                Password = "SomePassword".ConvertToSecureString(),
+                Password = "SomePassword",
                 Domain = "SomeDomain",
                 Hostname = "SomeHostname",
                 PuttySession = "SomePuttySession",

--- a/mRemoteNGTests/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsSerializerMremotengFormatTests.cs
+++ b/mRemoteNGTests/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsSerializerMremotengFormatTests.cs
@@ -113,7 +113,7 @@ public class CsvConnectionsSerializerMremotengFormatTests
         Assert.That(csv, Does.Match(container.Name));
         Assert.That(csv, Does.Match(container.Username));
         Assert.That(csv, Does.Match(container.Domain));
-        Assert.That(csv, Does.Match(container.Password?.ConvertToUnsecureString()));
+        Assert.That(csv, Does.Match(container.GetPlaintextPassword()));
         Assert.That(csv, Does.Contain(TreeNodeType.Container.ToString()));
     }
 
@@ -128,7 +128,7 @@ public class CsvConnectionsSerializerMremotengFormatTests
             .First(s => s.Contains(serializationTarget.Name));
         Assert.That(lineWithFolder3, Does.Contain(serializationTarget.Username));
         Assert.That(lineWithFolder3, Does.Contain(serializationTarget.Domain));
-        Assert.That(lineWithFolder3, Does.Contain(serializationTarget.Password?.ConvertToUnsecureString()));
+        Assert.That(lineWithFolder3, Does.Contain(serializationTarget.GetPlaintextPassword()));
     }
 
     private ConnectionInfo BuildConnectionInfo()
@@ -138,7 +138,7 @@ public class CsvConnectionsSerializerMremotengFormatTests
             Name = ConnectionName,
             Username = Username,
             Domain = Domain,
-            Password = Password?.ConvertToSecureString(),
+            Password = Password,//?.ConvertToSecureString(),
             Inheritance = { Colors = true }
         };
     }
@@ -150,7 +150,7 @@ public class CsvConnectionsSerializerMremotengFormatTests
             Name = "MyFolder",
             Username = "BlahBlah1",
             Domain = "aklkskkksh8",
-            Password = "qweraslkdjf87".ConvertToSecureString()
+            Password = "qweraslkdjf87"//.ConvertToSecureString()
         };
     }
 }

--- a/mRemoteNGTests/Config/Serializers/CredentialSerializers/XmlCredentialPasswordEncryptorDecoratorTests.cs
+++ b/mRemoteNGTests/Config/Serializers/CredentialSerializers/XmlCredentialPasswordEncryptorDecoratorTests.cs
@@ -79,7 +79,7 @@ public class XmlCredentialPasswordEncryptorDecoratorTests
         cryptoProvider.CipherEngine.Returns(CipherEngine);
         cryptoProvider.CipherMode.Returns(CipherMode);
         cryptoProvider.KeyDerivationIterations.Returns(KdfIterations);
-        cryptoProvider.Encrypt(null, null).ReturnsForAnyArgs("encrypted");
+        cryptoProvider.Encrypt(string.Empty, null).ReturnsForAnyArgs("encrypted");
         return cryptoProvider;
     }
 }

--- a/mRemoteNGTests/Config/Serializers/MiscSerializers/PuttyConnectionManagerDeserializerTests.cs
+++ b/mRemoteNGTests/Config/Serializers/MiscSerializers/PuttyConnectionManagerDeserializerTests.cs
@@ -100,7 +100,7 @@ public class PuttyConnectionManagerDeserializerTests
     public void ConnectionPasswordImported()
     {
         var connection = GetSshConnection();
-        Assert.That(connection.Password?.ConvertToUnsecureString(), Is.EqualTo(ExpectedConnectionPassword));
+        Assert.That(connection.GetPlaintextPassword(), Is.EqualTo(ExpectedConnectionPassword));
     }
 
     private ConnectionInfo GetSshConnection()

--- a/mRemoteNGTests/Connection/AbstractConnectionInfoDataTests.cs
+++ b/mRemoteNGTests/Connection/AbstractConnectionInfoDataTests.cs
@@ -94,7 +94,7 @@ public class AbstractConnectionInfoDataTests
     {
         var wasCalled = false;
         _testAbstractConnectionInfoData.PropertyChanged += (sender, args) => wasCalled = true;
-        _testAbstractConnectionInfoData.Password = "a".ConvertToSecureString();
+        _testAbstractConnectionInfoData.Password = "a";
         Assert.That(wasCalled, Is.True);
     }
 

--- a/mRemoteNGTests/TestHelpers/ConnectionTreeModelBuilder.cs
+++ b/mRemoteNGTests/TestHelpers/ConnectionTreeModelBuilder.cs
@@ -23,8 +23,8 @@ namespace mRemoteNGTests.TestHelpers
         {
             var model = new ConnectionTreeModel();
             var root = new RootNodeInfo(RootNodeType.Connection);
-            var folder1 = new ContainerInfo { Name = "folder1", Username = "user1", Domain = "domain1", Password = "password1".ConvertToSecureString() };
-            var folder2 = new ContainerInfo { Name = "folder2", Username = "user2", Domain = "domain2", Password = "password2".ConvertToSecureString() };
+            var folder1 = new ContainerInfo { Name = "folder1", Username = "user1", Domain = "domain1", Password = "password1" };
+            var folder2 = new ContainerInfo { Name = "folder2", Username = "user2", Domain = "domain2", Password = "password2" };
             var folder3 = new ContainerInfo
             {
                 Name = "folder3",
@@ -35,8 +35,8 @@ namespace mRemoteNGTests.TestHelpers
                     Password = true
                 }
             };
-            var con1 = new ConnectionInfo { Name = "Con1", Username = "user1", Domain = "domain1", Password = "password1".ConvertToSecureString() };
-            var con2 = new ConnectionInfo { Name = "Con2", Username = "user2", Domain = "domain2", Password = "password2".ConvertToSecureString() };
+            var con1 = new ConnectionInfo { Name = "Con1", Username = "user1", Domain = "domain1", Password = "password1" };
+            var con2 = new ConnectionInfo { Name = "Con2", Username = "user2", Domain = "domain2", Password = "password2" };
             var con3 = new ContainerInfo
             {
                 Name = "con3",

--- a/mRemoteNGTests/Tools/ExternalToolsArgumentParserTests.cs
+++ b/mRemoteNGTests/Tools/ExternalToolsArgumentParserTests.cs
@@ -29,7 +29,7 @@ namespace mRemoteNGTests.Tools
                 Hostname = TestString,
                 Port = Port,
                 Username = TestString,
-                Password = TestString.ConvertToSecureString(),
+                Password = TestString,
                 Domain = TestString,
                 Description = TestString,
                 MacAddress = TestString,


### PR DESCRIPTION
## Description
A public property must be of type string, so that it remains editable in PropertyGrid. However, password should be stored in a SecureString backing variable. Conversion from plain string to SecureString happens whenever the Setter() is called. The Getter() returns a default password that is only to allow the GUI to show that a password has been added. Calling the Getter() will NOT return the plaintext password. There is a helper functions to access Plaintext password only when required, which should be at the point of connection, or during unit tests. 

Added more secure encrypt/decrypt functions where required to avoid early conversion from SecureString to string.

## Motivation and Context
Fixes [issue-2630](https://github.com/mRemoteNG/mRemoteNG/issues/2630)

## How Has This Been Tested?
Confirmed through manual testing that password can be edited, and the edit is persisted.
Same # unit tests are passing as previous builds.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [X] All Tests within VisualStudio are passing
- [X] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
