### PR TITLE
P0P5-ProcessStart-hardening-and-external-tools-escaping

### DIFF
--- a/mRemoteNG/App/Shutdown.cs
+++ b/mRemoteNG/App/Shutdown.cs
@@ -121,7 +121,11 @@ namespace mRemoteNG.App
         private static void RunUpdateFile()
         {
             if (UpdatePending)
+            {
+                // Validate the update file path to prevent command injection
+                Tools.PathValidator.ValidateExecutablePathOrThrow(_updateFilePath, nameof(_updateFilePath));
                 Process.Start(new ProcessStartInfo(_updateFilePath) { UseShellExecute = true });
+            }
         }
     }
 }

--- a/mRemoteNG/Connection/Protocol/AnyDesk/ProtocolAnyDesk.cs
+++ b/mRemoteNG/Connection/Protocol/AnyDesk/ProtocolAnyDesk.cs
@@ -221,7 +221,7 @@ namespace mRemoteNG.Connection.Protocol.AnyDesk
                     return false;
                 }
                 
-                string arguments = $"{anydeskId}";
+                string arguments = anydeskId;
 
                 // Add --with-password flag if password is provided
                 bool hasPassword = !string.IsNullOrEmpty(_connectionInfo.Password);

--- a/mRemoteNG/Tools/Cmdline/CommandLineArguments.cs
+++ b/mRemoteNG/Tools/Cmdline/CommandLineArguments.cs
@@ -85,7 +85,7 @@ namespace mRemoteNG.Tools.Cmdline
 
         public static string EscapeShellMetacharacters(string argument)
         {
-            return string.IsNullOrEmpty(argument) ? argument : Regex.Replace(argument, "([()%!^\"<>&|])", "^$1");
+            return string.IsNullOrEmpty(argument) ? argument : Regex.Replace(argument, "([()%!^\"<>&|,;])", "^$1");
         }
 
         #endregion

--- a/mRemoteNG/Tools/ExternalTool.cs
+++ b/mRemoteNG/Tools/ExternalTool.cs
@@ -175,6 +175,9 @@ namespace mRemoteNG.Tools
             {
                 // With UseShellExecute = false, use ArgumentList for better security
                 // Parse arguments using CommandLineArguments for proper splitting
+                // Note: argParser will still escape shell metacharacters by default.
+                // If calling a program that doesn't expect escaped values, use %!VARIABLE% syntax
+                // to disable escaping (e.g., %!PASSWORD% instead of %PASSWORD%).
                 var cmdLineArgs = new Cmdline.CommandLineArguments { EscapeForShell = false };
                 string parsedArguments = argParser.ParseArguments(Arguments);
                 

--- a/mRemoteNG/UI/Forms/FrmAbout.cs
+++ b/mRemoteNG/UI/Forms/FrmAbout.cs
@@ -79,23 +79,50 @@ namespace mRemoteNG.UI.Forms
         {
             try
             {
-                Process.Start(url);
+                // Try to open URL with UseShellExecute
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = url,
+                    UseShellExecute = true
+                };
+                Process.Start(startInfo);
             }
             catch
             {
                 // hack because of this: https://github.com/dotnet/corefx/issues/10361
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    url = url.Replace("&", "^&");
-                    Process.Start(new ProcessStartInfo("cmd", $"/c start {url}") { CreateNoWindow = true });
+                    // Use ArgumentList for better security instead of string concatenation
+                    var startInfo = new ProcessStartInfo
+                    {
+                        FileName = "cmd",
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    };
+                    startInfo.ArgumentList.Add("/c");
+                    startInfo.ArgumentList.Add("start");
+                    startInfo.ArgumentList.Add(url);
+                    Process.Start(startInfo);
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    Process.Start("xdg-open", url);
+                    var startInfo = new ProcessStartInfo
+                    {
+                        FileName = "xdg-open",
+                        UseShellExecute = false
+                    };
+                    startInfo.ArgumentList.Add(url);
+                    Process.Start(startInfo);
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    Process.Start("open", url);
+                    var startInfo = new ProcessStartInfo
+                    {
+                        FileName = "open",
+                        UseShellExecute = false
+                    };
+                    startInfo.ArgumentList.Add(url);
+                    Process.Start(startInfo);
                 }
                 else
                 {

--- a/mRemoteNG/UI/Forms/FrmUnhandledException.cs
+++ b/mRemoteNG/UI/Forms/FrmUnhandledException.cs
@@ -91,7 +91,12 @@ namespace mRemoteNG.UI.Forms
 
         private void buttonCreateBug_Click(object sender, EventArgs e)
         {
-            Process.Start(GeneralAppInfo.UrlBugs);
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = GeneralAppInfo.UrlBugs,
+                UseShellExecute = true
+            };
+            Process.Start(startInfo);
         }
     }
 }

