### PR TITLE
Resolve nullable warnings in Tree, Container and Credential

### DIFF
--- a/mRemoteNG/Connection/AbstractConnectionRecord.cs
+++ b/mRemoteNG/Connection/AbstractConnectionRecord.cs
@@ -1120,7 +1120,7 @@ namespace mRemoteNG.Connection
 
         public event PropertyChangedEventHandler? PropertyChanged;
 
-        protected virtual void RaisePropertyChangedEvent(object sender, PropertyChangedEventArgs args)
+        protected virtual void RaisePropertyChangedEvent(object? sender, PropertyChangedEventArgs args)
         {
             PropertyChanged?.Invoke(sender, new PropertyChangedEventArgs(args.PropertyName));
         }

--- a/mRemoteNG/Container/ContainerInfo.cs
+++ b/mRemoteNG/Container/ContainerInfo.cs
@@ -95,7 +95,10 @@ namespace mRemoteNG.Container
         public virtual void RemoveChild(ConnectionInfo removalTarget)
         {
             if (!Children.Contains(removalTarget)) return;
-            removalTarget.Parent = null;
+            // Parent is typed non-nullable but null is the established sentinel for a detached node
+            // (see AddChildAt's "Parent?.RemoveChild" call). Making the property nullable would
+            // cascade across the whole codebase, so the detach assignment is null-forgiven here.
+            removalTarget.Parent = null!;
             Children.Remove(removalTarget);
             UnsubscribeToChildEvents(removalTarget);
             RaiseCollectionChangedEvent(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, removalTarget));
@@ -219,7 +222,7 @@ namespace mRemoteNG.Container
             foreach (ConnectionInfo child in Children)
             {
                 childList.Add(child);
-                ContainerInfo childContainer = child as ContainerInfo;
+                ContainerInfo? childContainer = child as ContainerInfo;
                 if (childContainer != null)
                     childList.AddRange(GetRecursiveChildList(childContainer));
             }
@@ -233,7 +236,7 @@ namespace mRemoteNG.Container
             foreach (ConnectionInfo child in container.Children)
             {
                 childList.Add(child);
-                ContainerInfo childContainer = child as ContainerInfo;
+                ContainerInfo? childContainer = child as ContainerInfo;
                 if (childContainer != null)
                     childList.AddRange(GetRecursiveChildList(childContainer));
             }
@@ -248,7 +251,7 @@ namespace mRemoteNG.Container
             {
                 if (child.Favorite && child.GetTreeNodeType() == TreeNodeType.Connection)
                     childList.Add(child);
-                ContainerInfo childContainer = child as ContainerInfo;
+                ContainerInfo? childContainer = child as ContainerInfo;
                 if (childContainer != null)
                     childList.AddRange(GetRecursiveFavoritChildList(childContainer));
             }
@@ -290,7 +293,7 @@ namespace mRemoteNG.Container
             {
                 if (child.Favorite && child.GetTreeNodeType() == TreeNodeType.Connection)
                     childList.Add(child);
-                ContainerInfo childContainer = child as ContainerInfo;
+                ContainerInfo? childContainer = child as ContainerInfo;
                 if (childContainer != null)
                     childList.AddRange(GetRecursiveFavoritChildList(childContainer));
             }
@@ -300,7 +303,7 @@ namespace mRemoteNG.Container
         protected virtual void SubscribeToChildEvents(ConnectionInfo child)
         {
             child.PropertyChanged += RaisePropertyChangedEvent;
-            ContainerInfo childAsContainer = child as ContainerInfo;
+            ContainerInfo? childAsContainer = child as ContainerInfo;
             if (childAsContainer == null) return;
             childAsContainer.CollectionChanged += RaiseCollectionChangedEvent;
         }
@@ -308,14 +311,14 @@ namespace mRemoteNG.Container
         protected virtual void UnsubscribeToChildEvents(ConnectionInfo child)
         {
             child.PropertyChanged -= RaisePropertyChangedEvent;
-            ContainerInfo childAsContainer = child as ContainerInfo;
+            ContainerInfo? childAsContainer = child as ContainerInfo;
             if (childAsContainer == null) return;
             childAsContainer.CollectionChanged -= RaiseCollectionChangedEvent;
         }
 
         public event NotifyCollectionChangedEventHandler? CollectionChanged;
 
