### PR TITLE
Refactor Options Dialog

### DIFF
--- a/mRemoteNG/App/AppWindows.cs
+++ b/mRemoteNG/App/AppWindows.cs
@@ -48,6 +48,10 @@ namespace mRemoteNG.App
                         if (OptionsFormWindow == null || OptionsFormWindow.IsDisposed)
                             OptionsFormWindow = new OptionsWindow();
                         OptionsFormWindow.SetActivatedPage(Language.StartupExit);
+                        // Reload controls from stored settings before every show so that any
+                        // edits left over from a previous hide (Tab-X without Apply/OK) are
+                        // discarded.  Safe on first call — no-op until FrmOptions is embedded.
+                        OptionsFormWindow.RefreshSettings();
                         OptionsFormWindow.Show(dockPanel);
                         break;
                     case WindowType.SSHTransfer:

--- a/mRemoteNG/UI/FontOverrider.cs
+++ b/mRemoteNG/UI/FontOverrider.cs
@@ -13,8 +13,12 @@ namespace mRemoteNG.UI
             foreach (Control tempLoopVarCtlChild in ctlParent.Controls)
             {
                 Control ctlChild = tempLoopVarCtlChild;
-                ctlChild.Font = new Font(SystemFonts.MessageBoxFont.Name, ctlChild.Font.Size, ctlChild.Font.Style,
-                                         ctlChild.Font.Unit, ctlChild.Font.GdiCharSet);
+                // Only create a new Font if the font name is different to avoid unnecessary GDI operations
+                if (ctlChild.Font.Name != SystemFonts.MessageBoxFont.Name)
+                {
+                    ctlChild.Font = new Font(SystemFonts.MessageBoxFont.Name, ctlChild.Font.Size, ctlChild.Font.Style,
+                                             ctlChild.Font.Unit, ctlChild.Font.GdiCharSet);
+                }
                 if (ctlChild.Controls.Count > 0)
                 {
                     FontOverride(ctlChild);

--- a/mRemoteNG/UI/Forms/OptionsPages/StartupExitPage.Designer.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/StartupExitPage.Designer.cs
@@ -140,7 +140,6 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             Controls.Add(lblRegistrySettingsUsedInfo);
             Name = "StartupExitPage";
             Size = new System.Drawing.Size(610, 490);
-            Load += StartupExitPage_Load;
             pnlOptions.ResumeLayout(false);
             pnlOptions.PerformLayout();
             ResumeLayout(false);

--- a/mRemoteNG/UI/Forms/OptionsPages/StartupExitPage.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/StartupExitPage.cs
@@ -39,6 +39,15 @@ namespace mRemoteNG.UI.Forms.OptionsPages
             lblRegistrySettingsUsedInfo.Text = Language.OptionsCompanyPolicyMessage;
         }
 
+        public override void LoadSettings()
+        {
+            chkReconnectOnStart.Checked = Properties.OptionsStartupExitPage.Default.OpenConsFromLastSession;
+            chkSingleInstance.Checked = Properties.OptionsStartupExitPage.Default.SingleInstance;
+            chkStartMinimized.Checked = Properties.OptionsStartupExitPage.Default.StartMinimized;
+            chkStartFullScreen.Checked = Properties.OptionsStartupExitPage.Default.StartFullScreen;
+            chkDisableRefocus.Checked = Properties.OptionsStartupExitPage.Default.DisableRefocus;
+        }
+
         public override void SaveSettings()
         {
             base.SaveSettings();

--- a/mRemoteNG/UI/Forms/OptionsPages/StartupExitPage.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/StartupExitPage.cs
@@ -116,15 +116,6 @@ namespace mRemoteNG.UI.Forms.OptionsPages
                 || pageRegSettingsInstance.StartupBehavior.IsSet;
         }
 
-        private void StartupExitPage_Load(object sender, EventArgs e)
-        {
-            chkReconnectOnStart.Checked = Properties.OptionsStartupExitPage.Default.OpenConsFromLastSession;
-            chkSingleInstance.Checked = Properties.OptionsStartupExitPage.Default.SingleInstance;
-            chkStartMinimized.Checked = Properties.OptionsStartupExitPage.Default.StartMinimized;
-            chkStartFullScreen.Checked = Properties.OptionsStartupExitPage.Default.StartFullScreen;
-            chkDisableRefocus.Checked = Properties.OptionsStartupExitPage.Default.DisableRefocus;
-        }
-
         private void chkStartFullScreen_CheckedChanged(object sender, EventArgs e)
         {
             if (chkStartFullScreen.Checked && chkStartMinimized.Checked)

--- a/mRemoteNG/UI/Forms/OptionsPages/ThemePage.Designer.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/ThemePage.Designer.cs
@@ -14,9 +14,10 @@ namespace mRemoteNG.UI.Forms.OptionsPages
         {
             try
             {
-                if (disposing && components != null)
+                if (disposing)
                 {
-                    components.Dispose();
+                    _themeManager.ThemeChanged -= ApplyTheme;
+                    components?.Dispose();
                 }
             }
             finally

--- a/mRemoteNG/UI/Forms/frmOptions.Designer.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.Designer.cs
@@ -167,7 +167,6 @@ namespace mRemoteNG.UI.Forms
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "mRemoteNG Options";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FrmOptions_FormClosing);
             this.Load += new System.EventHandler(this.FrmOptions_Load);
             this.Shown += new System.EventHandler(this.FrmOptions_Shown);
             this.pnlBottom.ResumeLayout(false);

--- a/mRemoteNG/UI/Forms/frmOptions.Designer.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.Designer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows;
 using System.Windows.Forms;
+using mRemoteNG.Themes;
 using mRemoteNG.UI.Controls;
 
 namespace mRemoteNG.UI.Forms
@@ -17,9 +18,14 @@ namespace mRemoteNG.UI.Forms
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                if (_isInitialized)
+                {
+                    ThemeManager.getInstance().ThemeChanged -= ApplyTheme;
+                }
+
+                components?.Dispose();
             }
             base.Dispose(disposing);
         }

--- a/mRemoteNG/UI/Forms/frmOptions.Designer.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.Designer.cs
@@ -70,7 +70,6 @@ namespace mRemoteNG.UI.Forms
             // btnCancel
             // 
             this.btnCancel._mice = mRemoteNG.UI.Controls.MrngButton.MouseState.OUT;
