### PR TITLE
fix-rdp-refocus-after-fullscreen-exit-1650

### DIFF
--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs
@@ -948,6 +948,22 @@ namespace mRemoteNG.Connection.Protocol.RDP
         {
             Fullscreen = false;
             _leaveFullscreenEvent?.Invoke(this, EventArgs.Empty);
+
+            try
+            {
+                if (_frmMain.WindowState == FormWindowState.Minimized)
+                {
+                    _frmMain.WindowState = FormWindowState.Normal;
+                }
+
+                _frmMain.Activate();
+                InterfaceControl?.Parent?.Focus();
+                Focus();
+            }
+            catch (Exception ex)
+            {
+                Runtime.MessageCollector.AddExceptionStackTrace("RDP leave-fullscreen refocus failed", ex, MessageClass.WarningMsg, false);
+            }
         }
 
         private void RdpClient_GotFocus(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- handle `OnLeaveFullScreenMode` by actively restoring and activating the main form (if minimized/backgrounded)
- refocus the active connection control after fullscreen exit
- reduce the "app goes to background after leaving fullscreen" behavior on RDP sessions

## Issue
- addresses #1650

## Validation
- fork CI (same fix merged on release branch): https://github.com/robertpopa22/mRemoteNG/actions/runs/21789549099
- local release-branch validation:
  - `Release|x64` solution build passed
  - targeted test passed:
    - `FullyQualifiedName~ConnectionsService` (4/4)
