### PR TITLE
"fix-config-panel-splitter-width-reset-after-minimize-850"

### DIFF
--- a/mRemoteNG/UI/Window/ConfigWindow.cs
+++ b/mRemoteNG/UI/Window/ConfigWindow.cs
@@ -497,7 +497,7 @@ namespace mRemoteNG.UI.Window
             _applySplitterWidthQueued = true;
             try
             {
-                BeginInvoke((MethodInvoker)(() =>
+                BeginInvoke((System.Windows.Forms.MethodInvoker)(() =>
                 {
                     _applySplitterWidthQueued = false;
                     TryApplyCachedPropertyGridLabelWidth();


### PR DESCRIPTION
## Summary 
- Fixes issue #850 for config PropertyGrid splitter reset after minimize and maximize. 
- Remembers user-adjusted label/value column split and reapplies it after UI resize and layout cycles. 
- Uses reflection with runtime-safe fallbacks for WinForms internal splitter APIs. 
 
## Files 
- mRemoteNG/UI/Window/ConfigWindow.cs 
 
## Validation 
- Fork CI PR_Validation passed on x86/x64/ARM64 and tests/specs: 
  - https://github.com/robertpopa22/mRemoteNG/actions/runs/21786942297 
