### PR TITLE
Harden-PuTTY-session-name-decoding-CJK-2785

### DIFF
--- a/mRemoteNG/Config/Putty/AbstractPuttySessionsProvider.cs
+++ b/mRemoteNG/Config/Putty/AbstractPuttySessionsProvider.cs
@@ -3,7 +3,6 @@ using System.Collections.Specialized;
 using System.Linq;
 using mRemoteNG.Connection;
 using mRemoteNG.Tree.Root;
-using System.Net;
 using System.Runtime.Versioning;
 
 // ReSharper disable ArrangeAccessorOwnerBody
@@ -54,7 +53,7 @@ namespace mRemoteNG.Config.Putty
             if (sessionNamesFromProvider == null) return Enumerable.Empty<PuttySessionInfo>();
             IEnumerable<string> currentlyKnownSessionNames = Sessions.Select(session => session.Name);
             IEnumerable<string> normalizedSessionNames =
-                sessionNamesFromProvider.Select(name => WebUtility.UrlDecode(name));
+                sessionNamesFromProvider.Select(name => PuttySessionNameDecoder.Decode(name));
             IEnumerable<string> sessionNamesToRemove = currentlyKnownSessionNames.Except(normalizedSessionNames);
             return Sessions.Where(session => sessionNamesToRemove.Contains(session.Name));
         }

--- a/mRemoteNG/Config/Putty/PuttySessionNameDecoder.cs
+++ b/mRemoteNG/Config/Putty/PuttySessionNameDecoder.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.Versioning;
+using System.Text;
+
+namespace mRemoteNG.Config.Putty
+{
+    [SupportedOSPlatform("windows")]
+    public static class PuttySessionNameDecoder
+    {
+        public static string Decode(string encodedSessionName, Encoding fallbackEncoding = null)
+        {
+            if (string.IsNullOrEmpty(encodedSessionName))
+                return encodedSessionName ?? string.Empty;
+
+            string utf8Decoded = DecodeWithEncoding(encodedSessionName, Encoding.UTF8);
+            if (!utf8Decoded.Contains('\uFFFD'))
+                return utf8Decoded;
+
+            Encoding fallback = fallbackEncoding ?? Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.ANSICodePage);
+            return DecodeWithEncoding(encodedSessionName, fallback);
+        }
+
+        private static string DecodeWithEncoding(string encodedSessionName, Encoding encoding)
+        {
+            List<byte> bytes = new(encodedSessionName.Length);
+            for (int i = 0; i < encodedSessionName.Length; i++)
+            {
+                char currentCharacter = encodedSessionName[i];
+                if (currentCharacter == '%' &&
+                    i + 2 < encodedSessionName.Length &&
+                    IsHex(encodedSessionName[i + 1]) &&
+                    IsHex(encodedSessionName[i + 2]))
+                {
+                    bytes.Add(ParseHexByte(encodedSessionName[i + 1], encodedSessionName[i + 2]));
+                    i += 2;
+                }
+                else
+                {
+                    bytes.AddRange(encoding.GetBytes([currentCharacter]));
+                }
+            }
+
+            return encoding.GetString(bytes.ToArray());
+        }
+
+        private static bool IsHex(char value)
+        {
+            return value is >= '0' and <= '9' ||
+                   value is >= 'a' and <= 'f' ||
+                   value is >= 'A' and <= 'F';
+        }
+
+        private static byte ParseHexByte(char high, char low)
+        {
+            return (byte)((HexValue(high) << 4) + HexValue(low));
+        }
+
+        private static int HexValue(char value)
+        {
+            if (value is >= '0' and <= '9')
+                return value - '0';
+            if (value is >= 'a' and <= 'f')
+                return value - 'a' + 10;
+            return value - 'A' + 10;
+        }
+    }
+}

--- a/mRemoteNG/Config/Putty/PuttySessionsRegistryProvider.cs
+++ b/mRemoteNG/Config/Putty/PuttySessionsRegistryProvider.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Management;
-using System.Net;
 using System.Runtime.Versioning;
 using System.Security.Principal;
 using Microsoft.Win32;
@@ -30,8 +29,7 @@ namespace mRemoteNG.Config.Putty
             List<string> sessionNames = new();
             foreach (string sessionName in sessionsKey.GetSubKeyNames())
             {
-                sessionNames.Add(raw ? sessionName
-                                     : WebUtility.UrlDecode(sessionName.Replace("+", "%2B")));
+                sessionNames.Add(raw ? sessionName : PuttySessionNameDecoder.Decode(sessionName));
             }
 
             if (raw && !sessionNames.Contains("Default%20Settings"))
@@ -51,7 +49,7 @@ namespace mRemoteNG.Config.Putty
             RegistryKey sessionKey = sessionsKey?.OpenSubKey(sessionName);
             if (sessionKey == null) return null;
 
-            sessionName = WebUtility.UrlDecode(sessionName.Replace("+", "%2B"));
+            sessionName = PuttySessionNameDecoder.Decode(sessionName);
 
             PuttySessionInfo sessionInfo = new()
             {

--- a/mRemoteNGTests/Config/Putty/PuttySessionNameDecoderTests.cs
+++ b/mRemoteNGTests/Config/Putty/PuttySessionNameDecoderTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Linq;
+using System.Text;
+using mRemoteNG.Config.Putty;
+using NUnit.Framework;
+
+namespace mRemoteNGTests.Config.Putty;
+
+[TestFixture]
+public class PuttySessionNameDecoderTests
+{
+    [Test]
+    public void Decode_DecodesUtf8PercentEncodedName()
+    {
+        const string encodedName = "%EC%84%9C%EB%B2%84%20%EC%84%A4%EC%B9%98";
+
+        string decodedName = PuttySessionNameDecoder.Decode(encodedName);
+
+        Assert.That(decodedName, Is.EqualTo("서버 설치"));
+    }
+
+    [Test]
+    public void Decode_PreservesPlusCharacter()
+    {
+        string decodedName = PuttySessionNameDecoder.Decode("Session+Name");
+
+        Assert.That(decodedName, Is.EqualTo("Session+Name"));
+    }
+
+    [Test]
+    public void Decode_FallsBackWhenUtf8DecodingFails()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+        Encoding koreanCodePage = Encoding.GetEncoding(949);
+        string encodedName = PercentEncode("서버 설치", koreanCodePage);
+
+        string decodedName = PuttySessionNameDecoder.Decode(encodedName, koreanCodePage);
+
+        Assert.That(decodedName, Is.EqualTo("서버 설치"));
+    }
+
+    private static string PercentEncode(string value, Encoding encoding)
+    {
+        byte[] bytes = encoding.GetBytes(value);
+        return string.Concat(bytes.Select(currentByte => $"%{currentByte:X2}"));
+    }
+}


### PR DESCRIPTION
Summary: add centralized PuTTY session-name decoder for percent-encoded registry keys, decode UTF-8 first with deterministic legacy fallback, and share normalization path in provider/removal flow. Includes focused tests for UTF-8, fallback and plus-sign handling. 
 
Linked issue: fixes #2785
