### PR TITLE
Add-master-password-autolock-on-minimize-idle-1649

### DIFF
--- a/mRemoteNG/App/NativeMethods.cs
+++ b/mRemoteNG/App/NativeMethods.cs
@@ -104,6 +104,9 @@ namespace mRemoteNG.App
         [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
 
+        [DllImport("user32.dll", SetLastError = true)]
+        internal static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
+
         [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern int GetDlgCtrlID(IntPtr hwndCtl);
 
@@ -156,9 +159,29 @@ namespace mRemoteNG.App
             public long bottom;
         }
 
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct LASTINPUTINFO
+        {
+            public uint cbSize;
+            public uint dwTime;
+        }
+
         #endregion
 
         #region Helpers
+
+        public static int GetIdleMilliseconds()
+        {
+            LASTINPUTINFO lastInputInfo = new()
+            {
+                cbSize = (uint)Marshal.SizeOf(typeof(LASTINPUTINFO))
+            };
+
+            if (!GetLastInputInfo(ref lastInputInfo))
+                return 0;
+
+            return unchecked((int)(Environment.TickCount - lastInputInfo.dwTime));
+        }
 
         public static int MAKELONG(int wLow, int wHigh)
         {

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
@@ -120,6 +120,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
         private void InitializeRootNode(XmlElement connectionsRootElement)
         {
             _rootNodeInfo.Name = connectionsRootElement?.Attributes["Name"]?.Value.Trim();
+            _rootNodeInfo.AutoLockOnMinimize = connectionsRootElement.GetAttributeAsBool("AutoLockOnMinimize");
         }
 
         private void CreateDecryptor(RootNodeInfo rootNodeInfo, XmlElement connectionsRootElement = null)

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlRootNodeSerializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlRootNodeSerializer.cs
@@ -20,6 +20,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
             element.Add(new XAttribute(XName.Get("BlockCipherMode"), cryptographyProvider.CipherMode));
             element.Add(new XAttribute(XName.Get("KdfIterations"), cryptographyProvider.KeyDerivationIterations));
             element.Add(new XAttribute(XName.Get("FullFileEncryption"), fullFileEncryption.ToString().ToLowerInvariant()));
+            element.Add(new XAttribute(XName.Get("AutoLockOnMinimize"), rootNodeInfo.AutoLockOnMinimize.ToString().ToLowerInvariant()));
             element.Add(CreateProtectedAttribute(rootNodeInfo, cryptographyProvider));
             element.Add(new XAttribute(XName.Get("ConfVersion"), version.ToString(2)));
             return element;

--- a/mRemoteNG/Tools/NotificationAreaIcon.cs
+++ b/mRemoteNG/Tools/NotificationAreaIcon.cs
@@ -103,19 +103,23 @@ namespace mRemoteNG.Tools
             }
             else
             {
-                ShowForm();
-                FrmMain.ShowInTaskbar = true;
+                if (ShowForm())
+                    FrmMain.ShowInTaskbar = true;
             }
         }
 
-        private static void ShowForm()
+        private static bool ShowForm()
         {
+            if (!FrmMain.TryUnlockIfNeeded())
+                return false;
+
             FrmMain.Show();
             FrmMain.WindowState = FrmMain.PreviousWindowState;
 
-            if (Properties.OptionsAppearancePage.Default.ShowSystemTrayIcon) return;
+            if (Properties.OptionsAppearancePage.Default.ShowSystemTrayIcon) return true;
             Runtime.NotificationAreaIcon.Dispose();
             Runtime.NotificationAreaIcon = null;
+            return true;
         }
 
         private static void HideForm()
@@ -128,8 +132,8 @@ namespace mRemoteNG.Tools
         {
             if (e.Button != MouseButtons.Left) return;
             if (((ToolStripMenuItem)sender).Tag is ContainerInfo) return;
-            if (FrmMain.Visible == false)
-                ShowForm();
+            if (FrmMain.Visible == false && !ShowForm())
+                return;
             Runtime.ConnectionInitiator.OpenConnection((ConnectionInfo)((ToolStripMenuItem)sender).Tag);
         }
 

--- a/mRemoteNG/Tree/Root/RootNodeInfo.cs
+++ b/mRemoteNG/Tree/Root/RootNodeInfo.cs
@@ -40,6 +40,13 @@ namespace mRemoteNG.Tree.Root
          TypeConverter(typeof(MiscTools.YesNoTypeConverter))]
         public new bool Password { get; set; }
 
+        [LocalizedAttributes.LocalizedCategory(nameof(Language.Miscellaneous)),
+         Browsable(true),
+         DisplayName("Auto lock on minimize"),
+         Description("Require master password when restoring the app after minimize."),
+         TypeConverter(typeof(MiscTools.YesNoTypeConverter))]
+        public bool AutoLockOnMinimize { get; set; }
+
         [Browsable(false)]
         public string PasswordString
         {

--- a/mRemoteNG/UI/Controls/ConnectionInfoPropertyGrid/ConnectionInfoPropertyGrid.cs
+++ b/mRemoteNG/UI/Controls/ConnectionInfoPropertyGrid/ConnectionInfoPropertyGrid.cs
@@ -116,11 +116,17 @@ namespace mRemoteNG.UI.Controls.ConnectionInfoPropertyGrid {
                             nameof(RootPuttySessionsNodeInfo.Name)
                         };
                     } else if (SelectedConnectionInfo is RootNodeInfo) {
-                        BrowsableProperties = new[]
-                        {
+                        RootNodeInfo rootInfo = (RootNodeInfo)SelectedConnectionInfo;
+                        List<string> rootProperties =
+                        [
                             nameof(RootNodeInfo.Name),
                             nameof(RootNodeInfo.Password)
-                        };
+                        ];
+
+                        if (rootInfo.Password)
+                            rootProperties.Add(nameof(RootNodeInfo.AutoLockOnMinimize));
+
+                        BrowsableProperties = rootProperties.ToArray();
                     }
 
                     Refresh();
