### PR TITLE
fix-inheritance-property-labels-cut-off-2155

### DIFF
--- a/mRemoteNG/UI/Window/ConfigWindow.cs
+++ b/mRemoteNG/UI/Window/ConfigWindow.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Net.NetworkInformation;
+using System.Reflection;
 using System.Threading;
 using System.Windows.Forms;
 using mRemoteNG.App;
@@ -39,6 +41,11 @@ namespace mRemoteNG.UI.Window
         private ToolStripSeparator _toolStripSeparator1;
         private ConnectionInfoPropertyGrid _pGrid;
         private ThemeManager _themeManager;
+        private bool _autoSizePropertyGridLabelWidthQueued;
+        private const int MinPropertyNameColumnWidth = 50;
+        private const int MinPropertyValueColumnWidth = 80;
+        private const int PropertyNameTextPadding = 24;
+        private static readonly BindingFlags NonPublicInstanceBinding = BindingFlags.Instance | BindingFlags.NonPublic;
 
         private ConnectionInfo _selectedTreeNode;
 
@@ -342,6 +349,7 @@ namespace mRemoteNG.UI.Window
                 UpdateShowDefaultInheritanceButton();
                 UpdateHostStatusButton();
                 UpdateIconButton();
+                QueueAutoSizePropertyGridLabelWidth();
             }
             catch (Exception ex)
             {
@@ -466,6 +474,7 @@ namespace mRemoteNG.UI.Window
             ApplyTheme();
             AddToolStripItems();
             _pGrid.HelpVisible = Settings.Default.ShowConfigHelpText;
+            QueueAutoSizePropertyGridLabelWidth();
         }
 
         private void Config_SystemColorsChanged(object sender, EventArgs e)
@@ -500,6 +509,8 @@ namespace mRemoteNG.UI.Window
         {
             if (_pGrid.PropertySort == PropertySort.CategorizedAlphabetical)
                 _pGrid.PropertySort = PropertySort.Categorized;
+
+            QueueAutoSizePropertyGridLabelWidth();
         }
 
         private void BtnShowProperties_Click(object sender, EventArgs e)
@@ -581,6 +592,144 @@ namespace mRemoteNG.UI.Window
             {
                 Runtime.MessageCollector.AddMessage(MessageClass.ErrorMsg, Language.ConfigPropertyGridMenuClickFailed + Environment.NewLine + ex.Message, true);
             }
