### PR TITLE
P0-LDAP-sanitizer-and-importer-guardrails

### DIFF
--- a/mRemoteNG/Config/Import/MRemoteNGCsvImporter.cs
+++ b/mRemoteNG/Config/Import/MRemoteNGCsvImporter.cs
@@ -21,8 +21,11 @@ namespace mRemoteNG.Config.Import
             }
 
             if (!File.Exists(filePath))
+            {
                 Runtime.MessageCollector.AddMessage(MessageClass.ErrorMsg,
                                                     $"Unable to import file. File does not exist. Path: {filePath}");
+                return;
+            }
 
             FileDataProvider dataProvider = new(filePath);
             string xmlString = dataProvider.Load();

--- a/mRemoteNG/Config/Import/MRemoteNGXmlImporter.cs
+++ b/mRemoteNG/Config/Import/MRemoteNGXmlImporter.cs
@@ -23,8 +23,11 @@ namespace mRemoteNG.Config.Import
             }
 
             if (!File.Exists(fileName))
+            {
                 Runtime.MessageCollector.AddMessage(MessageClass.ErrorMsg,
                                                     $"Unable to import file. File does not exist. Path: {fileName}");
+                return;
+            }
 
             FileDataProvider dataProvider = new(fileName);
             string xmlString = dataProvider.Load();

