### PR TITLE
fix(doc): the list format in the command_line_switches.rst is incorrect.

### DIFF
--- a/mRemoteNGDocumentation/command_line_switches.rst
+++ b/mRemoteNGDocumentation/command_line_switches.rst
@@ -7,7 +7,10 @@ The following commandlline switches are supported by mRemoteNG:
 ``/cons: PathToConnectionsFile``
 ``/c: PathToConnectionsFile``
 
- Loads the connections file from the given path. This path can be a:
+ Loads the connections file from the given path. 
+
+ This path can be a:
+
  - full file path
  - path relative to the current directory
  - path relative to the mRemoteNG application directory


### PR DESCRIPTION
## Description
This modification corrects the rendering of the list in the documentation of command_line_switches

## Motivation and Context
The document has a formatting issue that makes it difficult to read.

## How Has This Been Tested?
testing the fix's rendering with the GitHub preview

## Screenshots (if appropriate):
| Before | After |
|--------|--------|
| <img width="995" height="148" alt="image" src="https://github.com/user-attachments/assets/8b088bd3-f16b-44f2-8ac3-62bb9940e1e3" />| <img width="574" height="285" alt="image" src="https://github.com/user-attachments/assets/5674eb2f-7474-4b3a-907d-8646a2233dd2" /> | 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation
