### PR TITLE
codex/pr16 settings path observability 2987

### DIFF
--- a/mRemoteNG/App/Initialization/StartupDataLogger.cs
+++ b/mRemoteNG/App/Initialization/StartupDataLogger.cs
@@ -3,6 +3,7 @@ using System.Management;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Windows.Forms;
+using mRemoteNG.App.Info;
 using mRemoteNG.Messages;
 using mRemoteNG.Resources.Language;
 
@@ -16,6 +17,7 @@ namespace mRemoteNG.App.Initialization
         public void LogStartupData()
         {
             LogApplicationData();
+            LogSettingsData();
             LogCmdLineArgs();
             LogSystemData();
             LogClrData();
@@ -93,6 +95,17 @@ namespace mRemoteNG.App.Initialization
                 data += $" {Language.PortableEdition}";
             data += " starting.";
             _messageCollector.AddMessage(MessageClass.InformationMsg, data, true);
+        }
+
+        private void LogSettingsData()
+        {
+            if (string.IsNullOrWhiteSpace(SettingsFileInfo.UserSettingsFilePath))
+            {
+                return;
+            }
+
+            _messageCollector.AddMessage(MessageClass.InformationMsg,
+                $"User settings file: {SettingsFileInfo.UserSettingsFilePath}", true);
         }
 
         private void LogCmdLineArgs()

--- a/mRemoteNGDocumentation/troubleshooting.rst
+++ b/mRemoteNGDocumentation/troubleshooting.rst
@@ -25,21 +25,29 @@ Portable version
 Crash at Startup
 ================
 
-Try deleting the :code:`user.config` file. It contains all the user-specific program settings. This file is automatically upgraded between version when new user settings are added.
+Try deleting the user settings file. It contains all user-specific program settings and is automatically upgraded between versions.
+
+The exact file path is logged during startup in :code:`mRemoteNG.log` as:
+
+::
+
+   User settings file: <full path>
 
 Installed Version
 -----------------
 
 ::
 
-   %LOCALAPPDATA%\mRemoteNG\<most recently updated folder>\<mRemoteNG version>\user.config
+   %LOCALAPPDATA%\[CompanyName]\mRemoteNG.exe_Url_[hash]\[mRemoteNG version]\user.config
+
+The folder can vary by build metadata (company name and URL hash), so rely on the startup log entry above for the exact location.
 
 Portable Version
 ----------------
 
 ::
 
-   %APPDATA%\mRemoteNG\<most recently updated folder>\<mRemoteNG version>\user.config
+   [location of mRemoteNG.exe]\mRemoteNG.settings
 
 Crash Information
 =================


### PR DESCRIPTION
## Summary
- expose the effective user settings file path via `SettingsFileInfo.UserSettingsFilePath`
- log `User settings file: <path>` during startup to improve supportability
- update troubleshooting docs for installed vs portable settings file locations

## Why
Issue #2987 shows users cannot reliably find/reset settings after config problems. The path is dynamic in installed builds, so logging the exact resolved file path removes guesswork and shortens recovery time.

## Validation
- local .NET SDK build cannot fully validate this repo in current environment due COMReference MSBuild requirement (`MSB4803`)
- patch is queued for CI validation on fork release branch