--- a/mRemoteNG/UI/Forms/OptionsPages/NotificationsPage.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/NotificationsPage.cs
@@ -342,8 +342,17 @@ namespace mRemoteNG.UI.Forms.OptionsPages
         {
             try
             {
+                // Validate path to prevent command injection
+                Tools.PathValidator.ValidatePathOrThrow(path, nameof(path));
+                
                 // Open the file using the default application associated with its file type based on the user's preference
-                Process.Start(path);
+                // Use ProcessStartInfo with UseShellExecute for better control
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = path,
+                    UseShellExecute = true
+                };
+                Process.Start(startInfo);
                 return true;
             }
             catch
@@ -362,9 +371,19 @@ namespace mRemoteNG.UI.Forms.OptionsPages
         {
             try
             {
+                // Validate path to prevent command injection
+                Tools.PathValidator.ValidatePathOrThrow(path, nameof(path));
+                
                 // Open it in "Notepad" (Windows default editor).
                 // Usually available on all Windows systems
-                Process.Start("notepad.exe", path);
+                // Use ProcessStartInfo with ArgumentList for better security
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = "notepad.exe",
+                    UseShellExecute = false
+                };
+                startInfo.ArgumentList.Add(path);
+                Process.Start(startInfo);
                 return true;
             }
             catch
@@ -383,9 +402,19 @@ namespace mRemoteNG.UI.Forms.OptionsPages
         {
             try
             {
+                // Validate path to prevent command injection
+                Tools.PathValidator.ValidatePathOrThrow(path, nameof(path));
+                
                 // when all fails open filelocation to logfile...
                 // Open Windows Explorer to the directory containing the file
-                Process.Start("explorer.exe", $"/select,\"{path}\"");
+                // Use ArgumentList for better security
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = "explorer.exe",
+                    UseShellExecute = false
+                };
+                startInfo.ArgumentList.Add("/select," + path);
+                Process.Start(startInfo);
             return true;
         }
             catch

--- a/mRemoteNG/UI/Forms/OptionsPages/NotificationsPage.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/NotificationsPage.cs
@@ -407,13 +407,14 @@ namespace mRemoteNG.UI.Forms.OptionsPages
                 
                 // when all fails open filelocation to logfile...
                 // Open Windows Explorer to the directory containing the file
-                // Use ArgumentList for better security
+                // Use ArgumentList for better security with separate arguments
                 var startInfo = new ProcessStartInfo
                 {
                     FileName = "explorer.exe",
                     UseShellExecute = false
                 };
-                startInfo.ArgumentList.Add("/select," + path);
+                startInfo.ArgumentList.Add("/select,");
+                startInfo.ArgumentList.Add(path);
                 Process.Start(startInfo);
             return true;
         }

--- a/mRemoteNG/UI/Forms/OptionsPages/NotificationsPage.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/NotificationsPage.cs
@@ -7,6 +7,7 @@ using mRemoteNG.App;
 using mRemoteNG.Config.Settings.Registry;
 using mRemoteNG.Properties;
 using mRemoteNG.Resources.Language;
