### PR TITLE
Add UseRedirectionServerName connection property (fixes #2637)

### DIFF
--- a/mRemoteNG/App.config
+++ b/mRemoteNG/App.config
@@ -372,6 +372,12 @@
       <setting name="ConDefaultUseRCG" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="InhDefaultUseRedirectionServerName" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="ConDefaultUseRedirectionServerName" serializeAs="String">
+        <value>False</value>
+      </setting>
       <setting name="ConDefaultUseVmId" serializeAs="String">
         <value>False</value>
       </setting>

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsDeserializerMremotengFormat.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsDeserializerMremotengFormat.cs
@@ -258,6 +258,11 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Csv
                 if (bool.TryParse(connectionCsv[headers.IndexOf("UseRCG")], out bool value))
                     connectionRecord.UseRCG = value;
             }
+            if (headers.Contains("UseRedirectionServerName"))
+            {
+                if (bool.TryParse(connectionCsv[headers.IndexOf("UseRedirectionServerName")], out bool value))
+                    connectionRecord.UseRedirectionServerName = value;
+            }
 
 
             if (headers.Contains("UseVmId"))
@@ -696,6 +701,11 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Csv
             {
                 if (bool.TryParse(connectionCsv[headers.IndexOf("InheritUseRCG")], out bool value))
                     connectionRecord.Inheritance.UseRCG = value;
+            }
+            if (headers.Contains("InheritUseRedirectionServerName"))
+            {
+                if (bool.TryParse(connectionCsv[headers.IndexOf("InheritUseRedirectionServerName")], out bool value))
+                    connectionRecord.Inheritance.UseRedirectionServerName = value;
             }
 
 

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsSerializerMremotengFormat.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Csv/CsvConnectionsSerializerMremotengFormat.cs
@@ -58,7 +58,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Csv
             if (_saveFilter.SaveDomain)
                 sb.Append("Domain;");
 
