### PR TITLE
sql-schema-compatibility-hardening-empty-outdated-tblCons

### DIFF
--- a/mRemoteNG/Config/DataProviders/SqlDataProvider.cs
+++ b/mRemoteNG/Config/DataProviders/SqlDataProvider.cs
@@ -20,11 +20,9 @@ namespace mRemoteNG.Config.DataProviders
             DatabaseConnector.AssociateItemToThisConnector(dbQuery);
             if (!DatabaseConnector.IsConnected)
                 OpenConnection();
-            System.Data.Common.DbDataReader dbDataReader = dbQuery.ExecuteReader(CommandBehavior.CloseConnection);
-
-            if (dbDataReader.HasRows)
-                dataTable.Load(dbDataReader);
-            dbDataReader.Close();
+            using System.Data.Common.DbDataReader dbDataReader = dbQuery.ExecuteReader(CommandBehavior.CloseConnection);
+            // Always load the reader so table schema is available even when tblCons has 0 rows.
+            dataTable.Load(dbDataReader);
             return dataTable;
         }
 

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Sql/DataTableSerializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Sql/DataTableSerializer.cs
@@ -74,7 +74,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Sql
         {
             DataTable dataTable = _sourceDataTable ?? new DataTable(TABLE_NAME);
 
-            if (dataTable.Columns.Count == 0) CreateSchema(dataTable);
+            EnsureSchemaCompatibility(dataTable);
 
             if (dataTable.PrimaryKey.Length == 0) SetPrimaryKey(dataTable);
 
@@ -84,6 +84,27 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Sql
             }
 
             return dataTable;
+        }
+
+        private void EnsureSchemaCompatibility(DataTable dataTable)
+        {
+            if (dataTable.Columns.Count == 0)
+            {
+                CreateSchema(dataTable);
+                return;
+            }
+
+            DataTable expectedSchemaTable = new(TABLE_NAME);
+            CreateSchema(expectedSchemaTable);
+
+            foreach (DataColumn expectedColumn in expectedSchemaTable.Columns)
+            {
+                if (dataTable.Columns.Contains(expectedColumn.ColumnName))
+                    continue;
+
+                DataColumn missingColumn = new(expectedColumn.ColumnName, expectedColumn.DataType);
+                dataTable.Columns.Add(missingColumn);
+            }
         }
 
         private void CreateSchema(DataTable dataTable)

--- a/mRemoteNGTests/Config/Serializers/DataTableSerializerTests.cs
+++ b/mRemoteNGTests/Config/Serializers/DataTableSerializerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Data;
+using System.Linq;
 using System.Security;
 using mRemoteNG.Config.Serializers.ConnectionSerializers.Sql;
 using mRemoteNG.Connection;
@@ -119,6 +120,19 @@ public class DataTableSerializerTests
     {
         var dataTable = _dataTableSerializer.Serialize(new ConnectionInfo());
         Assert.That(dataTable.Rows.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void MissingColumnsAreAddedWhenSourceSqlSchemaIsOutdated()
+    {
+        var sourceDataTable = new DataTable("tblCons");
+        sourceDataTable.Columns.Add("ConstantID", typeof(string));
+        _dataTableSerializer.SetSourceDataTable(sourceDataTable);
+
+        Assert.DoesNotThrow(() => _dataTableSerializer.Serialize(new ConnectionInfo("existing-id")));
+
+        Assert.That(sourceDataTable.Columns.Contains("DisableCursorBlinking"), Is.True);
+        Assert.That(sourceDataTable.Columns.Contains("InheritDisableCursorBlinking"), Is.True);
     }
 
 


### PR DESCRIPTION
## Summary 
- always load tblCons reader schema even when table has 0 rows 
- add serializer schema-compat pass to inject missing required columns for partial or outdated SQL schemas 
- add regression test for missing-column source schema handling 
 
## Why 
Targets SQL save failures such as Missing the DataColumn DisableCursorBlinking and improves resilience with legacy DB schemas (#1916, #1883). 
 
## Validation 
- fork CI green on equivalent commit set: https://github.com/robertpopa22/mRemoteNG/actions/runs/21786116643
