### PR TITLE
P5-3092-onepassword-parser-and-fallback-fix

### DIFF
--- a/ExternalConnectors/OP/OnePasswordCli.cs
+++ b/ExternalConnectors/OP/OnePasswordCli.cs
@@ -13,6 +13,7 @@ public class OnePasswordCliException(string message, string arguments) : Excepti
 public class OnePasswordCli
 {
 	private const string OnePasswordCliExecutable = "op.exe";
+	private const string OnePasswordScheme = "op://";
 
 	// Username / password purpose metadata is used on Login category item fields
 	private const string UserNamePurpose = "USERNAME";
@@ -26,6 +27,7 @@ public class OnePasswordCli
 	
 	
 	private const string StringType = "STRING";
+	private const string ConcealedType = "CONCEALED";
 	private const string SshKeyType = "SSHKEY";
 	private const string DomainLabel = "domain";
 
@@ -42,12 +44,62 @@ public class OnePasswordCli
 
 	public static void ReadPassword(string input, out string username, out string password, out string domain, out string privateKey)
 	{
-		var inputUrl = new Uri(input);
-		var vault = WebUtility.UrlDecode(inputUrl.Host);
-		var queryParams = HttpUtility.ParseQueryString(inputUrl.Query);
-		var account = queryParams["account"];
-		var item = WebUtility.UrlDecode(inputUrl.AbsolutePath.TrimStart('/'));
+		var (item, vault, account) = ParseSecretReference(input);
 		ItemGet(item, vault, account, out username, out password, out domain, out privateKey);
+	}
+
+	private static (string Item, string? Vault, string? Account) ParseSecretReference(string input)
+	{
+		if (string.IsNullOrWhiteSpace(input))
+		{
+			throw new OnePasswordCliException("1Password secret reference is empty.", input);
+		}
+
+		string normalizedInput = input.Trim();
+		if (!normalizedInput.StartsWith(OnePasswordScheme, StringComparison.OrdinalIgnoreCase))
+		{
+			throw new OnePasswordCliException($"Invalid 1Password secret reference. Expected format {OnePasswordScheme}vault/item.", input);
+		}
+
+		string secret = normalizedInput[OnePasswordScheme.Length..];
+		int querySeparator = secret.IndexOf('?', StringComparison.Ordinal);
+		string pathPart = querySeparator >= 0 ? secret[..querySeparator] : secret;
+		string queryPart = querySeparator >= 0 ? secret[(querySeparator + 1)..] : string.Empty;
+
+		string? account = null;
+		if (!string.IsNullOrEmpty(queryPart))
+		{
+			var queryParams = HttpUtility.ParseQueryString(queryPart);
+			account = queryParams["account"];
+		}
+
+		string vaultPart = string.Empty;
+		string itemPart;
+
+		if (pathPart.StartsWith("/", StringComparison.Ordinal))
+		{
+			itemPart = pathPart.TrimStart('/');
+		}
+		else
+		{
+			int firstSlash = pathPart.IndexOf('/', StringComparison.Ordinal);
+			if (firstSlash <= 0 || firstSlash == pathPart.Length - 1)
+			{
+				throw new OnePasswordCliException($"Invalid 1Password secret reference. Expected format {OnePasswordScheme}vault/item.", input);
+			}
+
+			vaultPart = pathPart[..firstSlash];
+			itemPart = pathPart[(firstSlash + 1)..];
+		}
+
+		string item = WebUtility.UrlDecode(itemPart);
+		if (string.IsNullOrWhiteSpace(item))
+		{
+			throw new OnePasswordCliException("1Password item is missing in secret reference.", input);
+		}
+
+		string? vault = string.IsNullOrEmpty(vaultPart) ? null : WebUtility.UrlDecode(vaultPart);
+		return (item, vault, account);
 	}
 
 	private static void ItemGet(string item, string? vault, string? account, out string username, out string password, out string domain, out string privateKey)
@@ -82,26 +134,53 @@ public class OnePasswordCli
                 commandLine);
         }
 