-        private void RaiseCollectionChangedEvent(object sender, NotifyCollectionChangedEventArgs args)
+        private void RaiseCollectionChangedEvent(object? sender, NotifyCollectionChangedEventArgs args)
         {
             CollectionChanged?.Invoke(sender, args);
         }

--- a/mRemoteNG/Credential/CredentialDeletionMsgBoxConfirmer.cs
+++ b/mRemoteNG/Credential/CredentialDeletionMsgBoxConfirmer.cs
@@ -32,7 +32,7 @@ namespace mRemoteNG.Credential
 
         private bool PromptUser(string promptMessage)
         {
-            DialogResult msgBoxResponse = _confirmationFunc.Invoke(promptMessage, Application.ProductName, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+            DialogResult msgBoxResponse = _confirmationFunc.Invoke(promptMessage, Application.ProductName ?? string.Empty, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
             return msgBoxResponse == DialogResult.Yes;
         }
     }

--- a/mRemoteNG/Credential/CredentialInfo.cs
+++ b/mRemoteNG/Credential/CredentialInfo.cs
@@ -29,7 +29,8 @@ namespace mRemoteNG.Credential
             Browsable(true),
             LocalizedAttributes.LocalizedDisplayName("strPropertyNamePassword"),
             LocalizedAttributes.LocalizedDescription("strPropertyDescriptionPassword"), 
-            PasswordPropertyText(true)]public string Password { get; set; } = string.Empty;
+            PasswordPropertyText(true)]
+        public string Password { get; set; } = string.Empty;
 
 	    [LocalizedAttributes.LocalizedCategory("strCategoryCredentials", 2), 
             Browsable(true),

--- a/mRemoteNG/Credential/CredentialInfo.cs
+++ b/mRemoteNG/Credential/CredentialInfo.cs
@@ -11,31 +11,31 @@ namespace mRemoteNG.Credential
             Browsable(true),
             LocalizedAttributes.LocalizedDisplayName("strPropertyNameName"),
             LocalizedAttributes.LocalizedDescription("strPropertyDescriptionName")]
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
 
 	    [LocalizedAttributes.LocalizedCategory("strCategoryDisplay"), 
             Browsable(true),
             LocalizedAttributes.LocalizedDisplayName("strPropertyNameDescription"),
             LocalizedAttributes.LocalizedDescription("strPropertyDescriptionDescription")]
-        public string Description { get; set; }
+        public string Description { get; set; } = string.Empty;
 
 	    [LocalizedAttributes.LocalizedCategory("strCategoryCredentials", 2), 
             Browsable(true),
             LocalizedAttributes.LocalizedDisplayName("strPropertyNameUsername"),
             LocalizedAttributes.LocalizedDescription("strPropertyDescriptionUsername")]
-        public string Username { get; set; }
+        public string Username { get; set; } = string.Empty;
 
 	    [LocalizedAttributes.LocalizedCategory("strCategoryCredentials", 2), 
             Browsable(true),
             LocalizedAttributes.LocalizedDisplayName("strPropertyNamePassword"),
             LocalizedAttributes.LocalizedDescription("strPropertyDescriptionPassword"), 
-            PasswordPropertyText(true)]public string Password { get; set; }
+            PasswordPropertyText(true)]public string Password { get; set; } = string.Empty;
 
 	    [LocalizedAttributes.LocalizedCategory("strCategoryCredentials", 2), 
             Browsable(true),
             LocalizedAttributes.LocalizedDisplayName("strPropertyNameDomain"),
             LocalizedAttributes.LocalizedDescription("strPropertyDescriptionDomain")]
-        public string Domain { get; set; }
+        public string Domain { get; set; } = string.Empty;
 
 	    #endregion
 	}

--- a/mRemoteNG/Credential/CredentialRecordTypeConverter.cs
+++ b/mRemoteNG/Credential/CredentialRecordTypeConverter.cs
@@ -25,7 +25,7 @@ namespace mRemoteNG.Credential
             return base.ConvertTo(context, culture, value, destinationType);
         }
 