--- a/mRemoteNG/Config/Serializers/MiscSerializers/ActiveDirectoryDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/MiscSerializers/ActiveDirectoryDeserializer.cs
@@ -18,47 +18,8 @@ namespace mRemoteNG.Config.Serializers.MiscSerializers
     [SupportedOSPlatform("windows")]
     public class ActiveDirectoryDeserializer(string ldapPath, bool importSubOu)
     {
-        private readonly string _ldapPath = SanitizeLdapPath(ldapPath.ThrowIfNullOrEmpty(nameof(ldapPath)));
+        private readonly string _ldapPath = LdapPathSanitizer.SanitizeLdapPath(ldapPath.ThrowIfNullOrEmpty(nameof(ldapPath)));
         private readonly bool _importSubOu = importSubOu;
-
-        private static string SanitizeLdapPath(string ldapPath)
-        {
-            // Validate the LDAP path format
-            if (!LdapPathSanitizer.IsValidDistinguishedNameFormat(ldapPath))
-            {
-                throw new ArgumentException("Invalid LDAP path format", nameof(ldapPath));
-            }
-
-            // For LDAP paths (URIs like LDAP://...), we need to sanitize the DN portion
-            // If it starts with LDAP:// or LDAPS://, extract and sanitize the DN part
-            if (ldapPath.StartsWith("LDAP://", StringComparison.OrdinalIgnoreCase) ||
-                ldapPath.StartsWith("LDAPS://", StringComparison.OrdinalIgnoreCase))
-            {
-                int schemeEndIndex = ldapPath.IndexOf("://", StringComparison.OrdinalIgnoreCase) + 3;
-                if (schemeEndIndex < ldapPath.Length)
-                {
-                    // Find the server/domain part (before the first /)
-                    int pathStartIndex = ldapPath.IndexOf('/', schemeEndIndex);
-                    if (pathStartIndex > 0)
-                    {
-                        string scheme = ldapPath.Substring(0, schemeEndIndex);
-                        string serverPart = ldapPath.Substring(schemeEndIndex, pathStartIndex - schemeEndIndex);
-                        string dnPart = ldapPath.Substring(pathStartIndex + 1);
-                        
-                        // Sanitize the DN part
-                        string sanitizedDn = LdapPathSanitizer.SanitizeDistinguishedName(dnPart);
-                        return scheme + serverPart + "/" + sanitizedDn;
-                    }
-                }
-                // If no DN part found, return the path as-is (just the server)
-                return ldapPath;
-            }
-            else
-            {
-                // For plain DN strings, sanitize directly
-                return LdapPathSanitizer.SanitizeDistinguishedName(ldapPath);
-            }
-        }
 
         public ConnectionTreeModel Deserialize()
         {

--- a/mRemoteNG/Tools/ADhelper.cs
+++ b/mRemoteNG/Tools/ADhelper.cs
@@ -20,7 +20,7 @@ namespace mRemoteNG.Tools
         {
             // Sanitize inputs to prevent LDAP injection
             string sanitizedDomain = string.IsNullOrEmpty(Domain) ? string.Empty : LdapPathSanitizer.SanitizeDistinguishedName(Domain);
-            string sanitizedAdPath = string.IsNullOrEmpty(adPath) ? string.Empty : SanitizeLdapPath(adPath);
+            string sanitizedAdPath = string.IsNullOrEmpty(adPath) ? string.Empty : LdapPathSanitizer.SanitizeLdapPath(adPath);
 
             _dEntry = sanitizedAdPath.Length <= 0
                 ? sanitizedDomain.Length <= 0 ? new DirectoryEntry() : new DirectoryEntry("LDAP://" + sanitizedDomain)
@@ -34,44 +34,6 @@ namespace mRemoteNG.Tools
             {
                 if (ex.Message.ToLower().Equals("the server is not operational"))
                     throw new Exception("Could not find AD Server", ex);
-            }
-        }
-
-        private static string SanitizeLdapPath(string ldapPath)
-        {
-            // Validate the LDAP path format
-            if (!LdapPathSanitizer.IsValidDistinguishedNameFormat(ldapPath))
-            {
-                throw new ArgumentException("Invalid LDAP path format", nameof(ldapPath));
-            }
-
-            // For LDAP paths (URIs like LDAP://...), we need to sanitize the DN portion
-            if (ldapPath.StartsWith("LDAP://", StringComparison.OrdinalIgnoreCase) ||
-                ldapPath.StartsWith("LDAPS://", StringComparison.OrdinalIgnoreCase))
-            {
-                int schemeEndIndex = ldapPath.IndexOf("://", StringComparison.OrdinalIgnoreCase) + 3;
-                if (schemeEndIndex < ldapPath.Length)
-                {
-                    // Find the server/domain part (before the first /)
-                    int pathStartIndex = ldapPath.IndexOf('/', schemeEndIndex);
-                    if (pathStartIndex > 0)
-                    {
-                        string scheme = ldapPath.Substring(0, schemeEndIndex);
-                        string serverPart = ldapPath.Substring(schemeEndIndex, pathStartIndex - schemeEndIndex);
-                        string dnPart = ldapPath.Substring(pathStartIndex + 1);
-                        
-                        // Sanitize the DN part
-                        string sanitizedDn = LdapPathSanitizer.SanitizeDistinguishedName(dnPart);
-                        return scheme + serverPart + "/" + sanitizedDn;
-                    }
-                }
-                // If no DN part found, return the path as-is (just the server)
-                return ldapPath;
-            }
-            else
-            {
-                // For plain DN strings, sanitize directly
-                return LdapPathSanitizer.SanitizeDistinguishedName(ldapPath);
             }
         }
     }

--- a/mRemoteNGTests/Config/Import/MRemoteNGImportersTests.cs
+++ b/mRemoteNGTests/Config/Import/MRemoteNGImportersTests.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using mRemoteNG.Config.Import;
+using mRemoteNG.Container;
+using mRemoteNGTests.TestHelpers;
+using NUnit.Framework;
+
+namespace mRemoteNGTests.Config.Import;
+
+[TestFixture]
+public class MRemoteNGImportersTests
+{
+    [Test]
+    public void CsvImporter_ReturnsWithoutCreatingMissingFile()
+    {
+        string filePath = FileTestHelpers.NewTempFilePath(".csv");
+        var destination = new ContainerInfo();
+        var importer = new MRemoteNGCsvImporter();
+
+        importer.Import(filePath, destination);
+
+        Assert.That(File.Exists(filePath), Is.False);
+        Assert.That(destination.Children, Is.Empty);
+    }
+
+    [Test]
+    public void XmlImporter_ReturnsWithoutCreatingMissingFile()
+    {
+        string filePath = FileTestHelpers.NewTempFilePath(".xml");
+        var destination = new ContainerInfo();
+        var importer = new MRemoteNGXmlImporter();
+
+        importer.Import(filePath, destination);
+
+        Assert.That(File.Exists(filePath), Is.False);
+        Assert.That(destination.Children, Is.Empty);
+    }
+}
+

--- a/mRemoteNGTests/Security/LdapPathSanitizerTests.cs
+++ b/mRemoteNGTests/Security/LdapPathSanitizerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using mRemoteNG.Security;
 using NUnit.Framework;
 

--- a/mRemoteNGTests/Security/LdapPathSanitizerTests.cs
+++ b/mRemoteNGTests/Security/LdapPathSanitizerTests.cs
@@ -171,6 +171,22 @@ namespace mRemoteNGTests.Security
         }
 
         [Test]