-            sb.Append("Hostname;Port;VmId;Protocol;SSHTunnelConnectionName;OpeningCommand;SSHOptions;PuttySession;ConnectToConsole;UseCredSsp;UseRestrictedAdmin;UseRCG;UseVmId;UseEnhancedMode;RenderingEngine;RDPAuthenticationLevel;" +
+            sb.Append("Hostname;Port;VmId;Protocol;SSHTunnelConnectionName;OpeningCommand;SSHOptions;PuttySession;ConnectToConsole;UseCredSsp;UseRestrictedAdmin;UseRCG;UseRedirectionServerName;UseVmId;UseEnhancedMode;RenderingEngine;RDPAuthenticationLevel;" +
                       "LoadBalanceInfo;Colors;Resolution;AutomaticResize;DisplayWallpaper;DisplayThemes;EnableFontSmoothing;EnableDesktopComposition;DisableFullWindowDrag;DisableMenuAnimations;DisableCursorShadow;DisableCursorBlinking;" +
                       "CacheBitmaps;RedirectDiskDrives;RedirectDiskDrivesCustomRedirectPorts;RedirectPrinters;RedirectClipboard;RedirectSmartCards;RedirectSound;RedirectKeys;" +
                       "PreExtApp;PostExtApp;MacAddress;UserField;EnvironmentTags;ExtApp;Favorite;VNCCompression;VNCEncoding;VNCAuthMode;VNCProxyType;VNCProxyIP;" +
@@ -70,7 +70,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Csv
                           "InheritEnableFontSmoothing;InheritEnableDesktopComposition;InheritDisableFullWindowDrag;InheritDisableMenuAnimations;InheritDisableCursorShadow;InheritDisableCursorBlinking;InheritDomain;InheritIcon;InheritPanel;InheritTabColor;InheritConnectionFrameColor;InheritPassword;InheritPort;" +
                           "InheritProtocol;InheritSSHTunnelConnectionName;InheritOpeningCommand;InheritSSHOptions;InheritPuttySession;InheritRedirectDiskDrives;InheritRedirectDiskDrivesCustom;InheritRedirectKeys;InheritRedirectPorts;InheritRedirectPrinters;" +
                           "InheritRedirectClipboard;InheritRedirectSmartCards;InheritRedirectSound;InheritResolution;InheritAutomaticResize;" +
-                          "InheritUseConsoleSession;InheritUseCredSsp;InheritUseRestrictedAdmin;InheritUseRCG;InheritUseVmId;InheritUseEnhancedMode;InheritVmId;InheritRenderingEngine;InheritUsername;" +
+                          "InheritUseConsoleSession;InheritUseCredSsp;InheritUseRestrictedAdmin;InheritUseRCG;InheritUseRedirectionServerName;InheritUseVmId;InheritUseEnhancedMode;InheritVmId;InheritRenderingEngine;InheritUsername;" +
                           "InheritRDPAuthenticationLevel;InheritLoadBalanceInfo;InheritPreExtApp;InheritPostExtApp;InheritMacAddress;InheritUserField;" +
                           "InheritEnvironmentTags;InheritFavorite;InheritExtApp;InheritVNCCompression;InheritVNCEncoding;InheritVNCAuthMode;InheritVNCProxyType;InheritVNCProxyIP;" +
                           "InheritVNCProxyPort;InheritVNCProxyUsername;InheritVNCProxyPassword;InheritVNCColors;InheritVNCSmartSizeMode;InheritVNCViewOnly;" +
@@ -132,6 +132,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Csv
               .Append(FormatForCsv(con.UseCredSsp))
               .Append(FormatForCsv(con.UseRestrictedAdmin))
               .Append(FormatForCsv(con.UseRCG))
+              .Append(FormatForCsv(con.UseRedirectionServerName))
               .Append(FormatForCsv(con.UseVmId))
               .Append(FormatForCsv(con.UseEnhancedMode))
               .Append(FormatForCsv(con.RenderingEngine))
@@ -235,6 +236,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Csv
               .Append(FormatForCsv(con.Inheritance.UseCredSsp))
               .Append(FormatForCsv(con.Inheritance.UseRestrictedAdmin))
               .Append(FormatForCsv(con.Inheritance.UseRCG))
+              .Append(FormatForCsv(con.Inheritance.UseRedirectionServerName))
               .Append(FormatForCsv(con.Inheritance.UseVmId))
               .Append(FormatForCsv(con.Inheritance.UseEnhancedMode))
               .Append(FormatForCsv(con.Inheritance.VmId))

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer28.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer28.cs
@@ -152,6 +152,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
 
             element.Add(new XAttribute("UseRCG", connectionInfo.UseRCG));
             element.Add(new XAttribute("UseRestrictedAdmin", connectionInfo.UseRestrictedAdmin));
+            element.Add(new XAttribute("UseRedirectionServerName", connectionInfo.UseRedirectionServerName));
 
             element.Add(new XAttribute("UserViaAPI", connectionInfo.UserViaAPI));
             element.Add(new XAttribute("EC2InstanceId", connectionInfo.EC2InstanceId));
@@ -328,6 +329,8 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
                 element.Add(new XAttribute("InheritUseRCG", inheritance.UseRCG.ToString().ToLowerInvariant()));
             if (inheritance.UseRestrictedAdmin)
                 element.Add(new XAttribute("InheritUseRestrictedAdmin", inheritance.UseRestrictedAdmin.ToString().ToLowerInvariant()));
+            if (inheritance.UseRedirectionServerName)
+                element.Add(new XAttribute("InheritUseRedirectionServerName", inheritance.UseRedirectionServerName.ToString().ToLowerInvariant()));
         }
     }
 }

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
@@ -529,6 +529,8 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
                     connectionInfo.Inheritance.UseRestrictedAdmin = xmlnode.GetAttributeAsBool("InheritUseRestrictedAdmin");
                     connectionInfo.UseRCG = xmlnode.GetAttributeAsBool("UseRCG");
                     connectionInfo.Inheritance.UseRCG = xmlnode.GetAttributeAsBool("InheritUseRCG");