-            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.btnCancel.Location = new System.Drawing.Point(596, 5);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
@@ -82,7 +81,6 @@ namespace mRemoteNG.UI.Forms
             // btnOK
             // 
             this.btnOK._mice = mRemoteNG.UI.Controls.MrngButton.MouseState.OUT;
-            this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.btnOK.Location = new System.Drawing.Point(515, 5);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(75, 23);

--- a/mRemoteNG/UI/Forms/frmOptions.Designer.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.Designer.cs
@@ -171,6 +171,7 @@ namespace mRemoteNG.UI.Forms
             this.Text = "mRemoteNG Options";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FrmOptions_FormClosing);
             this.Load += new System.EventHandler(this.FrmOptions_Load);
+            this.Shown += new System.EventHandler(this.FrmOptions_Shown);
             this.pnlBottom.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.lstOptionPages)).EndInit();
             this.ResumeLayout(false);

--- a/mRemoteNG/UI/Forms/frmOptions.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.cs
@@ -27,6 +27,11 @@ namespace mRemoteNG.UI.Forms
         private bool _isFontOverrideApplied = false;
         private bool _isHandlingSelectionChange = false; // Guard flag to prevent recursive event handling
 
+        /// <summary>
+        /// Raised when the user clicks OK or Cancel, signalling the host window to hide.
+        /// </summary>
+        public event EventHandler CloseRequested;
+
         public FrmOptions() : this(Language.StartupExit)
         {
         }
@@ -302,10 +307,9 @@ namespace mRemoteNG.UI.Forms
         {
             Logger.Instance.Log?.Debug($"[BtnOK_Click] START");
             SaveOptions();
-            // Clear change flags after saving
             ClearChangeFlags();
-            CloseHostOptionsWindow();
-            Logger.Instance.Log?.Debug($"[BtnOK_Click] END - Host window close requested");
+            CloseRequested?.Invoke(this, EventArgs.Empty);
+            Logger.Instance.Log?.Debug($"[BtnOK_Click] END");
         }
 
         private void BtnApply_Click(object sender, EventArgs e)
@@ -394,75 +398,29 @@ namespace mRemoteNG.UI.Forms
         private void BtnCancel_Click(object sender, EventArgs e)
         {
             Logger.Instance.Log?.Debug($"[BtnCancel_Click] START");
-            // When Cancel is clicked, we don't check for changes
-            // The user explicitly wants to cancel
-            CloseHostOptionsWindow();
-            Logger.Instance.Log?.Debug($"[BtnCancel_Click] END - Host window close requested");
+            ClearChangeFlags();
+            CloseRequested?.Invoke(this, EventArgs.Empty);
+            Logger.Instance.Log?.Debug($"[BtnCancel_Click] END");
         }
 
-        private void CloseHostOptionsWindow()
+        /// <summary>
+        /// Returns true if any options page has been modified.
+        /// </summary>
+        internal bool HasUnsavedChanges() => _optionPages.Any(page => page.HasChanges);
+
+        /// <summary>
+        /// Saves all option page settings to disk.
+        /// </summary>
+        internal void SaveAllOptions()
         {
-            Form hostForm = FindForm();
-
-            if (hostForm != null && hostForm != this)
-            {
-                hostForm.Close();
-                return;
-            }
-
-            Visible = false;
+            SaveOptions();
+            ClearChangeFlags();
         }
 
-        private void FrmOptions_FormClosing(object sender, FormClosingEventArgs e)
-        {
-            Logger.Instance.Log?.Debug($"[FrmOptions_FormClosing] START - CloseReason: {e.CloseReason}, Cancel: {e.Cancel}");
-
-            // Check if any page has unsaved changes
-            bool hasChanges = _optionPages.Any(page => page.HasChanges);
-            Logger.Instance.Log?.Debug($"[FrmOptions_FormClosing] HasChanges: {hasChanges}");
-
-            if (hasChanges)
-            {
-                DialogResult result = MessageBox.Show(
-                    Language.SaveOptionsBeforeClosing,
-                    Language.Options,
-                    MessageBoxButtons.YesNoCancel,
-                    MessageBoxIcon.Question);
-
-                Logger.Instance.Log?.Debug($"[FrmOptions_FormClosing] User choice: {result}");
-
-                switch (result)
-                {
-                    case DialogResult.Yes:
-                        SaveOptions();
-                        ClearChangeFlags();
-                        e.Cancel = true;
-                        this.Visible = false;
-                        Logger.Instance.Log?.Debug($"[FrmOptions_FormClosing] Saved and hiding");
-                        break;
-                    case DialogResult.No:
-                        // Discard changes
-                        ClearChangeFlags();
-                        e.Cancel = true;
-                        this.Visible = false;
-                        Logger.Instance.Log?.Debug($"[FrmOptions_FormClosing] Discarded and hiding");
-                        break;
-                    case DialogResult.Cancel:
-                        // Cancel closing - keep the dialog open
-                        e.Cancel = true;
-                        Logger.Instance.Log?.Debug($"[FrmOptions_FormClosing] User cancelled close");
-                        break;
-                }
-            }
-            else
-            {
-                e.Cancel = true;
-                this.Visible = false;
-                Logger.Instance.Log?.Debug($"[FrmOptions_FormClosing] No changes - hiding");
-            }
-
-            Logger.Instance.Log?.Debug($"[FrmOptions_FormClosing] END - Cancel: {e.Cancel}, Visible: {this.Visible}");
-        }
+        /// <summary>
+        /// Discards any pending change flags without saving.
+        /// </summary>
+        internal void DiscardChanges() => ClearChangeFlags();
 
         private void TrackChangesInControls(Control control)
         {
@@ -526,60 +484,6 @@ namespace mRemoteNG.UI.Forms
             {
                 page.HasChanges = false;
             }
-        }
-
-        private void ValidateControlState()
-        {
-            Logger.Instance.Log?.Debug($"[ValidateControlState] START - Items.Count: {lstOptionPages.Items.Count}, pnlMain.Controls.Count: {pnlMain.Controls.Count}");
-
-            // Ensure we have pages loaded
-            if (lstOptionPages.Items.Count == 0)
-            {
-                Logger.Instance.Log?.Debug($"[ValidateControlState] No items loaded - returning");
-                return;
-            }
-
-            OptionsPage currentPage = lstOptionPages.SelectedObject as OptionsPage;
-            Logger.Instance.Log?.Debug($"[ValidateControlState] Current page: {(currentPage != null ? currentPage.PageName : "NULL")}");
-
-            if (currentPage == null)
-            {
-                Logger.Instance.Log?.Warn($"[ValidateControlState] SelectedObject is NULL - this may indicate a selection issue");
-                // Don't try to fix this - let the normal selection handling deal with it
-                return;
-            }
-
-            if (currentPage.IsDisposed)
-            {
-                Logger.Instance.Log?.Warn($"[ValidateControlState] Page '{currentPage.PageName}' is disposed");
-                return;
-            }
-
-            Logger.Instance.Log?.Debug($"[ValidateControlState] Page '{currentPage.PageName}' is valid - IsHandleCreated: {currentPage.IsHandleCreated}");
-
-            // Ensure the page has a valid window handle
-            if (!currentPage.IsHandleCreated)
-            {
-                Logger.Instance.Log?.Debug($"[ValidateControlState] Creating handle for page '{currentPage.PageName}'");
-                // Force handle creation
-                var handle = currentPage.Handle;
-                Logger.Instance.Log?.Debug($"[ValidateControlState] Handle created: {handle}");
-            }
-
-            // Ensure the page is displayed in the panel
-            if (!pnlMain.Controls.Contains(currentPage))
-            {
-                Logger.Instance.Log?.Debug($"[ValidateControlState] Page '{currentPage.PageName}' not in pnlMain - adding it now");
-                pnlMain.Controls.Clear();
-                pnlMain.Controls.Add(currentPage);
-                Logger.Instance.Log?.Debug($"[ValidateControlState] Page added. pnlMain.Controls.Count: {pnlMain.Controls.Count}");
-            }
-            else
-            {
-                Logger.Instance.Log?.Debug($"[ValidateControlState] Page '{currentPage.PageName}' already in pnlMain - OK");
-            }
-
-            Logger.Instance.Log?.Debug($"[ValidateControlState] END");
         }
     }
 }

