### PR TITLE
fix native build for Windows-x64

### DIFF
--- a/mRemoteNG/mRemoteNG.csproj
+++ b/mRemoteNG/mRemoteNG.csproj
@@ -610,7 +610,7 @@
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)'=='x64'">
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <Nullable>enable</Nullable>
     <PlatformTarget>x64</PlatformTarget>
@@ -618,7 +618,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Deploy to github|x64'">
     <WarningLevel>8</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)'=='arm64'">
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <Nullable>enable</Nullable>
     <PlatformTarget>ARM64</PlatformTarget>


### PR DESCRIPTION
## Description
- This PR fixes incorrect platform targeting in mRemoteNG.csproj, where x64 builds were being compiled as ARM64 due to misconfigured PropertyGroup entries.

## Fixes Made
- Added explicit `<PlatformTarget>x64</PlatformTarget>` for x64 builds.
- Added explicit `<PlatformTarget>ARM64</PlatformTarget>` for ARM64 builds.


## How Has This Been Tested?

- Unzipped the windows binaries generated for both x64 and ARM64 on target platform.
- Launched the application and verified the application architecture via task manager.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
