### PR TITLE
Change Default RDP Version to v10

### DIFF
--- a/mRemoteNG/Connection/AbstractConnectionRecord.cs
+++ b/mRemoteNG/Connection/AbstractConnectionRecord.cs
@@ -38,7 +38,7 @@ namespace mRemoteNG.Connection
         
         private string _sshTunnelConnectionName = "";
         private ProtocolType _protocol;
-        private RdpVersion _rdpProtocolVersion;
+        private RdpVersion _rdpProtocolVersion = RdpVersion.Rdc10;
         private string _extApp;
         private int _port;
         private string _sshOptions = "";


### PR DESCRIPTION
## Description
The RDP Protocol version has been changed from v6 (non-explicit - it was just the default enum value), to v10. RDP version 10 has been available since Windows 10. 
https://en.wikipedia.org/wiki/Remote_Desktop_Protocol#Version_10.0

## Motivation and Context
When importing RDP files, mRemoteNG defaults to RDPv6 (which is extremely old, and particularly does not support Gateway access tokens). For connections over Gateway, RDPv6 does not support the Gateway Access token. So the user would have to manually edit the config and select a newer RDP protocol, in order to be able to initiate the connection. There is not even a clear indication of why the connection is failing, which can get very frustrating if the user doesn't know about this limitation.

It is safe to assume that the majority of Windows PCs on the internet today are running Windows 10 or above, and that having RDP6 as the default is causing unnecessary friction to those majority users.


## How Has This Been Tested?
Import RDP file, observe that RDP version on the UI is showing as version 10.
Connect to desktop over a gateway, with access token provided in the rdp file. Success.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [X] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
