### PR TITLE
P5-2972-default-external-provider-fix

### DIFF
--- a/mRemoteNG/Connection/Protocol/PuttyBase.cs
+++ b/mRemoteNG/Connection/Protocol/PuttyBase.cs
@@ -189,18 +189,45 @@ namespace mRemoteNG.Connection.Protocol
                                     username = Properties.OptionsCredentialsPage.Default.DefaultUsername;
                                     break;
                                 case "custom":
-
-                                    if (Properties.OptionsCredentialsPage.Default.ExternalCredentialProviderDefault == ExternalCredentialProvider.DelineaSecretServer)
+                                    switch (Properties.OptionsCredentialsPage.Default.ExternalCredentialProviderDefault)
                                     {
-                                        try
-                                        {
-                                            ExternalConnectors.DSS.SecretServerInterface.FetchSecretFromServer(
-                                                $"{Properties.OptionsCredentialsPage.Default.UserViaAPIDefault}", out username, out password, out _, out privatekey);
-                                        }
-                                        catch (Exception ex)
-                                        {
-                                            Event_ErrorOccured(this, "Secret Server Interface Error: " + ex.Message, 0);
-                                        }
+                                        case ExternalCredentialProvider.DelineaSecretServer:
+                                            try
+                                            {
+                                                ExternalConnectors.DSS.SecretServerInterface.FetchSecretFromServer(
+                                                    $"{Properties.OptionsCredentialsPage.Default.UserViaAPIDefault}", out username, out password, out _, out privatekey);
+                                            }
+                                            catch (Exception ex)
+                                            {
+                                                Event_ErrorOccured(this, "Secret Server Interface Error: " + ex.Message, 0);
+                                            }
+
+                                            break;
+                                        case ExternalCredentialProvider.ClickstudiosPasswordState:
+                                            try
+                                            {
+                                                ExternalConnectors.CPS.PasswordstateInterface.FetchSecretFromServer(
+                                                    $"{Properties.OptionsCredentialsPage.Default.UserViaAPIDefault}", out username, out password, out _, out privatekey);
+                                            }
+                                            catch (Exception ex)
+                                            {
+                                                Event_ErrorOccured(this, "Passwordstate Interface Error: " + ex.Message, 0);
+                                            }
+
+                                            break;
+                                        case ExternalCredentialProvider.OnePassword:
+                                            try
+                                            {
+                                                ExternalConnectors.OP.OnePasswordCli.ReadPassword(
+                                                    $"{Properties.OptionsCredentialsPage.Default.UserViaAPIDefault}", out username, out password, out _, out privatekey);
+                                            }
+                                            catch (ExternalConnectors.OP.OnePasswordCliException ex)
+                                            {
+                                                Runtime.MessageCollector.AddMessage(MessageClass.InformationMsg, Language.ECPOnePasswordCommandLine + ": " + ex.Arguments);
+                                                Runtime.MessageCollector.AddMessage(MessageClass.ErrorMsg, Language.ECPOnePasswordReadFailed + Environment.NewLine + ex.Message);
+                                            }
+
+                                            break;
                                     }
 
                                     break;


### PR DESCRIPTION
## Summary

Fixes default external credential provider behavior when `EmptyCredentials=custom` so non-Delinea providers are correctly honored.

## Changes

- updates protocol fallback logic in:
  - `RdpProtocol`
  - `PuttyBase`
- ensures configured default external provider is respected for:
  - `DelineaSecretServer`
  - `ClickstudiosPasswordState`
  - `OnePassword`

## Issue Context

- related to `#2972`

## Files

- `mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs`
- `mRemoteNG/Connection/Protocol/PuttyBase.cs`

