### PR TITLE
"P5-3005-explicit-SqlClient-SNI-runtime-references"

### DIFF
--- a/mRemoteNG/mRemoteNG.csproj
+++ b/mRemoteNG/mRemoteNG.csproj
@@ -146,6 +146,8 @@
     <PackageReference Include="log4net" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.Data.SqlClient.SNI" />
+    <PackageReference Include="Microsoft.Data.SqlClient.SNI.runtime" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Microsoft.NETCore.Platforms" />
     <PackageReference Include="Microsoft.NETCore.Targets" />


### PR DESCRIPTION
## Summary
- add explicit Microsoft.Data.SqlClient.SNI and Microsoft.Data.SqlClient.SNI.runtime package references in mRemoteNG/mRemoteNG.csproj
- keep versions centrally managed through Directory.Packages.props

## Why
Issue #3005 reports System.BadImageFormatException from Microsoft.Data.SqlClient.SNILoadHandle when using SQL Server backend.

This patch makes the native SNI dependency explicit in the app project so architecture-specific native assets are resolved and copied predictably in platform-targeted builds.

## Validation
- Fork CI run (release branch with this commit included) is green across x86/x64/ARM64:
  - https://github.com/robertpopa22/mRemoteNG/actions/runs/21785156992

## Issue
- Addresses #3005
