### PR TITLE
Disable WinForms analyzers and suppress WFO1000 build errors for ObjectListView

### DIFF
--- a/ObjectListView/ObjectListView.NetCore.csproj
+++ b/ObjectListView/ObjectListView.NetCore.csproj
@@ -8,6 +8,8 @@
     <UseWindowsForms>true</UseWindowsForms>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
     <PlatformTarget>x64</PlatformTarget>
+    <NoWarn>$(NoWarn);WFO1000</NoWarn>
+    <EnableWinFormsAnalyzers>false</EnableWinFormsAnalyzers>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="CustomDictionary.xml" Link="CustomDictionary.xml" />


### PR DESCRIPTION
## Description

Trying to solve for #2705. I was unable to compile the `v1.78.2-dev` branch locally...

## Motivation and Context

For ObjectListView, each property that re-declares a WinForms‐designer property (TextAlign, DataSource, Value, etc.) needs a DesignerSerializationVisibility (or Browsable(false)/EditorBrowsable) attribute so the designer knows how to serialize it. Updating ObjectListView upstream would eliminate the errors without disabling the analyzer. 

For now, I am just going to disable the analyzer to unblock this, since I'm not a .NET dev

## How Has This Been Tested?

Compiles just fine after my changes and the app works.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [X] All Tests within VisualStudio are passing
- [X] This pull request does not target the master branch.
- [X] I have updated the changelog file accordingly, if necessary.
- [X] I have updated the documentation accordingly, if necessary.
