### PR TITLE
Make 1password integration more tolerant

### DIFF
--- a/ExternalConnectors/OP/OnePasswordCli.cs
+++ b/ExternalConnectors/OP/OnePasswordCli.cs
@@ -98,7 +98,8 @@ public class OnePasswordCli
     private static string FindField(VaultItem items, string purpose, string fallbackLabel)
     {
         return items.Fields?.FirstOrDefault(x => x.Purpose == purpose)?.Value ??
-			items.Fields?.FirstOrDefault(x => x.Type == StringType && x.Label == fallbackLabel)?.Value ??
+			items.Fields?.FirstOrDefault(x => x.Type == StringType && string.Equals(x.Id, fallbackLabel, StringComparison.InvariantCultureIgnoreCase))?.Value ??
+		 	items.Fields?.FirstOrDefault(x => x.Type == StringType && string.Equals(x.Label, fallbackLabel, StringComparison.InvariantCultureIgnoreCase))?.Value ??
 		 	string.Empty;
     }
 

--- a/ExternalConnectors/OP/OnePasswordCli.cs
+++ b/ExternalConnectors/OP/OnePasswordCli.cs
@@ -91,7 +91,7 @@ public class OnePasswordCli
         domain = items.Fields?.FirstOrDefault(x => x.Type == StringType && x.Label == DomainLabel)?.Value ?? string.Empty;
 		if(string.IsNullOrEmpty(password) && string.IsNullOrEmpty(privateKey))
 		{
-			throw new OnePasswordCliException("No secret found in 1Password", commandLine);
+			throw new OnePasswordCliException("No secret found in 1Password. At least fields with labels username/password or a SshKey are expected.", commandLine);
 		}
     }
 

--- a/mRemoteNGDocumentation/howtos/credvault.rst
+++ b/mRemoteNGDocumentation/howtos/credvault.rst
@@ -3,10 +3,11 @@ Credential Vault Connector
 **************************
 
 mRemote supports fetching credentials from external credential vaults. This allows providing credentials to the connection without storing sensitive information in the config file, which has numerous benefits (security, auditing, rotating passwords, etc).
-Two password vaults are currently supported: 
+Three password vaults are currently supported:
 
 - Delinea Secret Server
 - Clickstudios Passwordstate
+- 1Password
 
 The feature is implemented for RDP, RDP Gateway and SSH connections.
 
@@ -41,4 +42,51 @@ Authentication works with WinAuth/SSO and list-based API-Keys. MFA via OTP is su
 
 - There is currently no support for token authentication, so if your API has MFA enabled, you need to specify a fresh OTP code quite frequently
 - If you are using list-based API keys to access the vault, only one API key can currently be specified in the connector configuration
+
+
+1Password
+---------
+
+The secret reference uses the 1Password URL format. Specify the secret in the mRemote ``UserViaAPI`` field using this format:
+
+    ``op://vault-name/item-name``
+    ``op:///item-name``
+
+Or with an optional account parameter:
+
+    ``op://vault-name/item-name?account=account-name``
+
+Where:
+
+- ``vault-name`` is the name or id of your 1Password vault
+- ``item-name`` is the name or id of the item containing the credentials
+- ``account-name`` (optional) specifies which 1Password account to use if you have multiple accounts
+
+Field Mapping
+~~~~~~~~~~~~~
+
+The 1Password integration retrieves the following fields from your 1Password item:
+
+- **Username**: Fields with purpose "USERNAME" or label "username"
+- **Password**: Fields with purpose "PASSWORD" or label "password"
+- **Domain**: String fields with label "domain"
+- **SSH Private Key**: Fields of type "SSHKEY"
+
+At least a password or SSH private key must be present in the item.
+
+Prerequisites
+~~~~~~~~~~~~~
+
+The 1Password CLI (``op.exe``) must be installed and available in your system PATH. You can download it from https://1password.com/downloads/command-line/
+
+The CLI requires the GUI application to run, because the GUI provides the authentication prompt. You can verify authentication by running:
+
+    ``op signin``
+
+Configuration Notes
+~~~~~~~~~~~~~~~~~~~
+
+- Server category items and some other item types may not have the ``purpose`` metadata set on their username/password fields. In these cases, the integration will fall back to matching by field label ("username" and "password").
+- You can modify field labels in 1Password to match the expected conventions if needed.
+- The domain field is optional and should be a string field with the label "domain".
 


### PR DESCRIPTION
### **User description**
## Description
This PR aims to improve the documentation of the newish 1Password integration and make it more suitable for diverse existing vaults. This is done by applying the existing `domain` pattern to `username` and `password` as well.

## Motivation and Context
The 1password integration was undocumented; when testing it I found that it only worked on `login` type items and not on `server` type items. 

## How Has This Been Tested?
This has been integration tested and is Works On My Machine certified: it was run in the debugger with a local ConfCons.xml file with some servers configured to use the corporate 1password vaults.
I could not find test examples for this behavior or `ExternalConnectors` in general to build on.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary. (imo not necessary)
- [x] I have updated the documentation accordingly, if necessary.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add fallback mechanism for username/password field matching by label

- Support 1Password server category items with localized field labels

- Implement FindField helper method for flexible field resolution

- Add comprehensive 1Password integration documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["1Password Item Fields"] -->|"Purpose metadata"| B["FindField Method"]
  A -->|"Field ID/Label fallback"| B
  B -->|"Username"| C["Credential Resolution"]
  B -->|"Password"| C
  B -->|"Domain/SSH Key"| C
  C -->|"Supports Login & Server types"| D["Enhanced Compatibility"]
  E["Documentation"] -->|"Field mapping guide"| D
  E -->|"Prerequisites & config notes"| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OnePasswordCli.cs</strong><dd><code>Implement flexible field matching with fallback labels</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ExternalConnectors/OP/OnePasswordCli.cs

<ul><li>Added constants for fallback field labels (username/password) to <br>support server category items<br> <li> Introduced FindField helper method implementing three-tier field <br>resolution strategy<br> <li> Enhanced field matching to check purpose metadata first, then field <br>ID, then field label<br> <li> Improved error handling with validation that at least password or SSH <br>key exists<br> <li> Added inline documentation explaining purpose vs label field matching <br>behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/mRemoteNG/mRemoteNG/pull/3061/files#diff-6aa533e9b0bda023c040616df2555275711478c4dc62d01e5e49342a4e8ce174">+59/-35</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>credvault.rst</strong><dd><code>Add comprehensive 1Password integration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mRemoteNGDocumentation/howtos/credvault.rst

<ul><li>Added 1Password to the list of supported credential vaults<br> <li> Documented 1Password URL format with vault-name, item-name, and <br>optional account parameters<br> <li> Detailed field mapping for username, password, domain, and SSH private <br>key extraction<br> <li> Listed prerequisites including 1Password CLI installation and <br>authentication setup<br> <li> Added configuration notes explaining fallback field label matching for <br>server category items</ul>


</details>


  </td>
  <td><a href="https://github.com/mRemoteNG/mRemoteNG/pull/3061/files#diff-8b06a38e16e9dcdaab8434e31246b5cce7c713488e74cd2573289510624c9e6c">+49/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

