### PR TITLE
fix-rdp-fullscreen-toggle-guard-redirectkeys-847

### DIFF
--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs
@@ -85,6 +85,8 @@ namespace mRemoteNG.Connection.Protocol.RDP
             protected set => _rdpClient.FullScreen = value;
         }
 
+        public bool RedirectKeysEnabled => _redirectKeys;
+
         private bool RedirectKeys
         {
             set

--- a/mRemoteNG/UI/Window/ConnectionWindow.cs
+++ b/mRemoteNG/UI/Window/ConnectionWindow.cs
@@ -423,6 +423,7 @@ namespace mRemoteNG.UI.Window
                 {
                     RdpProtocol rdp = (RdpProtocol)interfaceControl.Protocol;
                     cmenTabFullscreen.Visible = true;
+                    cmenTabFullscreen.Enabled = !rdp.RedirectKeysEnabled || !rdp.Fullscreen;
                     cmenTabFullscreen.Checked = rdp.Fullscreen;
                     cmenTabSmartSize.Visible = true;
                     cmenTabSmartSize.Checked = rdp.SmartSize;
@@ -430,6 +431,7 @@ namespace mRemoteNG.UI.Window
                 else
                 {
                     cmenTabFullscreen.Visible = false;
+                    cmenTabFullscreen.Enabled = true;
                     cmenTabSmartSize.Visible = false;
                 }
 
@@ -609,6 +611,8 @@ namespace mRemoteNG.UI.Window
             {
                 InterfaceControl interfaceControl = GetInterfaceControl();
                 RdpProtocol rdp = interfaceControl?.Protocol as RdpProtocol;
+                if (rdp?.RedirectKeysEnabled == true && rdp.Fullscreen)
+                    return;
                 rdp?.ToggleFullscreen();
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- expose a runtime read-only `RedirectKeysEnabled` flag on `RdpProtocol`
- lock context-menu fullscreen toggle when redirect-keys mode is active and session is already fullscreen
- keep fullscreen toggle enabled for entering fullscreen (only lock the unstable exit path)

## Issue
- addresses #847

## Validation
- fork CI (same fix merged on release branch): https://github.com/robertpopa22/mRemoteNG/actions/runs/21789456797
- local release-branch validation:
  - `Release|x64` solution build passed
  - targeted tests passed:
    - `FullyQualifiedName~ConnectionsService` (4/4)
    - `FullyQualifiedName~XmlConnectionsLoaderTests` (4/4)
    - `FullyQualifiedName~PuttySessionNameDecoderTests` (3/3)
