### PR TITLE
Fix-Config-Connections-restored-panel-focus-override-2171

### DIFF
--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -250,7 +250,12 @@ namespace mRemoteNG.UI.Forms
             // Initialize panel binding for Connections and Config panels
             UI.Panels.PanelBinder.Instance.Initialize();
 
-            AppWindows.TreeForm.Focus();
+            // Respect the active panel restored from persisted dock layout.
+            // Fallback to the Connections panel only when no active content was restored.
+            if (pnlDock.ActiveContent == null && AppWindows.TreeForm.Visible)
+            {
+                AppWindows.TreeForm.Focus();
+            }
 
             PuttySessionsManager.Instance.StartWatcher();
 


### PR DESCRIPTION
Summary 
- preserve the active Connections/Config panel restored from persisted dock layout 
- avoid forcing Connections panel focus right after layout restore 
- fallback to Connections focus only when no active dock content exists 
 
Why 
Issue #2171 reports Config/Connections panel position or selection not retained after restart. 
The startup path always called AppWindows.TreeForm.Focus and could override restored active panel state. 
 
Validation 
- local shell in this session has no dotnet or msbuild; validation is CI and manual repro first. 