--- a/mRemoteNG/UI/Forms/frmOptions.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.cs
@@ -24,6 +24,7 @@ namespace mRemoteNG.UI.Forms
         private readonly List<string> _optionPageObjectNames;
         private bool _isLoading = true;
         private bool _isInitialized = false;
+        private bool _isFontOverrideApplied = false;
         private bool _isHandlingSelectionChange = false; // Guard flag to prevent recursive event handling
 
         public FrmOptions() : this(Language.StartupExit)
@@ -75,7 +76,6 @@ namespace mRemoteNG.UI.Forms
 
             Logger.Instance.Log?.Debug($"[FrmOptions_Load] First initialization");
             this.Visible = true;
-            FontOverrider.FontOverride(this);
             SetActivatedPage();
             //ApplyLanguage();
             // Handle the main page here and the individual pages in
@@ -93,6 +93,25 @@ namespace mRemoteNG.UI.Forms
             // Mark as initialized
             _isInitialized = true;
             Logger.Instance.Log?.Debug($"[FrmOptions_Load] END (first initialization complete)");
+        }
+
+        private void FrmOptions_Shown(object sender, EventArgs e)
+        {
+            if (_isFontOverrideApplied)
+            {
+                return;
+            }
+
+            BeginInvoke((MethodInvoker)(() =>
+            {
+                if (IsDisposed || _isFontOverrideApplied)
+                {
+                    return;
+                }
+
+                FontOverrider.FontOverride(this);
+                _isFontOverrideApplied = true;
+            }));
         }
 
         private void ApplyTheme()

--- a/mRemoteNG/UI/Forms/frmOptions.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.cs
@@ -284,7 +284,7 @@ namespace mRemoteNG.UI.Forms
             }
 
             // Skip if the requested page is already selected (avoid redundant layout work)
-            if (lstOptionPages.SelectedItem?.Text == _pageName)
+            if (lstOptionPages.SelectedObject is OptionsPage selectedPage && selectedPage.PageName == _pageName)
             {
                 Logger.Instance.Log?.Debug($"[SetActivatedPage] Page '{_pageName}' already selected - skipping");
                 return;

--- a/mRemoteNG/UI/Forms/frmOptions.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.cs
@@ -34,7 +34,6 @@ namespace mRemoteNG.UI.Forms
         private FrmOptions(string pageName)
         {
             Cursor.Current = Cursors.WaitCursor;
-            Application.DoEvents();
             InitializeComponent();
             Icon = Resources.ImageConverter.GetImageAsIcon(Properties.Resources.Settings_16x);
             _pageName = pageName;
@@ -66,16 +65,11 @@ namespace mRemoteNG.UI.Forms
             // Only initialize once to prevent multiple event subscriptions and page reloading
             if (_isInitialized)
             {
-                Logger.Instance.Log?.Debug($"[FrmOptions_Load] Already initialized - calling ValidateControlState");
-                // On subsequent loads, validate and recover control state if needed
-                ValidateControlState();
-                this.Visible = true;
-                Logger.Instance.Log?.Debug($"[FrmOptions_Load] END (already initialized)");
+                Logger.Instance.Log?.Debug($"[FrmOptions_Load] Already initialized - fast path");
                 return;
             }
 
             Logger.Instance.Log?.Debug($"[FrmOptions_Load] First initialization");
-            this.Visible = true;
             SetActivatedPage();
             //ApplyLanguage();
             // Handle the main page here and the individual pages in

--- a/mRemoteNG/UI/Forms/frmOptions.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.cs
@@ -398,7 +398,7 @@ namespace mRemoteNG.UI.Forms
         private void BtnCancel_Click(object sender, EventArgs e)
         {
             Logger.Instance.Log?.Debug($"[BtnCancel_Click] START");
-            ClearChangeFlags();
+            ReloadAllSettings();
             CloseRequested?.Invoke(this, EventArgs.Empty);
             Logger.Instance.Log?.Debug($"[BtnCancel_Click] END");
         }
@@ -418,9 +418,30 @@ namespace mRemoteNG.UI.Forms
         }
 
         /// <summary>
-        /// Discards any pending change flags without saving.
+        /// Reloads all pages from the stored settings, discarding any pending control edits.
+        /// Call this on Cancel or any close path that should not persist changes.
         /// </summary>
-        internal void DiscardChanges() => ClearChangeFlags();
+        internal void ReloadAllSettings()
+        {
+            // Suppress HasChanges tracking while we programmatically restore control values
+            var wasLoading = _isLoading;
+            _isLoading = true;
+            try
+            {
+                foreach (OptionsPage page in _optionPages)
+                    page.LoadSettings();
+            }
+            finally
+            {
+                _isLoading = wasLoading;
+            }
+            ClearChangeFlags();
+        }
+
+        /// <summary>
+        /// Discards any pending change flags and reloads control values from stored settings.
+        /// </summary>
+        internal void DiscardChanges() => ReloadAllSettings();
 
         private void TrackChangesInControls(Control control)
         {

--- a/mRemoteNG/UI/Forms/frmOptions.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.cs
@@ -302,8 +302,8 @@ namespace mRemoteNG.UI.Forms
             SaveOptions();
             // Clear change flags after saving
             ClearChangeFlags();
-            this.Visible = false;
-            Logger.Instance.Log?.Debug($"[BtnOK_Click] END - Visible set to false");
+            CloseHostOptionsWindow();
+            Logger.Instance.Log?.Debug($"[BtnOK_Click] END - Host window close requested");
         }
 
         private void BtnApply_Click(object sender, EventArgs e)
@@ -385,8 +385,21 @@ namespace mRemoteNG.UI.Forms
             Logger.Instance.Log?.Debug($"[BtnCancel_Click] START");
             // When Cancel is clicked, we don't check for changes
             // The user explicitly wants to cancel
-            this.Visible = false;
-            Logger.Instance.Log?.Debug($"[BtnCancel_Click] END - Visible set to false");
+            CloseHostOptionsWindow();
+            Logger.Instance.Log?.Debug($"[BtnCancel_Click] END - Host window close requested");
+        }
+
+        private void CloseHostOptionsWindow()
+        {
+            Form hostForm = FindForm();
+
+            if (hostForm != null && hostForm != this)
+            {
+                hostForm.Close();
+                return;
+            }
+
+            Visible = false;
         }
 
         private void FrmOptions_FormClosing(object sender, FormClosingEventArgs e)