-        public override object ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
+        public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
         {
             if (!(value is Guid)) return base.ConvertFrom(context, culture, value);
             ICredentialRecord[] matchedCredentials = Runtime.CredentialProviderCatalog.GetCredentialRecords()

--- a/mRemoteNG/Credential/CredentialServiceFacade.cs
+++ b/mRemoteNG/Credential/CredentialServiceFacade.cs
@@ -56,7 +56,7 @@ namespace mRemoteNG.Credential
             return _repositoryList.GetCredentialRecords();
         }
 
-        public ICredentialRecord GetCredentialRecord(Guid id)
+        public ICredentialRecord? GetCredentialRecord(Guid id)
         {
             return _repositoryList.GetCredentialRecord(id);
         }
@@ -69,18 +69,18 @@ namespace mRemoteNG.Credential
             _repositoryList.CredentialsUpdated += HandleCredentialsUpdatedEvent;
         }
 
-        private void HandleRepositoriesUpdatedEvent(object sender,
+        private void HandleRepositoriesUpdatedEvent(object? sender,
                                                     CollectionUpdatedEventArgs<ICredentialRepository>
                                                         collectionUpdatedEventArgs)
         {
             SaveRepositoryList();
         }
 
-        private void HandleCredentialsUpdatedEvent(object sender,
+        private void HandleCredentialsUpdatedEvent(object? sender,
                                                    CollectionUpdatedEventArgs<ICredentialRecord>
                                                        collectionUpdatedEventArgs)
         {
-            ICredentialRepository repo = sender as ICredentialRepository;
+            ICredentialRepository? repo = sender as ICredentialRepository;
             repo?.SaveCredentials(repo.Config.Key);
         }
 

--- a/mRemoteNG/Credential/ICredentialRepository.cs
+++ b/mRemoteNG/Credential/ICredentialRepository.cs
@@ -15,7 +15,7 @@ namespace mRemoteNG.Credential
         void LoadCredentials(SecureString key);
         void SaveCredentials(SecureString key);
         void UnloadCredentials();
-        event EventHandler RepositoryConfigUpdated;
-        event EventHandler<CollectionUpdatedEventArgs<ICredentialRecord>> CredentialsUpdated;
+        event EventHandler? RepositoryConfigUpdated;
+        event EventHandler<CollectionUpdatedEventArgs<ICredentialRecord>>? CredentialsUpdated;
     }
 }

--- a/mRemoteNG/Credential/ICredentialRepositoryList.cs
+++ b/mRemoteNG/Credential/ICredentialRepositoryList.cs
@@ -16,9 +16,9 @@ namespace mRemoteNG.Credential
 
         IEnumerable<ICredentialRecord> GetCredentialRecords();
 
-        ICredentialRecord GetCredentialRecord(Guid id);
+        ICredentialRecord? GetCredentialRecord(Guid id);
 
-        event EventHandler<CollectionUpdatedEventArgs<ICredentialRepository>> RepositoriesUpdated;
-        event EventHandler<CollectionUpdatedEventArgs<ICredentialRecord>> CredentialsUpdated;
+        event EventHandler<CollectionUpdatedEventArgs<ICredentialRepository>>? RepositoriesUpdated;
+        event EventHandler<CollectionUpdatedEventArgs<ICredentialRecord>>? CredentialsUpdated;
     }
 }

--- a/mRemoteNG/Credential/Repositories/CompositeRepositoryUnlocker.cs
+++ b/mRemoteNG/Credential/Repositories/CompositeRepositoryUnlocker.cs
@@ -10,7 +10,7 @@ namespace mRemoteNG.Credential.Repositories
         private readonly List<ICredentialRepository> _repositories = [];
 
         public IEnumerable<ICredentialRepository> Repositories => _repositories;
-        public ICredentialRepository SelectedRepository { get; set; }
+        public ICredentialRepository? SelectedRepository { get; set; }
 
         public CompositeRepositoryUnlocker(IEnumerable<ICredentialRepository> repositories)
         {
@@ -23,7 +23,7 @@ namespace mRemoteNG.Credential.Repositories
 
         public void Unlock(SecureString key)
         {
-            SelectedRepository.LoadCredentials(key);
+            SelectedRepository?.LoadCredentials(key);
         }
 
         public void SelectNextLockedRepository()
@@ -31,7 +31,7 @@ namespace mRemoteNG.Credential.Repositories
             SelectedRepository = GetNextLockedRepo();
         }
 
