### PR TITLE
Require-current-password-before-disabling-Password-protect-2673

### DIFF
--- a/mRemoteNG/Tree/Root/RootNodeInfo.cs
+++ b/mRemoteNG/Tree/Root/RootNodeInfo.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Security;
 using mRemoteNG.Connection;
 using mRemoteNG.Container;
+using mRemoteNG.Security;
 using mRemoteNG.Tools;
 using mRemoteNG.Resources.Language;
 using System.Runtime.Versioning;
@@ -52,6 +54,17 @@ namespace mRemoteNG.Tree.Root
         }
 
         [Browsable(false)] public string DefaultPassword { get; } = "mR3m"; //TODO move password away from code to settings
+
+        [Browsable(false)]
+        public bool IsPasswordMatch(SecureString? providedPassword)
+        {
+            if (providedPassword == null)
+                return false;
+
+            string expectedPassword = string.IsNullOrEmpty(_customPassword) ? DefaultPassword : _customPassword;
+            string suppliedPassword = providedPassword.ConvertToUnsecureString();
+            return string.Equals(expectedPassword, suppliedPassword, StringComparison.Ordinal);
+        }
 
         [Browsable(false)] public RootNodeType Type { get; set; } = rootType;
 

--- a/mRemoteNG/UI/Controls/ConnectionInfoPropertyGrid/ConnectionInfoPropertyGrid.cs
+++ b/mRemoteNG/UI/Controls/ConnectionInfoPropertyGrid/ConnectionInfoPropertyGrid.cs
@@ -348,8 +348,34 @@ namespace mRemoteNG.UI.Controls.ConnectionInfoPropertyGrid {
 
                 rootInfo.PasswordString = password.First().ConvertToUnsecureString();
             } else {
+                if (!CurrentPasswordVerified(rootInfo))
+                {
+                    rootInfo.Password = true;
+                    return;
+                }
+
                 rootInfo.PasswordString = "";
             }
+        }
+
+        private bool CurrentPasswordVerified(RootNodeInfo rootInfo)
+        {
+            string passwordName = Properties.OptionsDBsPage.Default.UseSQLServer
+                ? Language.SQLServer.TrimEnd(':')
+                : Path.GetFileName(Runtime.ConnectionsService.GetStartupConnectionFileName());
+
+            Optional<System.Security.SecureString> password = MiscTools.PasswordDialog(passwordName, false);
+            if (!password.Any() || password.First().Length == 0)
+                return false;
+
+            bool matches = rootInfo.IsPasswordMatch(password.First());
+            if (!matches)
+            {
+                Runtime.MessageCollector.AddMessage(MessageClass.WarningMsg,
+                    "Password protection disable request rejected: provided password did not match.");
+            }
+
+            return matches;
         }
 
         private void UpdateInheritanceNode() {

--- a/mRemoteNG/UI/Forms/FrmPassword.cs
+++ b/mRemoteNG/UI/Forms/FrmPassword.cs
@@ -86,8 +86,8 @@ namespace mRemoteNG.UI.Forms
 
         private void BtnOK_Click(object sender, EventArgs e)
         {
-            if (NewPasswordMode)
-                VerifyNewPassword();
+            if (NewPasswordMode && !VerifyNewPassword())
+                return;
 
             DialogResult = DialogResult.OK;
         }

--- a/mRemoteNGTests/Tree/RootNodeInfoTests.cs
+++ b/mRemoteNGTests/Tree/RootNodeInfoTests.cs
@@ -1,4 +1,5 @@
-﻿using mRemoteNG.Tree;
+﻿using mRemoteNG.Security;
+using mRemoteNG.Tree;
 using mRemoteNG.Tree.Root;
 using NUnit.Framework;
 
@@ -54,6 +55,35 @@ namespace mRemoteNGTests.Tree
             // Edge case: Password property set to true directly without setting PasswordString
             _rootNodeInfo.Password = true;
             Assert.That(_rootNodeInfo.PasswordString, Is.EqualTo(_rootNodeInfo.DefaultPassword));
+        }
+
+        [Test]
+        public void IsPasswordMatchReturnsTrueForDefaultPasswordWhenNoCustomPasswordSet()
+        {
+            Assert.That(_rootNodeInfo.IsPasswordMatch(_rootNodeInfo.DefaultPassword.ConvertToSecureString()), Is.True);
+        }
+
+        [Test]
+        public void IsPasswordMatchReturnsTrueForCustomPasswordEvenWhenPasswordFlagIsFalse()
+        {
+            _rootNodeInfo.PasswordString = "custom";
+            _rootNodeInfo.Password = false;
+
+            Assert.That(_rootNodeInfo.IsPasswordMatch("custom".ConvertToSecureString()), Is.True);
+        }
+
+        [Test]
+        public void IsPasswordMatchReturnsFalseForWrongPassword()
+        {
+            _rootNodeInfo.PasswordString = "custom";
+
+            Assert.That(_rootNodeInfo.IsPasswordMatch("wrong".ConvertToSecureString()), Is.False);
+        }
+
+        [Test]
+        public void IsPasswordMatchReturnsFalseForNullPassword()
+        {
+            Assert.That(_rootNodeInfo.IsPasswordMatch(null), Is.False);
         }
 
         [TestCase(RootNodeType.Connection, TreeNodeType.Root)]


### PR DESCRIPTION
## Summary  
- require the current password before allowing `Password protect` to be disabled on the root node (issue #2673). 
- keep `Password protect` enabled if password entry is cancelled or does not match. 
- fix `FrmPassword` so `OK` is blocked in new-password mode when verification fails. 
- add `RootNodeInfo` tests for password matching behavior, including the disabled-flag scenario. 
 
## Notes 
- this is scoped to password-protection safety; no encryption format or serialization changes. 
- local dotnet test/build in this shell remains blocked by COM reference build limitation (`MSB4803`), so validation is CI-first. 
