### PR TITLE
AlwaysShowPanelTabs Setting Not Respected at Application…

### DIFF
--- a/mRemoteNG/Config/Settings/SettingsLoader.cs
+++ b/mRemoteNG/Config/Settings/SettingsLoader.cs
@@ -55,7 +55,6 @@ namespace mRemoteNG.Config.Settings
                 SetShowSystemTrayIcon();
                 SetAutoSave();
                 LoadExternalAppsFromXml();
-                SetAlwaysShowPanelTabs();
 
                 if (Properties.App.Default.ResetToolbars)
                     SetToolbarsDefault();
@@ -66,12 +65,6 @@ namespace mRemoteNG.Config.Settings
             {
                 _messageCollector.AddExceptionMessage("Loading settings failed", ex);
             }
-        }
-
-        private static void SetAlwaysShowPanelTabs()
-        {
-            if (Properties.OptionsTabsPanelsPage.Default.AlwaysShowPanelTabs)
-                FrmMain.Default.pnlDock.DocumentStyle = DocumentStyle.DockingWindow;
         }
 
 

--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -234,6 +234,8 @@ namespace mRemoteNG.UI.Forms
             else
                 SetLayout();
 
+            ShowHidePanelTabs();
+
             Runtime.ConnectionsService.ConnectionsLoaded += ConnectionsServiceOnConnectionsLoaded;
             Runtime.ConnectionsService.ConnectionsSaved += ConnectionsServiceOnConnectionsSaved;
             


### PR DESCRIPTION
## Description
Attempts to fix #3142: The AlwaysShowPanelTabs setting in mRemoteNG is not properly applied when the application starts up. Users must manually re-toggle the setting in the options dialog for it to take effect, even though the setting appears to be saved correctly.

## Motivation and Context
The issue is in the SettingsLoader.cs file where the SetAlwaysShowPanelTabs() method is called during application initialization, but it has two problems:

- It is called before the UI panels were loaded from the layout file
- It only handled the "true" case (setting DocumentStyle.DockingWindow) but did nothing for the "false" case

The proper logic for AlwaysShowPanelTabs is implemented in the ShowHidePanelTabs() method, which:
 - When AlwaysShowPanelTabs is true: Shows tabs (DocumentStyle.DockingWindow)
 - When AlwaysShowPanelTabs is false: Shows tabs only if there are multiple non-connection panels, otherwise hides tabs (DocumentStyle.DockingSdi)

## How Has This Been Tested?
Complied locally and tested

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [X] All Tests within VisualStudio are passing
- [X] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