-        private ICredentialRepository GetNextLockedRepo()
+        private ICredentialRepository? GetNextLockedRepo()
         {
             IList<ICredentialRepository> newOrder = OrderListForNextLockedRepo();
             return newOrder.Any() ? newOrder.First() : null;
@@ -67,7 +67,8 @@ namespace mRemoteNG.Credential.Repositories
 
         private int GetNewListStartIndex()
         {
-            int currentItemIndex = _repositories.IndexOf(SelectedRepository);
+            // IndexOf of a null selection is -1; guard so the non-null IndexOf overload is satisfied.
+            int currentItemIndex = SelectedRepository is null ? -1 : _repositories.IndexOf(SelectedRepository);
             return currentItemIndex + 1;
         }
     }

--- a/mRemoteNG/Credential/Repositories/CredentialRepositoryList.cs
+++ b/mRemoteNG/Credential/Repositories/CredentialRepositoryList.cs
@@ -47,7 +47,7 @@ namespace mRemoteNG.Credential.Repositories
             return list;
         }
 
-        public ICredentialRecord GetCredentialRecord(Guid id)
+        public ICredentialRecord? GetCredentialRecord(Guid id)
         {
             return CredentialProviders.SelectMany(repo => repo.CredentialRecords)
                                       .FirstOrDefault(record => record.Id.Equals(id));
@@ -63,8 +63,8 @@ namespace mRemoteNG.Credential.Repositories
             return GetEnumerator();
         }
 
-        public event EventHandler<CollectionUpdatedEventArgs<ICredentialRepository>> RepositoriesUpdated;
-        public event EventHandler<CollectionUpdatedEventArgs<ICredentialRecord>> CredentialsUpdated;
+        public event EventHandler<CollectionUpdatedEventArgs<ICredentialRepository>>? RepositoriesUpdated;
+        public event EventHandler<CollectionUpdatedEventArgs<ICredentialRecord>>? CredentialsUpdated;
 
         private void RaiseRepositoriesUpdatedEvent(ActionType action, IEnumerable<ICredentialRepository> changedItems)
         {
@@ -72,14 +72,14 @@ namespace mRemoteNG.Credential.Repositories
                                         new CollectionUpdatedEventArgs<ICredentialRepository>(action, changedItems));
         }
 
-        private void RaiseCredentialsUpdatedEvent(object sender, CollectionUpdatedEventArgs<ICredentialRecord> args)
+        private void RaiseCredentialsUpdatedEvent(object? sender, CollectionUpdatedEventArgs<ICredentialRecord> args)
         {
             CredentialsUpdated?.Invoke(sender, args);
         }
 
-        private void OnRepoConfigChanged(object sender, EventArgs args)
+        private void OnRepoConfigChanged(object? sender, EventArgs args)
         {
-            ICredentialRepository repo = sender as ICredentialRepository;
+            ICredentialRepository? repo = sender as ICredentialRepository;
             if (repo == null) return;
             RaiseRepositoriesUpdatedEvent(ActionType.Updated, new[] {repo});
         }

--- a/mRemoteNG/Credential/Repositories/XmlCredentialRepository.cs
+++ b/mRemoteNG/Credential/Repositories/XmlCredentialRepository.cs
@@ -67,15 +67,15 @@ namespace mRemoteNG.Credential.Repositories
             _credentialRecordSaver.Save(CredentialRecords, key);
         }
 
-        public event EventHandler RepositoryConfigUpdated;
-        public event EventHandler<CollectionUpdatedEventArgs<ICredentialRecord>> CredentialsUpdated;
+        public event EventHandler? RepositoryConfigUpdated;
+        public event EventHandler<CollectionUpdatedEventArgs<ICredentialRecord>>? CredentialsUpdated;
 
         protected virtual void RaiseRepositoryConfigUpdatedEvent(PropertyChangedEventArgs args)
         {
             RepositoryConfigUpdated?.Invoke(this, args);
         }
 
