### PR TITLE
Fix FrmInputBox to use dynamic sizing instead of fixed dimensions

### DIFF
--- a/mRemoteNG/UI/Forms/FrmInputBox.Designer.cs
+++ b/mRemoteNG/UI/Forms/FrmInputBox.Designer.cs
@@ -44,6 +44,8 @@ namespace mRemoteNG.UI.Forms
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.AutoSize = true;
+            this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tableLayoutPanel1.Controls.Add(this._Ok, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.buttonCancel, 2, 2);
             this.tableLayoutPanel1.Controls.Add(this.textBox, 0, 1);
@@ -51,11 +53,12 @@ namespace mRemoteNG.UI.Forms
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.Padding = new System.Windows.Forms.Padding(8);
             this.tableLayoutPanel1.RowCount = 3;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(284, 81);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 28F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 35F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(284, 90);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // _Ok
@@ -103,12 +106,14 @@ namespace mRemoteNG.UI.Forms
             this.label.TabIndex = 3;
             this.label.Text = "Label";
             this.label.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
+            //
             // FrmInputBox
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(284, 81);
+            this.AutoSize = true;
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.ClientSize = new System.Drawing.Size(300, 95);
             this.ControlBox = false;
             this.Controls.Add(this.tableLayoutPanel1);
             this.DoubleBuffered = true;
@@ -116,6 +121,7 @@ namespace mRemoteNG.UI.Forms
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(300, 95);
             this.Name = "FrmInputBox";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;


### PR DESCRIPTION
### **User description**
## Description

Fix issue with New Panel display control buttons not visible.




## Motivation and Context

Resolves #3098

## How Has This Been Tested?

Visual test only,.

## Screenshots (if appropriate):

![mremote_fixed](https://github.com/user-attachments/assets/72540018-2c92-40f6-bac5-9a1b2072ccea)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.


___

### **PR Type**
Bug fix


___

### **Description**
- Enable dynamic sizing for FrmInputBox form and layout

- Replace fixed row heights with AutoSize mode

- Add padding and adjust control dimensions for visibility

- Set minimum size to prevent form shrinking below content


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fixed dimensions<br/>24px rows"] -->|Replace with AutoSize| B["Dynamic sizing<br/>AutoSize mode"]
  B -->|Add padding| C["8px padding<br/>improved spacing"]
  C -->|Set minimum size| D["300x95px minimum<br/>prevents shrinking"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FrmInputBox.Designer.cs</strong><dd><code>Enable dynamic sizing and improve layout spacing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mRemoteNG/UI/Forms/FrmInputBox.Designer.cs

<ul><li>Enable <code>AutoSize</code> and <code>AutoSizeMode.GrowAndShrink</code> on both form and table <br>layout panel<br> <li> Change row styles from fixed 24px heights to <code>AutoSize</code> for first row <br>and adjusted heights for button rows<br> <li> Add 8px padding to table layout panel for better spacing<br> <li> Update form <code>ClientSize</code> from 284x81 to 300x95 and set <code>MinimumSize</code> to <br>prevent shrinking<br> <li> Adjust label size to accommodate dynamic layout</ul>


</details>


  </td>
  <td><a href="https://github.com/mRemoteNG/mRemoteNG/pull/3099/files#diff-8d536c7b66b4f1a09fd034bfdd8b935dddc0943b284fafd67f3b92d512531c78">+13/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