+using mRemoteNG.Tools;
 
 namespace mRemoteNG.UI.Forms.OptionsPages
 {
@@ -343,7 +344,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             try
             {
                 // Validate path to prevent command injection
-                Tools.PathValidator.ValidatePathOrThrow(path, nameof(path));
+                PathValidator.ValidatePathOrThrow(path, nameof(path));
                 
                 // Open the file using the default application associated with its file type based on the user's preference
                 // Use ProcessStartInfo with UseShellExecute for better control
@@ -372,7 +373,7 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             try
             {
                 // Validate path to prevent command injection
-                Tools.PathValidator.ValidatePathOrThrow(path, nameof(path));
+                PathValidator.ValidatePathOrThrow(path, nameof(path));
                 
                 // Open it in "Notepad" (Windows default editor).
                 // Usually available on all Windows systems
@@ -403,18 +404,17 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             try
             {
                 // Validate path to prevent command injection
-                Tools.PathValidator.ValidatePathOrThrow(path, nameof(path));
+                PathValidator.ValidatePathOrThrow(path, nameof(path));
                 
                 // when all fails open filelocation to logfile...
                 // Open Windows Explorer to the directory containing the file
-                // Use ArgumentList for better security with separate arguments
+                // Explorer expects /select,"path" as a single argument
                 var startInfo = new ProcessStartInfo
                 {
                     FileName = "explorer.exe",
                     UseShellExecute = false
                 };
-                startInfo.ArgumentList.Add("/select,");
-                startInfo.ArgumentList.Add(path);
+                startInfo.ArgumentList.Add($"/select,\"{path}\"");
                 Process.Start(startInfo);
             return true;
         }

--- a/mRemoteNG/UI/Menu/msMain/HelpMenu.cs
+++ b/mRemoteNG/UI/Menu/msMain/HelpMenu.cs
@@ -188,19 +188,29 @@ namespace mRemoteNG.UI.Menu
             }
         }
 
-        private void mMenInfoHelp_Click(object? sender, EventArgs e) => Process.Start("explorer.exe", GeneralAppInfo.UrlDocumentation);
+        private void mMenInfoHelp_Click(object? sender, EventArgs e) => OpenUrl(GeneralAppInfo.UrlDocumentation);
 
-        private void mMenInfoForum_Click(object? sender, EventArgs e) => Process.Start("explorer.exe", GeneralAppInfo.UrlForum);
+        private void mMenInfoForum_Click(object? sender, EventArgs e) => OpenUrl(GeneralAppInfo.UrlForum);
 
-        private void mMenInfoChat_Click(object? sender, EventArgs e) => Process.Start("explorer.exe", GeneralAppInfo.UrlChat);
+        private void mMenInfoChat_Click(object? sender, EventArgs e) => OpenUrl(GeneralAppInfo.UrlChat);
 
-        private void mMenInfoCommunity_Click(object? sender, EventArgs e) => Process.Start("explorer.exe", GeneralAppInfo.UrlCommunity);
+        private void mMenInfoCommunity_Click(object? sender, EventArgs e) => OpenUrl(GeneralAppInfo.UrlCommunity);
 
-        private void mMenInfoBug_Click(object? sender, EventArgs e) => Process.Start("explorer.exe", GeneralAppInfo.UrlBugs);
+        private void mMenInfoBug_Click(object? sender, EventArgs e) => OpenUrl(GeneralAppInfo.UrlBugs);
 
-        private void mMenInfoWebsite_Click(object? sender, EventArgs e) => Process.Start("explorer.exe", GeneralAppInfo.UrlHome);
+        private void mMenInfoWebsite_Click(object? sender, EventArgs e) => OpenUrl(GeneralAppInfo.UrlHome);
 
-        private void mMenInfoDonate_Click(object? sender, EventArgs e) => Process.Start("explorer.exe", GeneralAppInfo.UrlDonate);
+        private void mMenInfoDonate_Click(object? sender, EventArgs e) => OpenUrl(GeneralAppInfo.UrlDonate);
+        
+        private static void OpenUrl(string url)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = url,
+                UseShellExecute = true
+            };
+            Process.Start(startInfo);
+        }
 
         private void mMenInfoAbout_Click(object? sender, EventArgs e)
         {

--- a/mRemoteNG/UI/Window/UpdateWindow.cs
+++ b/mRemoteNG/UI/Window/UpdateWindow.cs
@@ -99,7 +99,12 @@ namespace mRemoteNG.UI.Window
                 return;
             }
 