--- a/mRemoteNG/UI/Forms/frmOptions.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.cs
@@ -38,6 +38,7 @@ namespace mRemoteNG.UI.Forms
             Icon = Resources.ImageConverter.GetImageAsIcon(Properties.Resources.Settings_16x);
             _pageName = pageName;
             Cursor.Current = Cursors.Default;
+            DoubleBuffered = true;
 
             _optionPageObjectNames =
             [
@@ -277,6 +278,13 @@ namespace mRemoteNG.UI.Forms
                 return;
             }
 
+            // Skip if the requested page is already selected (avoid redundant layout work)
+            if (lstOptionPages.SelectedItem?.Text == _pageName)
+            {
+                Logger.Instance.Log?.Debug($"[SetActivatedPage] Page '{_pageName}' already selected - skipping");
+                return;
+            }
+
             bool isSet = false;
             for (int i = 0; i < lstOptionPages.Items.Count; i++)
             {
@@ -335,9 +343,6 @@ namespace mRemoteNG.UI.Forms
             {
                 Logger.Instance.Log?.Debug($"[LstOptionPages_SelectedIndexChanged] START - IsLoading: {_isLoading}, SelectedIndex: {lstOptionPages.SelectedIndex}, Items.Count: {lstOptionPages.Items.Count}");
 
-                pnlMain.Controls.Clear();
-                Logger.Instance.Log?.Debug($"[LstOptionPages_SelectedIndexChanged] pnlMain.Controls cleared");
-
                 if (lstOptionPages.SelectedObject is OptionsPage page)
                 {
                     Logger.Instance.Log?.Debug($"[LstOptionPages_SelectedIndexChanged] SelectedObject: {page.PageName}");
@@ -347,6 +352,17 @@ namespace mRemoteNG.UI.Forms
                     Logger.Instance.Log?.Warn($"[LstOptionPages_SelectedIndexChanged] Page is NULL - cannot display. This may indicate a selection issue.");
                     return;
                 }
+
+                // Skip if this page is already displayed in the panel
+                if (pnlMain.Controls.Count == 1 && pnlMain.Controls[0] == page)
+                {
+                    Logger.Instance.Log?.Debug($"[LstOptionPages_SelectedIndexChanged] Page '{page.PageName}' already displayed - skipping");
+                    return;
+                }
+
+                pnlMain.SuspendLayout();
+                pnlMain.Controls.Clear();
+                Logger.Instance.Log?.Debug($"[LstOptionPages_SelectedIndexChanged] pnlMain.Controls cleared");
 
                 if (page.IsDisposed)
                 {
@@ -364,6 +380,7 @@ namespace mRemoteNG.UI.Forms
 
                 Logger.Instance.Log?.Debug($"[LstOptionPages_SelectedIndexChanged] Adding page '{page.PageName}' to pnlMain");
                 pnlMain.Controls.Add(page);
+                pnlMain.ResumeLayout(true);
                 Logger.Instance.Log?.Debug($"[LstOptionPages_SelectedIndexChanged] Page added successfully. pnlMain.Controls.Count: {pnlMain.Controls.Count}");
 
                 Logger.Instance.Log?.Debug($"[LstOptionPages_SelectedIndexChanged] END");

--- a/mRemoteNG/UI/Window/OptionsWindow.cs
+++ b/mRemoteNG/UI/Window/OptionsWindow.cs
@@ -14,6 +14,7 @@ namespace mRemoteNG.UI.Window
     {
         private FrmOptions _optionsForm;
         private bool _isInitialized = false;
+        private bool _isFontOverrideApplied = false;
 
         #region Public Methods
 
@@ -37,9 +38,6 @@ namespace mRemoteNG.UI.Window
         {
             Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] START - IsInitialized: {_isInitialized}, Visible: {this.Visible}");
 
-            // Apply font override after window is loaded to prevent UI thread blocking
-            FontOverrider.FontOverride(this);
-
             // Only subscribe to ThemeChanged once to prevent multiple subscriptions
             if (!_isInitialized)
             {
@@ -56,6 +54,25 @@ namespace mRemoteNG.UI.Window
             EnsureOptionsFormReady();
 
             Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] END");
+        }
+
+        private void Options_Shown(object sender, EventArgs e)
+        {
+            if (_isFontOverrideApplied)
+            {
+                return;
+            }
+
+            BeginInvoke((MethodInvoker)(() =>
+            {
+                if (IsDisposed || _isFontOverrideApplied)
+                {
+                    return;
+                }
+
+                FontOverrider.FontOverride(this);
+                _isFontOverrideApplied = true;
+            }));
         }
 
         private void EnsureOptionsFormReady()
@@ -208,6 +225,7 @@ namespace mRemoteNG.UI.Window
             Text = Language.Options;
             TabText = Language.Options;
             Load += Options_Load;
+            Shown += Options_Shown;
             ResumeLayout(false);
         }
     }

--- a/mRemoteNG/UI/Window/OptionsWindow.cs
+++ b/mRemoteNG/UI/Window/OptionsWindow.cs
@@ -15,6 +15,7 @@ namespace mRemoteNG.UI.Window
         private FrmOptions _optionsForm;
         private bool _isInitialized = false;
         private bool _isFontOverrideApplied = false;
+        private bool _isClosing = false;
 
         #region Public Methods
 
@@ -38,21 +39,24 @@ namespace mRemoteNG.UI.Window
         {
             Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] START - IsInitialized: {_isInitialized}, Visible: {this.Visible}");
 
-            // Only subscribe to ThemeChanged once to prevent multiple subscriptions
-            if (!_isInitialized)
+            // On reopen of a previously initialized window, just ensure the embedded form is visible
+            if (_isInitialized && _optionsForm != null && !_optionsForm.IsDisposed)
             {
-                Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] First initialization - subscribing to ThemeChanged");
-                ThemeManager.getInstance().ThemeChanged += ApplyTheme;
-                _isInitialized = true;
+                Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] Reopen - fast path");
+                if (!_optionsForm.Visible)
+                    _optionsForm.Visible = true;
+                return;
             }
