### PR TITLE
VNCEvent_Disconnected send the ProtocolBase based object reference

### DIFF
--- a/mRemoteNG/Connection/Protocol/VNC/Connection.Protocol.VNC.cs
+++ b/mRemoteNG/Connection/Protocol/VNC/Connection.Protocol.VNC.cs
@@ -215,7 +215,7 @@ namespace mRemoteNG.Connection.Protocol.VNC
         private void VNCEvent_Disconnected(object sender, EventArgs e)
         {
             FrmMain.ClipboardChanged -= VNCEvent_ClipboardChanged;
-            Event_Disconnected(sender, @"VncSharp Disconnected.", null);
+            Event_Disconnected(this, @"VncSharp Disconnected.", null);
             Close();
         }
 


### PR DESCRIPTION
Fixes the exception mostly mentioned in #2321, but not the actual connection issues

## Description
Change the sender object in VNC disconnect from the `VncSharpCore` object, to the `ProtocolVNC` object

## Motivation and Context
`Unable to cast object of type 'VncSharpCore.RemoteDesktop' to type 'mRemoteNG.Connection.Protocol.ProtocolBase'. at mRemoteNG.Connection.ConnectionInitiator.Prot_Event_Disconnected`
`Prot_Event_Disconnected` expects the sender to be child of `ProtocolBase` #2321

## How Has This Been Tested?
Exception throw on connection, probably due to "old" version of `VncSharpCore` when building from source.
After change this exception was no longer thrown, while the connection issue remained.
This seems to be a bug in which objects are sent in the event handlers.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