-        protected virtual void RaiseCredentialsUpdatedEvent(object sender,
+        protected virtual void RaiseCredentialsUpdatedEvent(object? sender,
                                                             CollectionUpdatedEventArgs<ICredentialRecord> args)
         {
             CredentialsUpdated?.Invoke(this, args);

--- a/mRemoteNG/Credential/Repositories/XmlCredentialRepositoryFactory.cs
+++ b/mRemoteNG/Credential/Repositories/XmlCredentialRepositoryFactory.cs
@@ -33,15 +33,14 @@ namespace mRemoteNG.Credential.Repositories
 
         public ICredentialRepository Build(XElement repositoryXElement)
         {
-            string stringId = repositoryXElement.Attribute("Id")?.Value;
-            Guid id;
-            Guid.TryParse(stringId, out id);
+            string? stringId = repositoryXElement.Attribute("Id")?.Value;
+            Guid.TryParse(stringId, out Guid id);
             if (id.Equals(Guid.Empty)) id = Guid.NewGuid();
             CredentialRepositoryConfig config = new(id)
             {
-                TypeName = repositoryXElement.Attribute("TypeName")?.Value,
-                Title = repositoryXElement.Attribute("Title")?.Value,
-                Source = repositoryXElement.Attribute("Source")?.Value
+                TypeName = repositoryXElement.Attribute("TypeName")?.Value ?? string.Empty,
+                Title = repositoryXElement.Attribute("Title")?.Value ?? string.Empty,
+                Source = repositoryXElement.Attribute("Source")?.Value ?? string.Empty
             };
             return BuildXmlRepo(config);
         }

--- a/mRemoteNG/Tree/ClickHandlers/ExpandNodeClickHandler.cs
+++ b/mRemoteNG/Tree/ClickHandlers/ExpandNodeClickHandler.cs
@@ -19,7 +19,7 @@ namespace mRemoteNG.Tree.ClickHandlers
 
         public void Execute(ConnectionInfo clickedNode)
         {
-            ContainerInfo clickedNodeAsContainer = clickedNode as ContainerInfo;
+            ContainerInfo? clickedNodeAsContainer = clickedNode as ContainerInfo;
             if (clickedNodeAsContainer == null) return;
             _connectionTree.ToggleExpansion(clickedNodeAsContainer);
         }

--- a/mRemoteNG/Tree/ConnectionTreeDragAndDropHandler.cs
+++ b/mRemoteNG/Tree/ConnectionTreeDragAndDropHandler.cs
@@ -15,12 +15,12 @@ namespace mRemoteNG.Tree
     {
         private readonly Color DropAllowedFeedbackColor = Color.Green;
         private readonly Color DropDeniedFeedbackColor = Color.Red;
-        private string _infoMessage;
+        private string? _infoMessage;
         private Color _currentFeedbackColor;
         private bool _enableFeedback;
 
 
-        public void HandleEvent_ModelDropped(object sender, ModelDropEventArgs e)
+        public void HandleEvent_ModelDropped(object? sender, ModelDropEventArgs e)
         {
             if (!(e.TargetModel is ConnectionInfo dropTarget)) return;
             foreach(ConnectionInfo dropSource in e.SourceModels.Cast<ConnectionInfo>())
@@ -71,14 +71,14 @@ namespace mRemoteNG.Tree
                 dropTarget.Parent.SetChildBelow(dropSource, dropTarget);
         }
 
-        public void HandleEvent_ModelCanDrop(object sender, ModelDropEventArgs e)
+        public void HandleEvent_ModelCanDrop(object? sender, ModelDropEventArgs e)
         {
             _enableFeedback = true;
             _currentFeedbackColor = DropDeniedFeedbackColor;
             _infoMessage = null;
             foreach (ConnectionInfo dropSource in e.SourceModels.Cast<ConnectionInfo>())
             {
-                ConnectionInfo dropTarget = e.TargetModel as ConnectionInfo;
+                ConnectionInfo? dropTarget = e.TargetModel as ConnectionInfo;
 
                 e.Effect = CanModelDrop(dropSource, dropTarget, e.DropTargetLocation);
                 e.InfoMessage = _infoMessage;
@@ -89,7 +89,7 @@ namespace mRemoteNG.Tree
         }
 
         public DragDropEffects CanModelDrop(ConnectionInfo dropSource,
-                                            ConnectionInfo dropTarget,
+                                            ConnectionInfo? dropTarget,
                                             DropTargetLocation dropTargetLocation)
         {
             DragDropEffects dragDropEffect = DragDropEffects.None;
@@ -113,7 +113,7 @@ namespace mRemoteNG.Tree
             return dragDropEffect;
         }
 
-        private DragDropEffects HandleCanDropOnItem(ConnectionInfo dropSource, ConnectionInfo dropTarget)
+        private DragDropEffects HandleCanDropOnItem(ConnectionInfo dropSource, ConnectionInfo? dropTarget)
         {
             DragDropEffects dragDropEffect = DragDropEffects.None;
             if (dropTarget is ContainerInfo && !(dropTarget is RootPuttySessionsNodeInfo))
@@ -130,7 +130,7 @@ namespace mRemoteNG.Tree
             return dragDropEffect;
         }
 
-        private DragDropEffects HandleCanDropBetweenItems(ConnectionInfo dropSource, ConnectionInfo dropTarget)
+        private DragDropEffects HandleCanDropBetweenItems(ConnectionInfo dropSource, ConnectionInfo? dropTarget)
         {
             DragDropEffects dragDropEffect = DragDropEffects.None;
             if (AncestorDraggingOntoChild(dropSource, dropTarget))
@@ -165,18 +165,18 @@ namespace mRemoteNG.Tree
             return node != null && !(node is RootNodeInfo) && !(node is PuttySessionInfo);
         }
 
-        private bool NodeDraggingOntoSelf(ConnectionInfo source, ConnectionInfo target)
+        private bool NodeDraggingOntoSelf(ConnectionInfo source, ConnectionInfo? target)
         {
             return source.Equals(target);
         }
 
-        private bool AncestorDraggingOntoChild(ConnectionInfo source, ConnectionInfo target)
+        private bool AncestorDraggingOntoChild(ConnectionInfo source, ConnectionInfo? target)
         {
-            return source is ContainerInfo sourceAsContainer &&
+            return target is not null && source is ContainerInfo sourceAsContainer &&
                    sourceAsContainer.GetRecursiveChildList().Contains(target);
         }
 
-        private bool DraggingOntoCurrentParent(ConnectionInfo source, ConnectionInfo target)
+        private bool DraggingOntoCurrentParent(ConnectionInfo source, ConnectionInfo? target)
         {
             return target is ContainerInfo targetAsContainer && targetAsContainer.Children.Contains(source);
         }

--- a/mRemoteNG/Tree/NodeSearcher.cs
+++ b/mRemoteNG/Tree/NodeSearcher.cs
@@ -11,8 +11,8 @@ namespace mRemoteNG.Tree
     {
         private readonly ConnectionTreeModel _connectionTreeModel = connectionTreeModel;
 
-        private List<ConnectionInfo> Matches { get; set; }
-        public ConnectionInfo CurrentMatch { get; private set; }
+        private List<ConnectionInfo> Matches { get; set; } = [];
+        public ConnectionInfo? CurrentMatch { get; private set; }
 
         public IEnumerable<ConnectionInfo> SearchByName(string searchText)
         {
@@ -33,9 +33,9 @@ namespace mRemoteNG.Tree
             return Matches;
         }
 
-        public ConnectionInfo NextMatch()
+        public ConnectionInfo? NextMatch()
         {
-            int currentMatchIndex = Matches.IndexOf(CurrentMatch);
+            int currentMatchIndex = CurrentMatchIndex();
             if (!CurrentMatchIsTheLastMatchInTheList())
                 CurrentMatch = Matches[currentMatchIndex + 1];
             return CurrentMatch;
@@ -43,13 +43,12 @@ namespace mRemoteNG.Tree
 
         private bool CurrentMatchIsTheLastMatchInTheList()
         {
-            int currentMatchIndex = Matches.IndexOf(CurrentMatch);
-            return currentMatchIndex >= Matches.Count - 1;
+            return CurrentMatchIndex() >= Matches.Count - 1;
         }
 
-        public ConnectionInfo PreviousMatch()
+        public ConnectionInfo? PreviousMatch()
         {
-            int currentMatchIndex = Matches.IndexOf(CurrentMatch);
+            int currentMatchIndex = CurrentMatchIndex();
             if (!CurrentMatchIsTheFirstMatchInTheList())
                 CurrentMatch = Matches[currentMatchIndex - 1];
             return CurrentMatch;
@@ -57,8 +56,13 @@ namespace mRemoteNG.Tree
 
         private bool CurrentMatchIsTheFirstMatchInTheList()
         {
-            int currentMatchIndex = Matches.IndexOf(CurrentMatch);
-            return currentMatchIndex <= 0;
+            return CurrentMatchIndex() <= 0;
+        }
+
+        // IndexOf of a null match is -1; guard so the non-null IndexOf overload is satisfied.
+        private int CurrentMatchIndex()
+        {
+            return CurrentMatch is null ? -1 : Matches.IndexOf(CurrentMatch);
         }
 
         private void ResetMatches()

--- a/mRemoteNG/Tree/SelectedConnectionDeletionConfirmer.cs
+++ b/mRemoteNG/Tree/SelectedConnectionDeletionConfirmer.cs
@@ -17,7 +17,7 @@ namespace mRemoteNG.Tree
             if (deletionTarget == null)
                 return false;
 
-            ContainerInfo deletionTargetAsContainer = deletionTarget as ContainerInfo;
+            ContainerInfo? deletionTargetAsContainer = deletionTarget as ContainerInfo;
             if (deletionTargetAsContainer != null)
                 return deletionTargetAsContainer.HasChildren()
                     ? UserConfirmsNonEmptyFolderDeletion(deletionTargetAsContainer)

--- a/mRemoteNG/UI/Window/ConnectionTreeWindow.cs
+++ b/mRemoteNG/UI/Window/ConnectionTreeWindow.cs
@@ -273,14 +273,14 @@ namespace mRemoteNG.UI.Window
                         break;
                     case Keys.Up:
                         {
-                            ConnectionInfo match = ConnectionTree.NodeSearcher.PreviousMatch();
+                            ConnectionInfo? match = ConnectionTree.NodeSearcher.PreviousMatch();
                             JumpToNode(match);
                             e.Handled = true;
                             break;
                         }
                     case Keys.Down:
                         {
-                            ConnectionInfo match = ConnectionTree.NodeSearcher.NextMatch();
+                            ConnectionInfo? match = ConnectionTree.NodeSearcher.NextMatch();
                             JumpToNode(match);
                             e.Handled = true;
                             break;
@@ -321,7 +321,7 @@ namespace mRemoteNG.UI.Window
             }
         }
 
-        public void JumpToNode(ConnectionInfo connectionInfo)
+        public void JumpToNode(ConnectionInfo? connectionInfo)
         {
             if (connectionInfo == null)
             {


### PR DESCRIPTION
## What

Second batch of the incremental cleanup of the ~3,090 pre-existing nullable-reference warnings (`CS86xx`) in `mRemoteNG`. This PR clears the **Tree**, **Container** and **Credential** namespaces (~47 warnings). Follows #3322 (Security).

## Changes

- **Event handlers** — `object sender` → `object? sender` on handlers bound to `EventHandler` / `PropertyChangedEventHandler` / `NotifyCollectionChangedEventHandler` (ContainerInfo, CredentialRepositoryList, CredentialServiceFacade, XmlCredentialRepository, AbstractConnectionRecord).
- **Events** made nullable (`CredentialsUpdated`, `RepositoriesUpdated`, `RepositoryConfigUpdated`).
- **`as` casts** typed nullable (ContainerInfo, ExpandNodeClickHandler, SelectedConnectionDeletionConfirmer).
- **`GetCredentialRecord`** return type made nullable across `ICredentialRepositoryList` / `CredentialRepositoryList` / `CredentialServiceFacade` — it genuinely returns `null` on not-found (per existing tests).
- **`NodeSearcher`** — `CurrentMatch` / `NextMatch` / `PreviousMatch` made nullable; index lookups null-guarded via a helper.
- **`CredentialInfo`** string properties default-initialized to `string.Empty`.
- **`XmlCredentialRepositoryFactory`** — missing XML attributes coalesced to `string.Empty` for non-nullable config properties.
- **Latent bug fixed** — `CompositeRepositoryUnlocker.Unlock` would throw `NullReferenceException` when no repository was selected; now a null-conditional no-op.

## Verification

- `MSBuild -p:Platform=x64` — builds clean, **0 errors**; Tree/Container/Credential are free of `CS86xx` warnings, no new warnings introduced.
- Full unit-test suite: **2003 passed / 83 failed** — identical to the `v1.78.2-dev` baseline (same 83 pre-existing failures). **Zero regressions.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)