+                    connectionInfo.UseRedirectionServerName = xmlnode.GetAttributeAsBool("UseRedirectionServerName");
+                    connectionInfo.Inheritance.UseRedirectionServerName = xmlnode.GetAttributeAsBool("InheritUseRedirectionServerName");
                     connectionInfo.RDGatewayExternalCredentialProvider = xmlnode.GetAttributeAsEnum("RDGatewayExternalCredentialProvider", ExternalCredentialProvider.None);
                     connectionInfo.RDGatewayUserViaAPI = xmlnode.GetAttributeAsString("RDGatewayUserViaAPI");
                     connectionInfo.Inheritance.RDGatewayExternalCredentialProvider = xmlnode.GetAttributeAsBool("InheritRDGatewayExternalCredentialProvider");

--- a/mRemoteNG/Connection/AbstractConnectionRecord.cs
+++ b/mRemoteNG/Connection/AbstractConnectionRecord.cs
@@ -60,6 +60,7 @@ namespace mRemoteNG.Connection
         private bool _useRestrictedAdmin;
         private bool _useRCG;
         private bool _useVmId;
+        private bool _useRedirectionServerName;
 
         private RDGatewayUsageMethod _rdGatewayUsageMethod;
         private string _rdGatewayHostname;
@@ -524,6 +525,17 @@ namespace mRemoteNG.Connection
         {
             get => GetPropertyValue("UseRCG", _useRCG);
             set => SetField(ref _useRCG, value, "UseRCG");
+        }
+
+        [LocalizedAttributes.LocalizedCategory(nameof(Language.Protocol), 3),
+         LocalizedAttributes.LocalizedDisplayName(nameof(Language.UseRedirectionServerName)),
+         LocalizedAttributes.LocalizedDescription(nameof(Language.PropertyDescriptionUseRedirectionServerName)),
+         TypeConverter(typeof(MiscTools.YesNoTypeConverter)),
+         AttributeUsedInProtocol(ProtocolType.RDP)]
+        public bool UseRedirectionServerName
+        {
+            get => GetPropertyValue("UseRedirectionServerName", _useRedirectionServerName);
+            set => SetField(ref _useRedirectionServerName, value, "UseRedirectionServerName");
         }
 
         [LocalizedAttributes.LocalizedCategory(nameof(Language.Protocol), 3),

--- a/mRemoteNG/Connection/ConnectionInfo.cs
+++ b/mRemoteNG/Connection/ConnectionInfo.cs
@@ -327,6 +327,7 @@ namespace mRemoteNG.Connection
             UseCredSsp = Settings.Default.ConDefaultUseCredSsp;
             UseRestrictedAdmin = Settings.Default.ConDefaultUseRestrictedAdmin;
             UseRCG = Settings.Default.ConDefaultUseRCG;
+            UseRedirectionServerName = Settings.Default.ConDefaultUseRedirectionServerName;
             UseVmId = Settings.Default.ConDefaultUseVmId;
             UseEnhancedMode = Settings.Default.ConDefaultUseEnhancedMode;
         }

--- a/mRemoteNG/Connection/ConnectionInfoInheritance.cs
+++ b/mRemoteNG/Connection/ConnectionInfoInheritance.cs
@@ -225,6 +225,12 @@ namespace mRemoteNG.Connection
         public bool UseRCG { get; set; }
 
         [LocalizedAttributes.LocalizedCategory(nameof(Language.Protocol), 4),
+         LocalizedAttributes.LocalizedDisplayNameInherit(nameof(Language.UseRedirectionServerName)),
+         LocalizedAttributes.LocalizedDescriptionInherit(nameof(Language.PropertyDescriptionUseRedirectionServerName)),
+         TypeConverter(typeof(MiscTools.YesNoTypeConverter))]
+        public bool UseRedirectionServerName { get; set; }
+
+        [LocalizedAttributes.LocalizedCategory(nameof(Language.Protocol), 4),
          LocalizedAttributes.LocalizedDisplayNameInherit(nameof(Language.UseVmId)),
          LocalizedAttributes.LocalizedDescriptionInherit(nameof(Language.PropertyDescriptionUseVmId)),
          TypeConverter(typeof(MiscTools.YesNoTypeConverter))]