@@ -333,7 +339,16 @@ namespace mRemoteNG.UI.Controls.ConnectionInfoPropertyGrid {
             if (!(SelectedObject is RootNodeInfo rootInfo))
                 return;
 
-            if (e.ChangedItem.PropertyDescriptor?.Name != "Password")
+            string changedProperty = e.ChangedItem.PropertyDescriptor?.Name ?? "";
+            if (changedProperty == nameof(RootNodeInfo.AutoLockOnMinimize) && !rootInfo.Password)
+            {
+                rootInfo.AutoLockOnMinimize = false;
+                Runtime.MessageCollector.AddMessage(MessageClass.WarningMsg,
+                    "Autolock requires password protection to be enabled.");
+                return;
+            }
+
+            if (changedProperty != nameof(RootNodeInfo.Password))
                 return;
 
             if (rootInfo.Password) {
@@ -348,6 +363,7 @@ namespace mRemoteNG.UI.Controls.ConnectionInfoPropertyGrid {
 
                 rootInfo.PasswordString = password.First().ConvertToUnsecureString();
             } else {
+                rootInfo.AutoLockOnMinimize = false;
                 rootInfo.PasswordString = "";
             }
         }

--- a/mRemoteNGTests/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializerTests.cs
+++ b/mRemoteNGTests/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializerTests.cs
@@ -6,6 +6,7 @@ using mRemoteNG.Connection;
 using mRemoteNG.Container;
 using mRemoteNG.Security;
 using mRemoteNG.Tree;
+using mRemoteNG.Tree.Root;
 using mRemoteNGTests.Properties;
 using NUnit.Framework;
 
@@ -119,6 +120,19 @@ public class XmlConnectionsDeserializerTests
         Setup(testData.ConfCons, testData.Password);
         var folder1 = GetFolderNamed("Folder1", _connectionTreeModel.GetRecursiveChildList());
         Assert.That(folder1.IsExpanded, Is.True);
+    }
+
+    [Test]
+    public void RootNodeAutoLockOnMinimizeGetsDeserialized()
+    {
+        string xml = Resources.confCons_v2_6.Replace("<Connections ", "<Connections AutoLockOnMinimize=\"true\" ",
+            System.StringComparison.Ordinal);
+
+        Setup(xml, "mR3m");
+        var rootNode = _connectionTreeModel.RootNodes[0] as RootNodeInfo;
+
+        Assert.That(rootNode, Is.Not.Null);
+        Assert.That(rootNode.AutoLockOnMinimize, Is.True);
     }
 
     private bool ContainsNodeNamed(string name, IEnumerable<ConnectionInfo> list)

--- a/mRemoteNGTests/Config/Serializers/ConnectionSerializers/Xml/XmlRootNodeSerializerTests.cs
+++ b/mRemoteNGTests/Config/Serializers/ConnectionSerializers/Xml/XmlRootNodeSerializerTests.cs
@@ -83,6 +83,16 @@ public class XmlRootNodeSerializerTests
         Assert.That(bool.Parse(attributeValue), Is.EqualTo(fullFileEncryption));
     }
 
+    [TestCase(true)]
+    [TestCase(false)]
+    public void AutoLockOnMinimizeSerialized(bool autoLockOnMinimize)
+    {
+        _rootNodeInfo.AutoLockOnMinimize = autoLockOnMinimize;
+        var element = _rootNodeSerializer.SerializeRootNodeInfo(_rootNodeInfo, _cryptographyProvider, _version);
+        var attributeValue = element.Attribute(XName.Get("AutoLockOnMinimize"))?.Value;
+        Assert.That(bool.Parse(attributeValue), Is.EqualTo(autoLockOnMinimize));
+    }
+
     [TestCase("", "ThisIsNotProtected")]
     [TestCase(null, "ThisIsNotProtected")]
     [TestCase("mR3m", "ThisIsNotProtected")]

--- a/mRemoteNGTests/Tree/RootNodeInfoTests.cs
+++ b/mRemoteNGTests/Tree/RootNodeInfoTests.cs
@@ -16,6 +16,12 @@ namespace mRemoteNGTests.Tree
         }
 
         [Test]
+        public void AutoLockOnMinimizeIsDisabledByDefault()
+        {
+            Assert.That(_rootNodeInfo.AutoLockOnMinimize, Is.False);
+        }
+
+        [Test]
         public void DefaultPasswordReturnsExpectedValue()
         {
             var defaultPassword = _rootNodeInfo.DefaultPassword;


### PR DESCRIPTION
## Summary 
- Add root-level `Auto lock on minimize` option, visible only when password protection is enabled. 
- Persist `AutoLockOnMinimize` in root XML attributes. 
- Introduce runtime autolock behavior: 
  - lock when app is minimized (if option enabled) 
  - lock after 5 minutes of system inactivity (if option enabled) 
- Require master password to unlock when restoring from tray/taskbar. 
- Add regression tests for root default value and XML serialize/deserialize of the new flag. 
 
## Issue 
- Closes #1649