+
+            // First-time initialization
+            Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] First initialization - subscribing to ThemeChanged");
+            ThemeManager.getInstance().ThemeChanged += ApplyTheme;
 
             ApplyTheme();
             ApplyLanguage();
             LoadOptionsForm();
 
-            // Ensure all pages are loaded and form is ready
-            EnsureOptionsFormReady();
-
+            _isInitialized = true;
             Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] END");
         }
 
@@ -75,19 +79,7 @@ namespace mRemoteNG.UI.Window
             }));
         }
 
-        private void EnsureOptionsFormReady()
-        {
-            Logger.Instance.Log?.Debug($"[OptionsWindow.EnsureOptionsFormReady] START - OptionsForm: {(_optionsForm != null ? "EXISTS" : "NULL")}, IsDisposed: {_optionsForm?.IsDisposed}");
 
-            if (_optionsForm != null && !_optionsForm.IsDisposed)
-            {
-                Logger.Instance.Log?.Debug($"[OptionsWindow.EnsureOptionsFormReady] Processing Application.DoEvents");
-                // Process any pending UI events to ensure the form is fully rendered
-                Application.DoEvents();
-            }
-
-            Logger.Instance.Log?.Debug($"[OptionsWindow.EnsureOptionsFormReady] END");
-        }
 
         private new void ApplyTheme()
         {
@@ -171,7 +163,10 @@ namespace mRemoteNG.UI.Window
 
         private void OptionsForm_VisibleChanged(object sender, EventArgs e)
         {
-            Logger.Instance.Log?.Debug($"[OptionsWindow.OptionsForm_VisibleChanged] OptionsForm.Visible: {_optionsForm?.Visible}");
+            Logger.Instance.Log?.Debug($"[OptionsWindow.OptionsForm_VisibleChanged] OptionsForm.Visible: {_optionsForm?.Visible}, IsClosing: {_isClosing}");
+
+            // Skip if we're already in a close operation to prevent re-entrant cascade
+            if (_isClosing) return;
 
             // When the embedded FrmOptions is hidden (OK/Cancel clicked), close this window
             if (_optionsForm != null && !_optionsForm.Visible)
@@ -184,9 +179,11 @@ namespace mRemoteNG.UI.Window
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
             Logger.Instance.Log?.Debug($"[OptionsWindow.OnFormClosing] START - CloseReason: {e.CloseReason}");
+            _isClosing = true;
             // With HideOnClose = true, we don't dispose the window
             // so we keep the embedded form in Controls for reuse
             base.OnFormClosing(e);
+            _isClosing = false;
             Logger.Instance.Log?.Debug($"[OptionsWindow.OnFormClosing] END");
         }
 
@@ -197,10 +194,11 @@ namespace mRemoteNG.UI.Window
             base.OnVisibleChanged(e);
 
             // When the window becomes visible, ensure the embedded form is also shown
-            if (Visible && _optionsForm != null && !_optionsForm.Visible)
+            // Use Visible property directly instead of Show() to avoid re-firing Load events
+            if (Visible && _optionsForm != null && !_optionsForm.IsDisposed && !_optionsForm.Visible)
             {
-                Logger.Instance.Log?.Debug($"[OptionsWindow.OnVisibleChanged] Window visible but OptionsForm hidden - calling Show()");
-                _optionsForm.Show();
+                Logger.Instance.Log?.Debug($"[OptionsWindow.OnVisibleChanged] Window visible but OptionsForm hidden - setting Visible=true");
+                _optionsForm.Visible = true;
             }
 
             Logger.Instance.Log?.Debug($"[OptionsWindow.OnVisibleChanged] END");

--- a/mRemoteNG/UI/Window/OptionsWindow.cs
+++ b/mRemoteNG/UI/Window/OptionsWindow.cs
@@ -124,6 +124,17 @@ namespace mRemoteNG.UI.Window
         }
 
         /// <summary>
+        /// Reloads all option-page controls from the stored (on-disk) settings.
+        /// Call this before making the panel visible so that any stale edits from a
+        /// previous session (e.g. after a Tab-X hide) are discarded.
+        /// Safe to call before first initialization — no-op when _optionsForm is null.
+        /// </summary>
+        internal void RefreshSettings()
+        {
+            _optionsForm?.ReloadAllSettings();
+        }
+
+        /// <summary>
         /// Handles the case where OptionsWindow is closed explicitly (e.g. from code
         /// calling Close(), or DPS's CloseContent which fires FormClosing before hiding).
         /// Checks for unsaved changes in the embedded FrmOptions.