+        public void IsValidDistinguishedNameFormat_ReturnsFalseForLdapUriWithQuery()
+        {
+            string input = "LDAP://dc01.example.com/DC=example,DC=com??sub?(objectClass=*)";
+            bool result = LdapPathSanitizer.IsValidDistinguishedNameFormat(input);
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void IsValidDistinguishedNameFormat_ReturnsFalseForLdapUriWithFragment()
+        {
+            string input = "LDAP://dc01.example.com/DC=example,DC=com#fragment";
+            bool result = LdapPathSanitizer.IsValidDistinguishedNameFormat(input);
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
         public void IsValidDistinguishedNameFormat_ReturnsTrueForDnWithEquals()
         {
             string input = "CN=User,OU=Users,DC=example,DC=com";
@@ -204,6 +220,29 @@ namespace mRemoteNGTests.Security
         {
             bool result = LdapPathSanitizer.IsValidDistinguishedNameFormat("plainstring");
             Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void SanitizeLdapPath_ReturnsServerOnlyPath()
+        {
+            const string input = "LDAP://dc01.example.com";
+            string result = LdapPathSanitizer.SanitizeLdapPath(input);
+            Assert.That(result, Is.EqualTo(input));
+        }
+
+        [Test]
+        public void SanitizeLdapPath_SanitizesDnPart()
+        {
+            const string input = "LDAP://dc01.example.com/OU=Admins,DC=example,DC=com";
+            string result = LdapPathSanitizer.SanitizeLdapPath(input);
+            Assert.That(result, Is.EqualTo("LDAP://dc01.example.com/OU\\=Admins\\,DC\\=example\\,DC\\=com"));
+        }
+
+        [Test]
+        public void SanitizeLdapPath_ThrowsForUnsafeLdapUri()
+        {
+            const string input = "LDAP://dc01.example.com/DC=example,DC=com??sub?(objectClass=*)";
+            Assert.Throws<ArgumentException>(() => LdapPathSanitizer.SanitizeLdapPath(input));
         }
 
         [Test]


### PR DESCRIPTION
## Summary

Security follow-up hardening for AD import + importer entrypoints:

- centralizes LDAP path sanitization and blocks unsafe LDAP URL query/fragment forms,
- removes duplicated AD sanitizer logic by routing through shared `LdapPathSanitizer`,
- adds missing-file guardrails in XML/CSV importers to fail safely and avoid unsafe import flow continuation,
- adds/updates regression tests for sanitizer and importer behavior.

## Issue Context

- related to `#3080` (LDAP query/path injection hardening)
- related to `#2988` (deserialization/RCE scanner findings; importer/safe-entry hardening in this PR)

## Files

- `mRemoteNG/Security/LdapPathSanitizer.cs`
- `mRemoteNG/Config/Serializers/MiscSerializers/ActiveDirectoryDeserializer.cs`
- `mRemoteNG/Tools/ADhelper.cs`
- `mRemoteNG/Config/Import/MRemoteNGCsvImporter.cs`
- `mRemoteNG/Config/Import/MRemoteNGXmlImporter.cs`
- tests under `mRemoteNGTests/Security` and `mRemoteNGTests/Config`

## Notes

- This PR intentionally excludes local fork triage docs/automation (`NEXTUP/*`) and keeps only upstream-relevant code/tests.