+        }
+
+        private void QueueAutoSizePropertyGridLabelWidth()
+        {
+            if (_autoSizePropertyGridLabelWidthQueued || !_pGrid.IsHandleCreated || IsDisposed || Disposing)
+                return;
+
+            _autoSizePropertyGridLabelWidthQueued = true;
+            try
+            {
+                BeginInvoke((System.Windows.Forms.MethodInvoker)(() =>
+                {
+                    _autoSizePropertyGridLabelWidthQueued = false;
+                    AutoSizePropertyGridLabelWidth();
+                }));
+            }
+            catch (ObjectDisposedException)
+            {
+                _autoSizePropertyGridLabelWidthQueued = false;
+            }
+            catch (InvalidOperationException)
+            {
+                _autoSizePropertyGridLabelWidthQueued = false;
+            }
+        }
+
+        private void AutoSizePropertyGridLabelWidth()
+        {
+            if (!_pGrid.Visible || _pGrid.SelectedObject == null)
+                return;
+
+            int maxLabelWidth = Math.Max(MinPropertyNameColumnWidth, _pGrid.ClientSize.Width - MinPropertyValueColumnWidth);
+            if (maxLabelWidth <= MinPropertyNameColumnWidth)
+                return;
+
+            int requiredLabelWidth = CalculateRequiredPropertyGridLabelWidth();
+            if (requiredLabelWidth <= MinPropertyNameColumnWidth)
+                return;
+
+            int targetLabelWidth = Math.Min(requiredLabelWidth, maxLabelWidth);
+            if (targetLabelWidth <= MinPropertyNameColumnWidth)
+                return;
+
+            if (TryGetPropertyGridLabelWidth(_pGrid, out int currentLabelWidth) && currentLabelWidth >= targetLabelWidth)
+                return;
+
+            TrySetPropertyGridLabelWidth(_pGrid, targetLabelWidth);
+        }
+
+        private int CalculateRequiredPropertyGridLabelWidth()
+        {
+            if (_pGrid.SelectedObject == null)
+                return 0;
+
+            int requiredLabelWidth = 0;
+            PropertyDescriptorCollection objectProperties = TypeDescriptor.GetProperties(_pGrid.SelectedObject);
+
+            foreach (string propertyName in VisibleObjectProperties)
+            {
+                PropertyDescriptor descriptor = objectProperties.Find(propertyName, true);
+                string displayName = descriptor?.DisplayName;
+                if (string.IsNullOrWhiteSpace(displayName))
+                    continue;
+
+                int labelWidth = TextRenderer.MeasureText(displayName, _pGrid.Font).Width + PropertyNameTextPadding;
+                if (labelWidth > requiredLabelWidth)
+                    requiredLabelWidth = labelWidth;
+            }
+
+            return requiredLabelWidth;
+        }
+
+        private static bool TryGetPropertyGridLabelWidth(PropertyGrid propertyGrid, out int labelWidth)
+        {
+            labelWidth = 0;
+            if (propertyGrid == null)
+                return false;
+
+            try
+            {
+                object gridView = typeof(PropertyGrid).GetField("gridView", NonPublicInstanceBinding)?.GetValue(propertyGrid);
+                if (gridView == null)
+                    return false;
+
+                PropertyInfo internalLabelWidth = gridView.GetType().GetProperty("InternalLabelWidth", NonPublicInstanceBinding);
+                if (internalLabelWidth?.GetValue(gridView) is int widthFromProperty && widthFromProperty > 0)
+                {
+                    labelWidth = widthFromProperty;
+                    return true;
+                }
+
+                FieldInfo labelWidthField = gridView.GetType().GetField("labelWidth", NonPublicInstanceBinding);
+                if (labelWidthField?.GetValue(gridView) is int widthFromField && widthFromField > 0)
+                {
+                    labelWidth = widthFromField;
+                    return true;
+                }
+            }
+            catch
+            {
+                // Ignore reflection differences between runtime versions.
+            }
+
+            return false;
+        }
+
+        private static bool TrySetPropertyGridLabelWidth(PropertyGrid propertyGrid, int labelWidth)
+        {
+            if (propertyGrid == null || labelWidth <= 0)
+                return false;
+
+            try
+            {
+                object gridView = typeof(PropertyGrid).GetField("gridView", NonPublicInstanceBinding)?.GetValue(propertyGrid);
+                if (gridView == null)
+                    return false;
+
+                MethodInfo moveSplitterTo = gridView.GetType().GetMethod("MoveSplitterTo", NonPublicInstanceBinding);
+                if (moveSplitterTo != null)
+                {
+                    moveSplitterTo.Invoke(gridView, [labelWidth]);
+                    return true;
+                }
+
+                PropertyInfo internalLabelWidth = gridView.GetType().GetProperty("InternalLabelWidth", NonPublicInstanceBinding);
+                if (internalLabelWidth is { CanWrite: true })
+                {
+                    internalLabelWidth.SetValue(gridView, labelWidth);
+                    propertyGrid.Invalidate();
+                    return true;
+                }
+            }
+            catch
+            {
+                // Ignore reflection differences between runtime versions.
+            }
+
+            return false;
         }
 
         #endregion


### PR DESCRIPTION
## Summary 
- auto-size the Config PropertyGrid name column based on visible property display names 
- re-apply sizing after config state transitions and property-sort updates 
- cap label width to preserve a minimum value-column width 
 
## Validation 
- `MSBuild.exe mRemoteNG.sln /m /p:Configuration=Release /p:Platform=x64 /t:Restore` 
- `MSBuild.exe mRemoteNG.sln /m /p:Configuration=Release /p:Platform=x64 /t:Build` 
 
## Issue 
- closes #2155