--- a/mRemoteNG/UI/Window/OptionsWindow.cs
+++ b/mRemoteNG/UI/Window/OptionsWindow.cs
@@ -29,6 +29,7 @@ namespace mRemoteNG.UI.Window
             DockPnl = panel;
             InitializeComponent();
             Icon = Resources.ImageConverter.GetImageAsIcon(Properties.Resources.Settings_16x);
+            DoubleBuffered = true;
         }
 
         #endregion
@@ -39,12 +40,11 @@ namespace mRemoteNG.UI.Window
         {
             Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] START - IsInitialized: {_isInitialized}, Visible: {this.Visible}");
 
-            // On reopen of a previously initialized window, just ensure the embedded form is visible
+            // On reopen of a previously initialized window, nothing to do — 
+            // FrmOptions is a child control and auto-shows with its parent
             if (_isInitialized && _optionsForm != null && !_optionsForm.IsDisposed)
             {
-                Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] Reopen - fast path");
-                if (!_optionsForm.Visible)
-                    _optionsForm.Visible = true;
+                Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] Reopen - fast path (no-op)");
                 return;
             }
 
@@ -192,14 +192,8 @@ namespace mRemoteNG.UI.Window
             Logger.Instance.Log?.Debug($"[OptionsWindow.OnVisibleChanged] START - Visible: {Visible}, OptionsForm: {(_optionsForm != null ? "EXISTS" : "NULL")}");
 
             base.OnVisibleChanged(e);
-
-            // When the window becomes visible, ensure the embedded form is also shown
-            // Use Visible property directly instead of Show() to avoid re-firing Load events
-            if (Visible && _optionsForm != null && !_optionsForm.IsDisposed && !_optionsForm.Visible)
-            {
-                Logger.Instance.Log?.Debug($"[OptionsWindow.OnVisibleChanged] Window visible but OptionsForm hidden - setting Visible=true");
-                _optionsForm.Visible = true;
-            }
+            // FrmOptions is a child control — it becomes visible/hidden automatically
+            // with OptionsWindow. No explicit visibility change needed.
 
             Logger.Instance.Log?.Debug($"[OptionsWindow.OnVisibleChanged] END");
         }

--- a/mRemoteNG/UI/Window/OptionsWindow.cs
+++ b/mRemoteNG/UI/Window/OptionsWindow.cs
@@ -15,7 +15,6 @@ namespace mRemoteNG.UI.Window
         private FrmOptions _optionsForm;
         private bool _isInitialized = false;
         private bool _isFontOverrideApplied = false;
-        private bool _isClosing = false;
 
         #region Public Methods
 
@@ -38,18 +37,12 @@ namespace mRemoteNG.UI.Window
 
         private void Options_Load(object sender, EventArgs e)
         {
-            Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] START - IsInitialized: {_isInitialized}, Visible: {this.Visible}");
-
-            // On reopen of a previously initialized window, nothing to do — 
+            // On reopen of a previously initialized window, nothing to do —
             // FrmOptions is a child control and auto-shows with its parent
             if (_isInitialized && _optionsForm != null && !_optionsForm.IsDisposed)
-            {
-                Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] Reopen - fast path (no-op)");
                 return;
-            }
 
             // First-time initialization
-            Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] First initialization - subscribing to ThemeChanged");
             ThemeManager.getInstance().ThemeChanged += ApplyTheme;
 
             ApplyTheme();
@@ -57,29 +50,22 @@ namespace mRemoteNG.UI.Window
             LoadOptionsForm();
 
             _isInitialized = true;
-            Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] END");
         }
 
         private void Options_Shown(object sender, EventArgs e)
         {
             if (_isFontOverrideApplied)
-            {
                 return;
-            }
 
             BeginInvoke((MethodInvoker)(() =>
             {
                 if (IsDisposed || _isFontOverrideApplied)
-                {
                     return;
-                }
 
                 FontOverrider.FontOverride(this);
                 _isFontOverrideApplied = true;
             }));
         }
