### PR TITLE
Fix panel tab header visibility issue when single panel is docked

### DIFF
--- a/mRemoteNG/UI/Forms/frmMain.Designer.cs
+++ b/mRemoteNG/UI/Forms/frmMain.Designer.cs
@@ -60,7 +60,7 @@ namespace mRemoteNG.UI.Forms
             // 
             this.pnlDock.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pnlDock.DockBackColor = System.Drawing.SystemColors.Control;
-            this.pnlDock.DocumentStyle = WeifenLuo.WinFormsUI.Docking.DocumentStyle.DockingSdi;
+            this.pnlDock.DocumentStyle = WeifenLuo.WinFormsUI.Docking.DocumentStyle.DockingWindow;
             this.pnlDock.Location = new System.Drawing.Point(0, 0);
             this.pnlDock.Name = "pnlDock";
             this.pnlDock.Size = new System.Drawing.Size(1129, 546);


### PR DESCRIPTION
Changed DockPanel DocumentStyle from DockingSdi to DockingWindow to ensure panel tab headers remain visible even when only one panel exists in a dock area.

This resolves the issue where users could not access panel controls (close button, pin/auto-hide, dropdown menu) after moving panels to new locations, as the tab strip was completely hidden with DockingSdi when only one panel was present.

With DockingWindow style:
- Panel name/title always visible
- Close button (X) always accessible
- Pin/auto-hide button always available
- Dropdown menu always accessible
- No more "lost" panels requiring layout reset

Fixes #2960

---------------------

Note: This fix was developed with assistance from Claude Code for codebase
analysis, implementation, code review, and comprehensive testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude [noreply@anthropic.com](mailto:noreply@anthropic.com)
