### PR TITLE
Add ARM64 support for .NET runtime detection

### DIFF
--- a/mRemoteNG/App/Update/DotNetRuntimeCheck.cs
+++ b/mRemoteNG/App/Update/DotNetRuntimeCheck.cs
@@ -88,9 +88,21 @@ namespace mRemoteNG.DotNet.Update
                 if (dotnetEntry != null && dotnetEntry["latest-runtime"] != null)
                 {
                     string? latestRuntimeVersion = dotnetEntry["latest-runtime"]?.ToString();
-                    string arch = RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "arm64"
-                                  : RuntimeInformation.OSArchitecture == Architecture.X86   ? "x86"
-                                  : "x64";
+                    string arch;
+                    switch (RuntimeInformation.OSArchitecture)
+                    {
+                        case Architecture.Arm64:
+                            arch = "arm64";
+                            break;
+                        case Architecture.X86:
+                            arch = "x86";
+                            break;
+                       case Architecture.X64:
+                           arch = "x64";
+                           break;
+                       default:
+                           throw new NotSupportedException($"Unsupported architecture: {RuntimeInformation.OSArchitecture}");
+                   }
                     if (!string.IsNullOrEmpty(latestRuntimeVersion))
                     {
                         // Construct the download URL using the latest version

--- a/mRemoteNG/App/Update/DotNetRuntimeCheck.cs
+++ b/mRemoteNG/App/Update/DotNetRuntimeCheck.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using System.Runtime.InteropServices;
 
 namespace mRemoteNG.DotNet.Update
 {

--- a/mRemoteNG/App/Update/DotNetRuntimeCheck.cs
+++ b/mRemoteNG/App/Update/DotNetRuntimeCheck.cs
@@ -28,7 +28,8 @@ namespace mRemoteNG.DotNet.Update
             string[] registryPaths = new[]
             {
                 @"SOFTWARE\dotnet\Setup\InstalledVersions\x86",
-                @"SOFTWARE\dotnet\Setup\InstalledVersions\x64"
+                @"SOFTWARE\dotnet\Setup\InstalledVersions\x64",
+                @"SOFTWARE\dotnet\Setup\InstalledVersions\arm64"
             };
 
             foreach (string path in registryPaths)
@@ -86,10 +87,13 @@ namespace mRemoteNG.DotNet.Update
                 if (dotnetEntry != null && dotnetEntry["latest-runtime"] != null)
                 {
                     string? latestRuntimeVersion = dotnetEntry["latest-runtime"]?.ToString();
+                    string arch = RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "arm64"
+                                  : RuntimeInformation.OSArchitecture == Architecture.X86   ? "x86"
+                                  : "x64";
                     if (!string.IsNullOrEmpty(latestRuntimeVersion))
                     {
                         // Construct the download URL using the latest version
-                        string downloadUrl = $"https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-{latestRuntimeVersion}-windows-x64-installer";
+                        string downloadUrl = $"https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-{latestRuntimeVersion}-windows-{arch}-installer";
                         return (latestRuntimeVersion, downloadUrl);
                     }
                 }


### PR DESCRIPTION
## Description
- Add support for detecting and downloading the correct .NET runtime on Windows ARM64.
- Updated registry checks and download URL construction to handle x86, x64, and arm64 explicitly.

## Motivation and Context
- Previously, only x86 and x64 were handled. This change ensures the application can properly detect and fetch runtimes on Windows ARM64 devices.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