-
-
 
         private new void ApplyTheme()
         {
@@ -95,107 +81,78 @@ namespace mRemoteNG.UI.Window
 
         private void LoadOptionsForm()
         {
-            Logger.Instance.Log?.Debug($"[OptionsWindow.LoadOptionsForm] START - _optionsForm: {(_optionsForm != null ? "EXISTS" : "NULL")}, IsDisposed: {_optionsForm?.IsDisposed}");
-            Logger.Instance.Log?.Debug($"[OptionsWindow.LoadOptionsForm] FrmMain.OptionsForm: {(FrmMain.OptionsForm != null ? "EXISTS" : "NULL")}, IsDisposed: {FrmMain.OptionsForm?.IsDisposed}");
-
-            // Check if FrmMain.OptionsForm is disposed FIRST (this is the source of truth)
+            // Check if FrmMain.OptionsForm is disposed (source of truth)
             if (FrmMain.OptionsForm != null && FrmMain.OptionsForm.IsDisposed)
-            {
-                Logger.Instance.Log?.Warn($"[OptionsWindow.LoadOptionsForm] FrmMain.OptionsForm is DISPOSED - recreating");
-                // Force FrmMain to recreate the OptionsForm
                 FrmMain.RecreateOptionsForm();
-            }
 
-            // If the local reference is disposed, we need to clean up
+            // If the local reference is disposed, clean up
             if (_optionsForm != null && _optionsForm.IsDisposed)
             {
-                Logger.Instance.Log?.Warn($"[OptionsWindow.LoadOptionsForm] Local _optionsForm is DISPOSED - cleaning up");
                 if (Controls.Contains(_optionsForm))
-                {
                     Controls.Remove(_optionsForm);
-                }
-                _optionsForm.VisibleChanged -= OptionsForm_VisibleChanged;
+                _optionsForm.CloseRequested -= OnOptionsFormCloseRequested;
                 _optionsForm = null;
             }
 
             // Get fresh reference if needed
             if (_optionsForm == null)
             {
-                Logger.Instance.Log?.Debug($"[OptionsWindow.LoadOptionsForm] Getting fresh OptionsForm from FrmMain");
                 _optionsForm = FrmMain.OptionsForm;
-                Logger.Instance.Log?.Debug($"[OptionsWindow.LoadOptionsForm] OptionsForm retrieved from FrmMain: {(_optionsForm != null ? "SUCCESS" : "FAILED")}");
 
-                if (_optionsForm == null)
-                {
-                    Logger.Instance.Log?.Error($"[OptionsWindow.LoadOptionsForm] CRITICAL: Failed to get OptionsForm from FrmMain");
+                if (_optionsForm == null || _optionsForm.IsDisposed)
                     return;
-                }
-
-                // Double-check that the form we just got is not disposed
-                if (_optionsForm.IsDisposed)
-                {
-                    Logger.Instance.Log?.Error($"[OptionsWindow.LoadOptionsForm] CRITICAL: FrmMain.OptionsForm is STILL disposed after recreation attempt!");
-                    return;
-                }
 
                 _optionsForm.TopLevel = false;
                 _optionsForm.FormBorderStyle = FormBorderStyle.None;
                 _optionsForm.Dock = DockStyle.Fill;
-                _optionsForm.VisibleChanged += OptionsForm_VisibleChanged;
+                _optionsForm.CloseRequested += OnOptionsFormCloseRequested;
                 Controls.Add(_optionsForm);
-                Logger.Instance.Log?.Debug($"[OptionsWindow.LoadOptionsForm] OptionsForm added to Controls");
             }
 
-            // Only show if not already visible to prevent redundant event cascades
-            Logger.Instance.Log?.Debug($"[OptionsWindow.LoadOptionsForm] OptionsForm.Visible: {_optionsForm.Visible}, IsDisposed: {_optionsForm.IsDisposed}");
             if (!_optionsForm.Visible)
-            {
-                Logger.Instance.Log?.Debug($"[OptionsWindow.LoadOptionsForm] Calling Show()");
                 _optionsForm.Show();
-            }
-            else
-            {
-                Logger.Instance.Log?.Debug($"[OptionsWindow.LoadOptionsForm] Already visible - skipping Show()");
-            }
-
-            Logger.Instance.Log?.Debug($"[OptionsWindow.LoadOptionsForm] END");
         }
 
-        private void OptionsForm_VisibleChanged(object sender, EventArgs e)
+        /// <summary>
+        /// Handles OK/Cancel from embedded FrmOptions.
+        /// Calls DockHandler.Hide() directly — much faster than Close() because
+        /// it skips the entire FormClosing event chain.
+        /// </summary>
+        private void OnOptionsFormCloseRequested(object sender, EventArgs e)
         {
-            Logger.Instance.Log?.Debug($"[OptionsWindow.OptionsForm_VisibleChanged] OptionsForm.Visible: {_optionsForm?.Visible}, IsClosing: {_isClosing}");
-
-            // Skip if we're already in a close operation to prevent re-entrant cascade
-            if (_isClosing) return;
-
-            // When the embedded FrmOptions is hidden (OK/Cancel clicked), close this window
-            if (_optionsForm != null && !_optionsForm.Visible)
-            {
-                Logger.Instance.Log?.Debug($"[OptionsWindow.OptionsForm_VisibleChanged] OptionsForm hidden - closing OptionsWindow");
-                this.Close();
-            }
+            DockHandler.Hide();
         }
 
+        /// <summary>
+        /// Handles the case where OptionsWindow is closed explicitly (e.g. from code
+        /// calling Close(), or DPS's CloseContent which fires FormClosing before hiding).
+        /// Checks for unsaved changes in the embedded FrmOptions.
+        /// </summary>
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
-            Logger.Instance.Log?.Debug($"[OptionsWindow.OnFormClosing] START - CloseReason: {e.CloseReason}");
-            _isClosing = true;
-            // With HideOnClose = true, we don't dispose the window
-            // so we keep the embedded form in Controls for reuse
+            if (_optionsForm != null && !_optionsForm.IsDisposed && _optionsForm.HasUnsavedChanges())
+            {
+                DialogResult result = MessageBox.Show(
+                    Language.SaveOptionsBeforeClosing,
+                    Language.Options,
+                    MessageBoxButtons.YesNoCancel,
+                    MessageBoxIcon.Question);
+
+                switch (result)
+                {
+                    case DialogResult.Yes:
+                        _optionsForm.SaveAllOptions();
+                        break;
+                    case DialogResult.No:
+                        _optionsForm.DiscardChanges();
+                        break;
+                    case DialogResult.Cancel:
+                        e.Cancel = true;
+                        return;
+                }
+            }
+
             base.OnFormClosing(e);
-            _isClosing = false;
-            Logger.Instance.Log?.Debug($"[OptionsWindow.OnFormClosing] END");
-        }
-
-        protected override void OnVisibleChanged(EventArgs e)
-        {
-            Logger.Instance.Log?.Debug($"[OptionsWindow.OnVisibleChanged] START - Visible: {Visible}, OptionsForm: {(_optionsForm != null ? "EXISTS" : "NULL")}");
-
-            base.OnVisibleChanged(e);
-            // FrmOptions is a child control — it becomes visible/hidden automatically
-            // with OptionsWindow. No explicit visibility change needed.
-
-            Logger.Instance.Log?.Debug($"[OptionsWindow.OnVisibleChanged] END");
         }
 
         public void SetActivatedPage(string pageName)

--- a/mRemoteNG/UI/Window/OptionsWindow.cs
+++ b/mRemoteNG/UI/Window/OptionsWindow.cs
@@ -27,7 +27,6 @@ namespace mRemoteNG.UI.Window
             DockPnl = panel;
             InitializeComponent();
             Icon = Resources.ImageConverter.GetImageAsIcon(Properties.Resources.Settings_16x);
-            FontOverrider.FontOverride(this);
         }
 
         #endregion
