### PR TITLE
Fix cross-thread crash when closing the splash screen on startup errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [1.78.2]
 ### Fixed
+- #3367: fixed cross-thread crash when closing the splash screen on a startup error
 - #2939: fixed SQL injection vulnerabilities via parameterized queries 
 - #2940: fixed for Possible command injection via Process.Start 
 - #2932: fixed HTTP/HTTPS protocol to support multiple concurrent connections

--- a/mRemoteNG/App/CompatibilityChecker.cs
+++ b/mRemoteNG/App/CompatibilityChecker.cs
@@ -39,7 +39,7 @@ namespace mRemoteNG.App
             messageCollector.AddMessage(MessageClass.ErrorMsg, errorText, true);
 
             //About to pop up a message, let's not block it...
-            FrmSplashScreenNew.GetInstance().Close();
+            ProgramRoot.CloseSplash();
 
             DialogResult ShouldIStayOrShouldIGo = CTaskDialog.MessageBox(Application.ProductName ?? string.Empty, Language.CompatibilityProblemDetected, errorText, "", "", Language.CheckboxDoNotShowThisMessageAgain, ETaskDialogButtons.OkCancel, ESysIcons.Warning, ESysIcons.Warning);
             if (CTaskDialog.VerificationChecked && ShouldIStayOrShouldIGo == DialogResult.OK)

--- a/mRemoteNG/App/ProgramRoot.cs
+++ b/mRemoteNG/App/ProgramRoot.cs
@@ -2,6 +2,7 @@
 
 using mRemoteNG.App.Update;
 using mRemoteNG.Config.Settings;
+using mRemoteNG.Messages;
 using mRemoteNG.UI.Forms;
 using mRemoteNG.Resources.Language;
 using System;
@@ -233,16 +234,36 @@ namespace mRemoteNG.App
 
         internal static void CloseSplash()
         {
-            if (_wpfSplash != null)
+            // Capture and clear the cached state up front so this is safe to call from
+            // multiple startup paths (e.g. the LoadConnections error handler) without
+            // acting on stale references or re-running against an already-closed splash.
+            FrmSplashScreenNew? splash = _wpfSplash;
+            System.Threading.Thread? splashThread = _wpfSplashThread;
+            _wpfSplash = null;
+            _wpfSplashThread = null;
+
+            if (splash != null)
             {
-                _wpfSplash.Dispatcher.Invoke(() => _wpfSplash.Close());
-                _wpfSplash = null;
+                try
+                {
+                    splash.Dispatcher.Invoke(() =>
+                    {
+                        splash.Close();
+                        // The splash runs its own STA message loop; ask it to exit so the
+                        // thread can actually be joined below instead of running forever.
+                        splash.Dispatcher.BeginInvokeShutdown(System.Windows.Threading.DispatcherPriority.Normal);
+                    });
+                }
+                catch (Exception ex)
+                {
+                    // Never let splash cleanup mask an in-progress startup error.
+                    Runtime.MessageCollector.AddExceptionMessage("Failed to close splash screen.", ex, MessageClass.WarningMsg);
+                }
             }
-            if (_wpfSplashThread != null)
-            {
-                _wpfSplashThread.Join();
-                _wpfSplashThread = null;
-            }
+
+            // The splash thread is a background thread, so a bounded join keeps startup
+            // from hanging if the dispatcher did not shut down; it dies on process exit anyway.
+            splashThread?.Join(TimeSpan.FromSeconds(2));
         }
 
         // Helper to show a dialog with "Download" and "Cancel" buttons.

--- a/mRemoteNG/App/ProgramRoot.cs
+++ b/mRemoteNG/App/ProgramRoot.cs
@@ -231,7 +231,7 @@ namespace mRemoteNG.App
             _wpfSplashThread.Start();
         }
 
-        private static void CloseSplash()
+        internal static void CloseSplash()
         {
             if (_wpfSplash != null)
             {

--- a/mRemoteNG/App/Runtime.cs
+++ b/mRemoteNG/App/Runtime.cs
@@ -115,7 +115,7 @@ namespace mRemoteNG.App
             }
             catch (Exception ex)
             {
-                FrmSplashScreenNew.GetInstance().Close();
+                ProgramRoot.CloseSplash();
 
                 if (Properties.OptionsDBsPage.Default.UseSQLServer)
                 {

--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -240,11 +240,7 @@ namespace mRemoteNG.UI.Forms
             Runtime.ConnectionsService.ConnectionsSaved += ConnectionsServiceOnConnectionsSaved;
             
             // Close splash screen before loading connections to ensure password dialog appears on top
-            FrmSplashScreenNew splash = FrmSplashScreenNew.GetInstance();
-            if (splash.Dispatcher.CheckAccess())
-                splash.Close();
-            else
-                splash.Dispatcher.Invoke(() => splash.Close());
+            ProgramRoot.CloseSplash();
 
             CredsAndConsSetup credsAndConsSetup = new();
             credsAndConsSetup.LoadCredsAndCons();


### PR DESCRIPTION
# Description
The splash screen (`FrmSplashScreenNew`) is a WPF window running on its own STA thread. Two startup error paths closed it directly from the main thread — `Runtime.LoadConnections` and `CompatibilityChecker.CheckFipsPolicy` — via `FrmSplashScreenNew.GetInstance().Close()`, which throws `InvalidOperationException: The calling thread cannot access this object because a different thread owns it.` and **masks the real error** (e.g. a missing connections file).

Both paths now reuse the existing `ProgramRoot.CloseSplash()` helper, which marshals the close through the splash dispatcher (`Dispatcher.Invoke`). `CloseSplash()` was changed from `private` to `internal` for reuse.

## Motivation and Context
Fixes #3367.
Previously, when connection loading failed at startup (e.g. the configured connections file did not exist), the app crashed with a cross-thread exception instead of showing the proper "connections file not found" recovery dialog.

## How Has This Been Tested?
- Release build passes.
- Reproduced the missing-connections-file path: the splash now closes cleanly and the expected recovery dialog is shown instead of the cross-thread crash.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing  **(84 pre-existing failures on base; this PR adds none)**
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [x] I have updated the documentation accordingly, if necessary. (N/A)