### PR TITLE
Fix Automatic Update Check Running Every Startup & Ignoring Preferences

### DIFF
--- a/mRemoteNG/UI/Forms/OptionsPages/UpdatesPage.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/UpdatesPage.cs
@@ -127,6 +127,10 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             Properties.OptionsUpdatesPage.Default.UpdateProxyAuthUser = txtProxyUsername.Text;
             LegacyRijndaelCryptographyProvider cryptographyProvider = new();
             Properties.OptionsUpdatesPage.Default.UpdateProxyAuthPass = cryptographyProvider.Encrypt(txtProxyPassword.Text, Runtime.EncryptionKey);
+
+            // Mark that the user has explicitly configured their update preference so the
+            // first-run preference prompt does not appear again.
+            Properties.OptionsUpdatesPage.Default.CheckForUpdatesAsked = true;
         }
 
         public override void LoadRegistrySettings()

--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -416,6 +416,15 @@ namespace mRemoteNG.UI.Forms
             if (!CommonRegistrySettings.AllowCheckForUpdatesAutomatical) return;
 
             if (Properties.OptionsUpdatesPage.Default.CheckForUpdatesAsked) return;
+
+            // If the user has already explicitly disabled automatic updates via settings, don't ask again
+            if (!Properties.OptionsUpdatesPage.Default.CheckForUpdatesOnStartup)
+            {
+                Properties.OptionsUpdatesPage.Default.CheckForUpdatesAsked = true;
+                Properties.OptionsUpdatesPage.Default.Save();
+                return;
+            }
+
             string[] commandButtons =
             [
                 Language.AskUpdatesCommandRecommended,
@@ -425,16 +434,25 @@ namespace mRemoteNG.UI.Forms
 
             CTaskDialog.ShowTaskDialogBox(this, GeneralAppInfo.ProductName, Language.AskUpdatesMainInstruction, string.Format(Language.AskUpdatesContent, GeneralAppInfo.ProductName), "", "", "", "", string.Join(" | ", commandButtons), ETaskDialogButtons.None, ESysIcons.Question, ESysIcons.Question);
 
-            if (CTaskDialog.CommandButtonResult == 0 | CTaskDialog.CommandButtonResult == 1)
+            if (CTaskDialog.CommandButtonResult == 0)
             {
+                // Use Recommended Settings: enable automatic updates with the default frequency
+                Properties.OptionsUpdatesPage.Default.CheckForUpdatesOnStartup = true;
+                if (Properties.OptionsUpdatesPage.Default.CheckForUpdatesFrequencyDays < 1)
+                    Properties.OptionsUpdatesPage.Default.CheckForUpdatesFrequencyDays = 14;
                 Properties.OptionsUpdatesPage.Default.CheckForUpdatesAsked = true;
+                Properties.OptionsUpdatesPage.Default.Save();
             }
-
-            if (CTaskDialog.CommandButtonResult != 1) return;
-
-            AppWindows.Show(WindowType.Options);
-            if (AppWindows.OptionsFormWindow != null)
-                AppWindows.OptionsFormWindow.SetActivatedPage(Language.Updates);
+            else if (CTaskDialog.CommandButtonResult == 1)
+            {
+                // Customize: let the user configure update settings manually, then open Options
+                Properties.OptionsUpdatesPage.Default.CheckForUpdatesAsked = true;
+                Properties.OptionsUpdatesPage.Default.Save();
+                AppWindows.Show(WindowType.Options);
+                if (AppWindows.OptionsFormWindow != null)
+                    AppWindows.OptionsFormWindow.SetActivatedPage(Language.Updates);
+            }
+            // For "Ask Later" (button 2), CheckForUpdatesAsked remains false so the dialog will show again next startup
         }
 
         private async Task CheckForUpdates()


### PR DESCRIPTION
## Description
Fix automatic update check running on every startup regardless of user preferences, and wire up the update preference dialog buttons correctly.

Three bugs were fixed:

1. **Update preference dialog appeared every startup even when updates were disabled** - `PromptForUpdatesPreference()` only guarded on `CheckForUpdatesAsked`, so if the user had explicitly disabled `CheckForUpdatesOnStartup` via the Options dialog, the prompt would still appear repeatedly. Added an early-exit that sets `CheckForUpdatesAsked = true` and persists it when `CheckForUpdatesOnStartup` is already `false`.

2. **"Use Recommended Settings" button did not enable automatic updates** - The button handler only set `CheckForUpdatesAsked = true` but never actually set `CheckForUpdatesOnStartup = true` or ensured a valid `CheckForUpdatesFrequencyDays` value. Fixed to fully configure automatic updates (defaulting frequency to 14 days if unset).

3. **Options dialog save did not prevent the preference prompt from reappearing** - `UpdatesPage.SaveSettings()` never set `CheckForUpdatesAsked = true`, so the first-run prompt would reappear even after the user explicitly saved their update preference via the Options dialog. Fixed by setting `CheckForUpdatesAsked = true` at the end of `SaveSettings()`.

All dialog button responses now immediately call `Properties.OptionsUpdatesPage.Default.Save()` to persist the choice even if the app is closed before the normal shutdown save path runs.

## Motivation and Context
The update check preference dialog appeared on every launch regardless of what was configured in the Options dialog, which was annoying me.

## How Has This Been Tested?
- Launched the application with `CheckForUpdatesAsked = false` and `CheckForUpdatesOnStartup = false` - confirmed the preference prompt no longer appears.
- Launched with `CheckForUpdatesAsked = false` and `CheckForUpdatesOnStartup = true` - confirmed the prompt appears once, and not again on subsequent launches.
- Clicked "Use Recommended Settings" - confirmed `CheckForUpdatesOnStartup` is set to `true` and `CheckForUpdatesFrequencyDays` defaults to 14.
- Clicked "Customize" - confirmed Options dialog opens on the Updates page and the prompt does not reappear on next launch.
- Clicked "Ask Later" - confirmed the prompt reappears on the next launch only.
- Saved update preferences via the Options dialog - confirmed the preference prompt does not reappear on next launch.
- Verified all existing NUnit tests pass with `dotnet test mRemoteNGTests/mRemoteNGTests.csproj`.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.