-        var items = JsonSerializer.Deserialize<VaultItem>(output, JsonSerializerOptions) ??
-                    throw new OnePasswordCliException("1Password returned null",
-                        commandLine);
-        username = FindField(items, UserNamePurpose, UserNameLabel);
-        password = FindField(items, PasswordPurpose, PasswordLabel);
-        privateKey = items.Fields?.FirstOrDefault(x => x.Type == SshKeyType)?.Value ?? string.Empty;
-        domain = items.Fields?.FirstOrDefault(x => x.Type == StringType && x.Label == DomainLabel)?.Value ?? string.Empty;
-		if(string.IsNullOrEmpty(password) && string.IsNullOrEmpty(privateKey))
+		(username, password, domain, privateKey) = ExtractCredentialsFromJson(output, commandLine);
+    }
+
+	private static (string Username, string Password, string Domain, string PrivateKey) ExtractCredentialsFromJson(
+		string output, string commandLine)
+	{
+		var items = JsonSerializer.Deserialize<VaultItem>(output, JsonSerializerOptions) ??
+		            throw new OnePasswordCliException("1Password returned null",
+			            commandLine);
+
+		string username = FindField(items, UserNamePurpose, UserNameLabel);
+		string password = FindField(items, PasswordPurpose, PasswordLabel);
+		string privateKey = items.Fields?.FirstOrDefault(x =>
+			string.Equals(x.Type, SshKeyType, StringComparison.OrdinalIgnoreCase))?.Value ?? string.Empty;
+		string domain = items.Fields?.FirstOrDefault(x =>
+			string.Equals(x.Type, StringType, StringComparison.OrdinalIgnoreCase) &&
+			string.Equals(x.Label, DomainLabel, StringComparison.OrdinalIgnoreCase))?.Value ?? string.Empty;
+
+		if (string.IsNullOrEmpty(password) && string.IsNullOrEmpty(privateKey))
 		{
 			throw new OnePasswordCliException("No secret found in 1Password. At least fields with labels username/password or a SshKey are expected.", commandLine);
 		}
-    }
+
+		return (username, password, domain, privateKey);
+	}
 
     private static string FindField(VaultItem items, string purpose, string fallbackLabel)
     {
-        return items.Fields?.FirstOrDefault(x => x.Purpose == purpose)?.Value ??
-			items.Fields?.FirstOrDefault(x => x.Type == StringType && string.Equals(x.Id, fallbackLabel, StringComparison.InvariantCultureIgnoreCase))?.Value ??
-		 	items.Fields?.FirstOrDefault(x => x.Type == StringType && string.Equals(x.Label, fallbackLabel, StringComparison.InvariantCultureIgnoreCase))?.Value ??
-		 	string.Empty;
+	    return items.Fields?.FirstOrDefault(x =>
+			string.Equals(x.Purpose, purpose, StringComparison.OrdinalIgnoreCase) &&
+			!string.IsNullOrEmpty(x.Value))?.Value ??
+			items.Fields?.FirstOrDefault(x =>
+				SupportsFallbackType(x.Type) &&
+				string.Equals(x.Id, fallbackLabel, StringComparison.InvariantCultureIgnoreCase) &&
+				!string.IsNullOrEmpty(x.Value))?.Value ??
+			items.Fields?.FirstOrDefault(x =>
+				SupportsFallbackType(x.Type) &&
+				string.Equals(x.Label, fallbackLabel, StringComparison.InvariantCultureIgnoreCase) &&
+				!string.IsNullOrEmpty(x.Value))?.Value ??
+			string.Empty;
     }
+
+	private static bool SupportsFallbackType(string type)
+	{
+		return string.Equals(type, StringType, StringComparison.OrdinalIgnoreCase) ||
+		       string.Equals(type, ConcealedType, StringComparison.OrdinalIgnoreCase);
+	}
 
     private static int RunCommand(string command, IReadOnlyCollection<string> arguments, out string output,
 		out string error)