--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol7.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol7.cs
@@ -1,5 +1,6 @@
 ﻿using AxMSTSCLib;
 using mRemoteNG.App;
+using mRemoteNG.Messages;
 using MSTSCLib;
 using System;
 using System.Windows.Forms;
@@ -27,6 +28,8 @@ namespace mRemoteNG.Connection.Protocol.RDP
                 RdpClient7.AdvancedSettings8.AudioCaptureRedirectionMode = connectionInfo.RedirectAudioCapture;
                 RdpClient7.AdvancedSettings8.NetworkConnectionType = (int)RdpNetworkConnectionType.Modem;
 
+                SetUseRedirectionServerName();
+
                 if (connectionInfo.UseVmId)
                 {
                     SetExtendedProperty("DisableCredentialsDelegation", true);
@@ -42,7 +45,7 @@ namespace mRemoteNG.Connection.Protocol.RDP
                 {
                     string authToken = connectionInfo.RDGatewayAccessToken;
                     string encryptedAuthToken = RdGatewayAccessTokenHelper.EncryptAuthCookieString(authToken);
-                    RdpClient7.TransportSettings3.GatewayEncryptedAuthCookie = encryptedAuthToken;  
+                    RdpClient7.TransportSettings3.GatewayEncryptedAuthCookie = encryptedAuthToken;
                     RdpClient7.TransportSettings3.GatewayEncryptedAuthCookieSize = (uint)encryptedAuthToken.Length;
                     RdpClient7.TransportSettings3.GatewayCredsSource = 5;
                 }
@@ -56,10 +59,41 @@ namespace mRemoteNG.Connection.Protocol.RDP
             return true;
         }
 
+        /// <summary>
+        /// When enabled, instructs the RDP client to reconnect using the originally configured
+        /// server name on a server-issued load-balance redirect, instead of following the redirect
+        /// target's host name. Required for servers such as GNOME Remote Desktop in --system mode,
+        /// which redirect to a load-balance token that is only meaningful when reconnecting to the
+        /// original endpoint. Must remain disabled for standard load-balanced deployments such as
+        /// Windows RDS, Azure Virtual Desktop, and Citrix.
+        /// See: IMsRdpPreferredRedirectionInfo.UseRedirectionServerName.
+        /// </summary>
+        private void SetUseRedirectionServerName()
+        {
+            if (!connectionInfo.UseRedirectionServerName) return;
+
+            try
+            {
+                var redirectionInfo = ((AxHost)Control).GetOcx() as IMsRdpPreferredRedirectionInfo;
+                if (redirectionInfo == null)
+                {
+                    Runtime.MessageCollector.AddMessage(MessageClass.WarningMsg,
+                        "IMsRdpPreferredRedirectionInfo is not implemented by the current RDP client; UseRedirectionServerName ignored.");
+                    return;
+                }
+                redirectionInfo.UseRedirectionServerName = true;
+            }
+            catch (Exception ex)
+            {
+                Runtime.MessageCollector.AddExceptionStackTrace(
+                    "Unable to set UseRedirectionServerName.", ex);
+            }
+        }
+
         protected override AxHost CreateActiveXRdpClientControl()
         {
             return new AxMsRdpClient11NotSafeForScripting();
         }
-        
+
     }
 }

