### PR TITLE
ci: fix T4 template transform by adding EnvDTE & Interop references

### DIFF
--- a/.github/workflows/Build_mR-NB.yml
+++ b/.github/workflows/Build_mR-NB.yml
@@ -32,21 +32,15 @@ jobs:
         shell: pwsh
         run: |
           dotnet tool install --global dotnet-t4
-
           # Refresh PATH to include global tools
           $env:PATH += ";$env:USERPROFILE\.dotnet\tools"
-      
-          $interopPath = "$env:GITHUB_WORKSPACE\mRemoteNG\libs\Microsoft.VisualStudio.Interop.dll"
           $ttFile = "$env:GITHUB_WORKSPACE\mRemoteNG\Properties\AssemblyInfo.tt"
-      
+          # VS Enterprise 2022 assemblies
+          $vsPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\PublicAssemblies"
           Write-Host "Transforming T4 template"
-          t4 $ttFile -P platformType=${{ matrix.platform }}
+          t4 $ttFile -P platformType=${{ matrix.platform }} -r:"$vsPath\EnvDTE.dll" -r:"$vsPath\Microsoft.VisualStudio.Interop.dll"
         env:
           PLATFORM: '${{ matrix.platform }}'
-
-
-
-
   
       - name: (04) Cache NuGet Packages
         uses: actions/cache@v4


### PR DESCRIPTION
## Description
The GitHub Actions workflow was failing during the T4 template transform step. This PR fixes the failing step in github action by including necessary libraries during the T4 template transform.

## Motivation and Context
- Updated CI step to include explicit references to both `EnvDTE.dll` and
  `Microsoft.VisualStudio.Interop.dll` from the Visual Studio Enterprise 2022
  PublicAssemblies directory.
- Ensures dotnet-t4 can resolve `DTE` types correctly when generating
  AssemblyInfo.cs during builds.

## How Has This Been Tested?
- Tested via CI and locally with sample transform code

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