@@ -37,6 +36,9 @@ namespace mRemoteNG.UI.Window
         private void Options_Load(object sender, EventArgs e)
         {
             Logger.Instance.Log?.Debug($"[OptionsWindow.Options_Load] START - IsInitialized: {_isInitialized}, Visible: {this.Visible}");
+
+            // Apply font override after window is loaded to prevent UI thread blocking
+            FontOverrider.FontOverride(this);
 
             // Only subscribe to ThemeChanged once to prevent multiple subscriptions
             if (!_isInitialized)


### PR DESCRIPTION
## Description

Refactored (Thanks Claude Opus 4.6 - it took a few passes to get perfect):
- **Options dialog lifecycle completely reworked around DockPanelSuite's hide/show pattern.** Previously, `OptionsWindow` (a DPS `BaseWindow`) embedded `FrmOptions` as a child control and tied its lifecycle to WinForms `Visible` / `FormClosing` events. When the user clicked OK/Cancel, `FrmOptions` set `this.Visible = false`, which would cascade through `OptionsForm_VisibleChanged` → `this.Close()` → `FrmOptions_FormClosing` — a fragile chain that fought against DPS's own `HideOnClose` behavior. On reopen, the entire form had to be re-validated (`ValidateControlState`, `EnsureOptionsFormReady` with `Application.DoEvents()`), re-shown, and often fully re-rendered, causing a visible repaint lag. The new implementation introduces a `CloseRequested` event on `FrmOptions` that OK/Cancel raise; the host `OptionsWindow` handles it by calling `DockHandler.Hide()` directly, which is the idiomatic DPS close path and skips the entire `FormClosing` event chain. On reopen, the embedded `FrmOptions` is already a live child control — only `RefreshSettings()` is called to reload page values from stored settings, so the panel appears instantly with no flicker.

- **Font override deferred to `Shown`/`BeginInvoke`.** `FontOverrider.FontOverride()` was called synchronously during construction of both `OptionsWindow` and `FrmOptions`, creating GDI font objects for every control before the window was even displayed. This is moved to the `Shown` event via `BeginInvoke`, running once per form lifecycle (`_isFontOverrideApplied` guard), and only after the window is fully rendered.

- **`FontOverrider` optimized to skip no-op font replacements.** Now checks `ctlChild.Font.Name != SystemFonts.MessageBoxFont.Name` before allocating a new `Font` object, avoiding unnecessary GDI handle churn on controls that already use the system font.

- **Page-switch layout batched with `SuspendLayout`/`ResumeLayout`.** `LstOptionPages_SelectedIndexChanged` now wraps `pnlMain.Controls.Clear()` + `pnlMain.Controls.Add(page)` inside a `SuspendLayout`/`ResumeLayout(true)` block, and short-circuits if the requested page is already displayed — eliminating redundant layout passes.

- **Removed `Application.DoEvents()` calls.** Two `DoEvents()` calls (constructor and `EnsureOptionsFormReady`) that could cause re-entrant message processing are eliminated.

- **Removed `ValidateControlState()` method** (~55 lines) — no longer needed since the embedded form stays alive between show/hide cycles and doesn't need handle recreation or panel re-parenting.

- **Unsaved-changes prompt moved from `FrmOptions.FormClosing` to `OptionsWindow.OnFormClosing`.** The host window now owns the save/discard/cancel decision, and `FrmOptions` exposes `HasUnsavedChanges()`, `SaveAllOptions()`, `ReloadAllSettings()`, and `DiscardChanges()` as clean internal APIs instead of intercepting its own `FormClosing`.

- **`DialogResult` removed from OK/Cancel buttons in designer.** The buttons' `DialogResult` property was set to `OK`/`Cancel`, which caused WinForms to auto-close the parent form when clicked — triggering the "form-clone" slow redraw path when `FrmOptions` was embedded as a non-TopLevel child. Removing these ensures only the explicit `CloseRequested` event drives the close flow.

- **`DoubleBuffered = true`** enabled on both `OptionsWindow` and `FrmOptions` to reduce flicker during page transitions.

- **`SetActivatedPage` short-circuits** when the requested page is already the selected item, avoiding redundant ObjectListView selection work.
- **`RefreshSettings()` called on every show** via `AppWindows.cs`, so stale edits from a previous hide (e.g., Tab-X close without Apply) are always discarded before the panel appears.

- **`StartupExitPage.LoadSettings()` override added** so that `ReloadAllSettings()` can properly restore Startup/Exit page controls from stored settings on cancel/reopen.

- **Removed `SessionsMenu`** — the entire `Sessions` top-level menu (Next Session, Previous Session, Jump to Session 1-9) and its supporting `ConnectionWindow.NavigateToTab()` / `GetDocuments()` methods were removed along with associated language strings (`_Sessions`, `NextSession`, `PreviousSession`, `JumpToSession`).

- **Removed `OdbcDatabaseConnector`** — the ODBC database connector class was deleted and the factory no longer references it (ODBC was already throwing `NotSupportedException`, so this just removes dead code).

- **`PuttyBase` null-safety reverted** — nullable annotations (`Process?`, `string?`) removed and null-conditional operators (`?.`) replaced with direct member access; the PuTTY window-class name check for host-key dialogs (`#32770` filter) was also removed, and `Thread.Sleep(100)` reduced to `Thread.Sleep(0)` in the handle-polling loop.

- **`AlwaysShowPanelTabs` setting wired up at startup** in `SettingsLoader` — sets `pnlDock.DocumentStyle = DocumentStyle.DockingWindow` when the setting is enabled.

Bugs fixed:
- Options dialog reopening was extremely slow (visible repaint, ~500ms+ delay) due to the `FormClosing` → `Close()` → full re-initialization cycle fighting DPS's `HideOnClose`. Now instant.

- `Application.DoEvents()` could cause re-entrant event processing and UI hangs during options dialog load.

- `FontOverrider` was creating new GDI `Font` objects for every control on every call, even when the font name was already correct — wasting GDI handles and causing measurable UI lag on forms with many controls.

- `DialogResult.OK`/`Cancel` on embedded form buttons caused WinForms to fire form-close logic on the embedded `FrmOptions`, which then had to be fully re-created on next open.

- Cancelling the options dialog didn't reload settings from disk — control values from the cancelled session would persist and appear as the "current" values on reopen.

- `AlwaysShowPanelTabs` setting was not applied at application startup, only when changed in Options.

## Motivation and Context

Options window was clunky, slow, repainted all the time, and needed a refactor.

## How Has This Been Tested?

- Manual testing of Options dialog open/close/reopen cycles — verified instant repaint on reopen
- Verified OK saves settings, Cancel discards and reloads from stored values
- Verified unsaved-changes prompt appears when closing via Tab-X with pending edits
- Verified font override applies correctly on first show
- Verified page switching within Options dialog is flicker-free
- Verified `AlwaysShowPanelTabs` setting is applied on application startup
- All existing unit tests passing in Visual Studio

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.