--- a/mRemoteNG/Language/Language.Designer.cs
+++ b/mRemoteNG/Language/Language.Designer.cs
@@ -4700,6 +4700,15 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("PropertyDescriptionUseRCG", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to On server-issued load-balance redirects, reconnect using the originally configured server name instead of the redirection target. Required for some servers such as GNOME Remote Desktop (--system mode). Leave unchecked for Windows RDS / Azure Virtual Desktop / Citrix..
+        /// </summary>
+        internal static string PropertyDescriptionUseRedirectionServerName {
+            get {
+                return ResourceManager.GetString("PropertyDescriptionUseRedirectionServerName", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Use restricted admin mode on the target host (local system context)..
@@ -6982,6 +6991,15 @@ namespace mRemoteNG.Resources.Language {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Use Redirection Server Name.
+        /// </summary>
+        internal static string UseRedirectionServerName {
+            get {
+                return ResourceManager.GetString("UseRedirectionServerName", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Use Remote Credential Guard.
         /// </summary>

--- a/mRemoteNG/Language/Language.ja-JP.resx
+++ b/mRemoteNG/Language/Language.ja-JP.resx
@@ -1081,6 +1081,9 @@ If you run into such an error, please create a new connection file!</comment>
   <data name="PropertyDescriptionUseConsoleSession" xml:space="preserve">
     <value>Connect to the console session of the remote host.</value>
   </data>
+  <data name="PropertyDescriptionUseRedirectionServerName" xml:space="preserve">
+    <value>サーバーから負荷分散リダイレクトが発行された際、リダイレクト先のホスト名ではなく、元の設定どおりのサーバー名で再接続します。GNOME Remote Desktop (--system モード) のような、リダイレクト先で同じサーバーへ再接続させる必要があるサーバーで必要です。Windows RDS / Azure Virtual Desktop / Citrix では、本来のリダイレクト先で接続を続行する設計なので無効のままにしてください。</value>
+  </data>
   <data name="PropertyDescriptionUseCredSsp" xml:space="preserve">
     <value>Use the Credential Security Support Provider (CredSSP) for authentication if it is available.</value>
   </data>
@@ -1224,6 +1227,9 @@ If you run into such an error, please create a new connection file!</comment>
   </data>
   <data name="UseConsoleSession" xml:space="preserve">
     <value>コンソールセッションを使用</value>
+  </data>
+  <data name="UseRedirectionServerName" xml:space="preserve">
+    <value>リダイレクトサーバー名を使用</value>
   </data>
   <data name="UseCredSsp" xml:space="preserve">
     <value>Use CredSSP</value>

--- a/mRemoteNG/Language/Language.resx
+++ b/mRemoteNG/Language/Language.resx
@@ -1119,6 +1119,9 @@ If you run into such an error, please create a new connection file!</value>
   <data name="PropertyDescriptionUseRCG" xml:space="preserve">
     <value>Use Remote Credential Guard to tunnel authentication on target back to source through the RDP channel.</value>
   </data>
+  <data name="PropertyDescriptionUseRedirectionServerName" xml:space="preserve">
+    <value>On server-issued load-balance redirects, reconnect using the originally configured server name instead of the redirection target. Required for some servers such as GNOME Remote Desktop (--system mode). Leave unchecked for Windows RDS / Azure Virtual Desktop / Citrix.</value>
+  </data>
   <data name="PropertyDescriptionUser1" xml:space="preserve">
     <value>Feel free to enter any information you need here.</value>
   </data>
@@ -1283,6 +1286,9 @@ If you run into such an error, please create a new connection file!</value>
   </data>
   <data name="UseRCG" xml:space="preserve">
     <value>Use Remote Credential Guard</value>
+  </data>
+  <data name="UseRedirectionServerName" xml:space="preserve">
+    <value>Use Redirection Server Name</value>
   </data>
   <data name="UserField" xml:space="preserve">
     <value>User Field</value>

--- a/mRemoteNG/Properties/Settings.Designer.cs
+++ b/mRemoteNG/Properties/Settings.Designer.cs
@@ -1450,7 +1450,31 @@ namespace mRemoteNG.Properties {
                 this["ConDefaultUseRCG"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool InhDefaultUseRedirectionServerName {
+            get {
+                return ((bool)(this["InhDefaultUseRedirectionServerName"]));
+            }
+            set {
+                this["InhDefaultUseRedirectionServerName"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ConDefaultUseRedirectionServerName {
+            get {
+                return ((bool)(this["ConDefaultUseRedirectionServerName"]));
+            }
+            set {
+                this["ConDefaultUseRedirectionServerName"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]

--- a/mRemoteNG/Properties/Settings.settings
+++ b/mRemoteNG/Properties/Settings.settings
@@ -359,6 +359,12 @@
     <Setting Name="ConDefaultUseRCG" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="InhDefaultUseRedirectionServerName" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="ConDefaultUseRedirectionServerName" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="ConDefaultUseVmId" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>


### PR DESCRIPTION
## Summary

Adds support for `IMsRdpPreferredRedirectionInfo.UseRedirectionServerName` as an **opt-in per-connection property defaulting to false**.

When enabled, the RDP client reconnects using the originally configured server name on a server-issued load-balance redirect, instead of following the redirection target's hostname.

## Motivation

This is required for servers such as **GNOME Remote Desktop in `--system` mode** (the GNOME RDP backend used on modern Wayland-based Ubuntu/Fedora desktops). GNOME RDP issues a load-balance redirect that is only meaningful when reconnecting to the original endpoint — without `UseRedirectionServerName=true` the client follows the redirect to an unreachable target and the connection drops mid-handshake.

`xrdp`, the older alternative, is being phased out on many distros in favour of GNOME RDP. Without this fix, mRemoteNG cannot connect to modern GNOME desktops/servers with RDP enabled.

Closes #2637.

## Compatibility / Trade-off

When this property is `true`, the client will not follow load-balance redirects to alternate hosts. Therefore it **must remain off** for standard load-balanced deployments such as:

- Windows RD Connection Broker / RDS
- Azure Virtual Desktop (AVD)
- Citrix XenApp / XenDesktop

The default value is `false` so existing connections are not affected. Users must explicitly opt in per connection (or via the Default Inheritance settings).

## Implementation

- `AbstractConnectionRecord.UseRedirectionServerName` (bool, default false) — new per-connection property in the Protocol category.
- `ConnectionInfoInheritance.UseRedirectionServerName` — inheritance flag, matching the pattern of `UseRCG`/`UseRestrictedAdmin`.
- `RdpProtocol7.SetUseRedirectionServerName()` — applies the setting via `IMsRdpPreferredRedirectionInfo` on the RDP OCX, with try/catch and a warning if the interface is unavailable. Inherited by `RdpProtocol8`-`RdpProtocol11`.
- Settings: `ConDefaultUseRedirectionServerName` / `InhDefaultUseRedirectionServerName` added to `App.config` and `Settings.settings`/`Designer.cs`.
- Localization: English strings added to `Language.resx` and `Language.Designer.cs`. Other locale `.resx` files left untranslated — they will fall back to English until contributors translate them.
- XML serializer (v28) + deserializer: persists `UseRedirectionServerName` and `InheritUseRedirectionServerName` attributes.
- CSV serializer + deserializer: round-trips the new column.

## Manual test

Verified against a live **Ubuntu Server 26.04 LTS** with `gnome-remote-desktop --system` listening on port 3389:

- Without property (default false): connection fails at the redirect step (matches mstsc's behaviour when `use redirection server name:i:1` is absent in the .rdp file) — preserves current mRemoteNG behaviour.
- With property enabled: NLA + redirect both pass; GNOME GDM greeter is reached over RDP. Same outcome as `mstsc.exe` with `use redirection server name:i:1` in the .rdp file.

## References

- MS docs: [`IMsRdpPreferredRedirectionInfo.UseRedirectionServerName`](https://learn.microsoft.com/en-us/windows/win32/termserv/imsrdppreferredredirectioninfo-useredirectionservername)
- Issue #2637

## Notes for maintainers

- I targeted `v1.78.2-dev` per the current dev branch. Happy to rebase onto whichever branch you prefer.
- `AssemblyInfo.cs` build number auto-bump was reverted to avoid noise.
- The CSV column order was extended by inserting `UseRedirectionServerName` adjacent to `UseRCG`. Older CSVs without the column will deserialize to `false` (existing `headers.Contains` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)