-            Process.Start(linkUri.ToString());
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = linkUri.ToString(),
+                UseShellExecute = true
+            };
+            Process.Start(startInfo);
         }
 
         #endregion

--- a/mRemoteNGTests/Connection/Protocol/ProtocolAnydeskTests.cs
+++ b/mRemoteNGTests/Connection/Protocol/ProtocolAnydeskTests.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Reflection;
+using mRemoteNG.Connection;
+using mRemoteNG.Connection.Protocol.AnyDesk;
+using NUnit.Framework;
+
+namespace mRemoteNGTests.Connection.Protocol;
+
+public class ProtocolAnydeskTests
+{
+    private ProtocolAnyDesk _protocolAnydesk;
+    private ConnectionInfo _connectionInfo;
+
+    [SetUp]
+    public void Setup()
+    {
+        _connectionInfo = new ConnectionInfo();
+        _protocolAnydesk = new ProtocolAnyDesk(_connectionInfo);
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        _protocolAnydesk?.Close();
+        _protocolAnydesk = null;
+        _connectionInfo = null;
+    }
+
+    #region IsValidAnydeskId Tests
+
+    [Test]
+    public void IsValidAnydeskId_NumericId_ReturnsTrue()
+    {
+        // Valid numeric AnyDesk ID
+        bool result = InvokeIsValidAnydeskId("123456789");
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_AlphanumericWithAt_ReturnsTrue()
+    {
+        // Valid alias format: alias@ad
+        bool result = InvokeIsValidAnydeskId("myalias@ad");
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_WithHyphen_ReturnsTrue()
+    {
+        // Valid ID with hyphen
+        bool result = InvokeIsValidAnydeskId("my-alias@ad");
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_WithUnderscore_ReturnsTrue()
+    {
+        // Valid ID with underscore
+        bool result = InvokeIsValidAnydeskId("my_alias@ad");
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_WithDot_ReturnsTrue()
+    {
+        // Valid ID with dot
+        bool result = InvokeIsValidAnydeskId("alias.name@ad");
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_WithSemicolon_ReturnsFalse()
+    {
+        // Command injection attempt with semicolon
+        bool result = InvokeIsValidAnydeskId("123456789; calc.exe");
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_WithAmpersand_ReturnsFalse()
+    {
+        // Command injection attempt with ampersand
+        bool result = InvokeIsValidAnydeskId("123456789 & calc.exe");
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_WithPipe_ReturnsFalse()
+    {
+        // Command injection attempt with pipe
+        bool result = InvokeIsValidAnydeskId("123456789 | calc.exe");
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_WithRedirection_ReturnsFalse()
+    {
+        // Command injection attempt with redirection
+        bool result = InvokeIsValidAnydeskId("123456789 > output.txt");
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_WithBacktick_ReturnsFalse()
+    {
+        // PowerShell escape character
+        bool result = InvokeIsValidAnydeskId("123456789`calc");
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_WithDollarSign_ReturnsFalse()
+    {
+        // PowerShell variable indicator
+        bool result = InvokeIsValidAnydeskId("123456789$var");
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_WithParentheses_ReturnsFalse()
+    {
+        // Command substitution
+        bool result = InvokeIsValidAnydeskId("123456789(calc)");
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_WithNewline_ReturnsFalse()
+    {
+        // Newline injection
+        bool result = InvokeIsValidAnydeskId("123456789\ncalc");
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_WithCarriageReturn_ReturnsFalse()
+    {
+        // Carriage return injection
+        bool result = InvokeIsValidAnydeskId("123456789\rcalc");
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_WithQuotes_ReturnsFalse()
+    {
+        // Quote escape attempt
+        bool result = InvokeIsValidAnydeskId("123456789\"calc\"");
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_WithSingleQuotes_ReturnsFalse()
+    {
+        // Single quote escape attempt
+        bool result = InvokeIsValidAnydeskId("123456789'calc'");
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_EmptyString_ReturnsFalse()
+    {
+        // Empty string
+        bool result = InvokeIsValidAnydeskId("");
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_Whitespace_ReturnsFalse()
+    {
+        // Only whitespace
+        bool result = InvokeIsValidAnydeskId("   ");
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsValidAnydeskId_Null_ReturnsFalse()
+    {
+        // Null string
+        bool result = InvokeIsValidAnydeskId(null);
+        Assert.That(result, Is.False);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    /// <summary>
+    /// Uses reflection to invoke the private IsValidAnydeskId method
+    /// </summary>
+    private bool InvokeIsValidAnydeskId(string anydeskId)
+    {
+        var method = typeof(ProtocolAnyDesk).GetMethod("IsValidAnydeskId",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        
+        if (method == null)
+        {
+            throw new Exception("IsValidAnydeskId method not found. The method may have been renamed or removed.");
+        }
+
+        return (bool)method.Invoke(_protocolAnydesk, new object[] { anydeskId });
+    }
+
+    #endregion
+}

--- a/mRemoteNGTests/Tools/ExternalToolsArgumentParserTests.cs
+++ b/mRemoteNGTests/Tools/ExternalToolsArgumentParserTests.cs
@@ -102,6 +102,43 @@ namespace mRemoteNGTests.Tools
                     yield return new TestCaseData(@"^%COMSPEC^%") { TestName = "ChevronEscapedEnvironmentVariablesNotParsed" }.Returns("%COMSPEC%");
                 }
             }
+        }
+
+        [Test]
+        public void PasswordWithCommaIsEscaped()
+        {
+            var connectionInfo = new ConnectionInfo
+            {
+                Password = "1234,56789"
+            };
+            var parser = new ExternalToolArgumentParser(connectionInfo);
+            var result = parser.ParseArguments("%PASSWORD%");
+            Assert.That(result, Is.EqualTo("1234^,56789"));
+        }
+
+        [Test]
+        public void PasswordWithSemicolonIsEscaped()
+        {
+            var connectionInfo = new ConnectionInfo
+            {
+                Password = "1234;56789"
+            };
+            var parser = new ExternalToolArgumentParser(connectionInfo);
+            var result = parser.ParseArguments("%PASSWORD%");
+            Assert.That(result, Is.EqualTo("1234^;56789"));
+        }
+
+        [Test]
+        public void PasswordWithMultipleSpecialCharsIsEscaped()
+        {
+            var connectionInfo = new ConnectionInfo
+            {
+                Password = "pass,word;test&more"
+            };
+            var parser = new ExternalToolArgumentParser(connectionInfo);
+            var result = parser.ParseArguments("%PASSWORD%");
+            Assert.That(result, Is.EqualTo("pass^,word^;test^&more"));
+        }
     }
     }
 }


### PR DESCRIPTION
## Summary

Security and stability hardening for command-line/process invocation paths and external tool argument escaping.

## What this PR includes

- hardens `Process.Start` usage across affected UI/protocol paths to reduce injection risk,
- strengthens AnyDesk input validation + adds dedicated tests,
- extends external-tools argument escaping for credentials containing comma/semicolon (plus special-char regression tests),
- keeps behavior compatible while reducing command/argument parsing ambiguity.

## Issues addressed

- `#2989` Possible command injection via Process.Start
- `#3044` Password split when external tool password contains comma (and related special-character cases)

## Files (high impact)

- `mRemoteNG/Connection/Protocol/AnyDesk/ProtocolAnyDesk.cs`
- `mRemoteNG/Tools/Cmdline/CommandLineArguments.cs`
- `mRemoteNGTests/Connection/Protocol/ProtocolAnydeskTests.cs`
- `mRemoteNGTests/Tools/ExternalToolsArgumentParserTests.cs`