--- a/mRemoteNGTests/ExternalConnectors/OnePasswordCliTests.cs
+++ b/mRemoteNGTests/ExternalConnectors/OnePasswordCliTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Reflection;
+using ExternalConnectors.OP;
+using NUnit.Framework;
+
+namespace mRemoteNGTests.ExternalConnectors;
+
+[TestFixture]
+public class OnePasswordCliTests
+{
+	[Test]
+	public void ParseSecretReference_AllowsUnescapedSpacesInVaultAndItem()
+	{
+		var result = InvokePrivate<(string Item, string? Vault, string? Account)>(
+			"ParseSecretReference",
+			"op://My Vault/My RDP item");
+
+		Assert.That(result.Item, Is.EqualTo("My RDP item"));
+		Assert.That(result.Vault, Is.EqualTo("My Vault"));
+		Assert.That(result.Account, Is.Null);
+	}
+
+	[Test]
+	public void ParseSecretReference_AllowsVaultlessFormat()
+	{
+		var result = InvokePrivate<(string Item, string? Vault, string? Account)>(
+			"ParseSecretReference",
+			"op:///Server Login");
+
+		Assert.That(result.Item, Is.EqualTo("Server Login"));
+		Assert.That(result.Vault, Is.Null);
+		Assert.That(result.Account, Is.Null);
+	}
+
+	[Test]
+	public void ParseSecretReference_ParsesEncodedValuesAndAccountQuery()
+	{
+		var result = InvokePrivate<(string Item, string? Vault, string? Account)>(
+			"ParseSecretReference",
+			"op://My%20Vault/My%20RDP%20item?account=Work%20Account");
+
+		Assert.That(result.Item, Is.EqualTo("My RDP item"));
+		Assert.That(result.Vault, Is.EqualTo("My Vault"));
+		Assert.That(result.Account, Is.EqualTo("Work Account"));
+	}
+
+	[Test]
+	public void ParseSecretReference_ThrowsForInvalidInput()
+	{
+		var ex = Assert.Throws<TargetInvocationException>(() =>
+			InvokePrivate<(string Item, string? Vault, string? Account)>("ParseSecretReference", "https://example.com/secret"));
+
+		Assert.That(ex?.InnerException, Is.TypeOf<OnePasswordCliException>());
+	}
+
+	[Test]
+	public void ExtractCredentialsFromJson_UsesConcealedFallbackWhenPurposeFieldIsEmpty()
+	{
+		const string json = """
+		                    {
+		                      "fields": [
+		                        { "id": "username", "label": "username", "type": "STRING", "purpose": "USERNAME", "value": "alice" },
+		                        { "id": "password", "label": "password", "type": "CONCEALED", "purpose": "PASSWORD", "value": "" },
+		                        { "id": "password", "label": "password", "type": "CONCEALED", "purpose": "", "value": "S3cr3t!" },
+		                        { "id": "domain", "label": "domain", "type": "STRING", "purpose": "", "value": "CONTOSO" }
+		                      ]
+		                    }
+		                    """;
+
+		var result = InvokePrivate<(string Username, string Password, string Domain, string PrivateKey)>(
+			"ExtractCredentialsFromJson",
+			json,
+			"op.exe item get");
+
+		Assert.That(result.Username, Is.EqualTo("alice"));
+		Assert.That(result.Password, Is.EqualTo("S3cr3t!"));
+		Assert.That(result.Domain, Is.EqualTo("CONTOSO"));
+		Assert.That(result.PrivateKey, Is.EqualTo(string.Empty));
+	}
+
+	private static T InvokePrivate<T>(string methodName, params object[] args)
+	{
+		var method = typeof(OnePasswordCli).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+		Assert.That(method, Is.Not.Null, $"Method '{methodName}' was not found.");
+		return (T)method!.Invoke(null, args)!;
+	}
+}


### PR DESCRIPTION
## Summary

Improves OnePassword CLI reference parsing and field extraction fallback behavior to fix credential resolution regressions.

## Changes

- replaces strict `Uri` parsing with robust `op://` parsing that supports vault/item names with spaces,
- improves fallback extraction to support `CONCEALED` fields for username/password mapping,
- tightens validation and explicit error handling for malformed references.

## Issue Context

- related to `#3092`

## Files

- `ExternalConnectors/OP/OnePasswordCli.cs`
- `mRemoteNGTests/ExternalConnectors/OnePasswordCliTests.cs`

