### PR TITLE
Dark native title bar matching the active theme (and dark-mode coverage for native controls)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - #2723: added read keyboardhook, gatewayaccesstoken and gatewaycredentialssource from RDP File
 - #2690: added தமிழ் (ta) Translation update
 - #2643: added registry Settings: enhancements and new settings implementation
+- #2642: added dark native title bar and matching dark mode for scrollbars, floating windows and dialogs
 - #2591: add Clickstudios Passwordstate API connector
 - #2212: added 1Password integration
 

--- a/mRemoteNG/App/NativeMethods.cs
+++ b/mRemoteNG/App/NativeMethods.cs
@@ -122,6 +122,23 @@ namespace mRemoteNG.App
         [DllImport("kernel32", SetLastError = true)]
         internal static extern bool CloseHandle(IntPtr handle);
 
+        [DllImport("dwmapi.dll")]
+        private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
+
+        // Enables/disables the dark (immersive) title bar. Attribute 20 on Win10 20H1+ (build 19041)
+        // and Win11; 19 on earlier builds. Returns true if the OS accepted the change.
+        internal static bool UseImmersiveDarkMode(IntPtr handle, bool enabled)
+        {
+            if (handle == IntPtr.Zero)
+                return false;
+
+            int useDark = enabled ? 1 : 0;
+            if (DwmSetWindowAttribute(handle, 20, ref useDark, sizeof(int)) == 0)
+                return true;
+
+            return DwmSetWindowAttribute(handle, 19, ref useDark, sizeof(int)) == 0;
+        }
+
         #endregion
 
         #region Structures

--- a/mRemoteNG/App/ProgramRoot.cs
+++ b/mRemoteNG/App/ProgramRoot.cs
@@ -2,6 +2,7 @@
 
 using mRemoteNG.App.Update;
 using mRemoteNG.Config.Settings;
+using mRemoteNG.Themes;
 using mRemoteNG.UI.Forms;
 using mRemoteNG.Resources.Language;
 using System;
@@ -124,6 +125,12 @@ namespace mRemoteNG.App
             CatchAllUnhandledExceptions();
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+
+            // Match the OS dark mode for common controls (scrollbars, context menus, ...)
+            // to the active theme. Applied once at startup; theme changes require a restart.
+            Application.SetColorMode(ThemeManager.getInstance().IsActiveThemeDark
+                ? SystemColorMode.Dark
+                : SystemColorMode.Classic);
 
             ShowSplashOnStaThread();
 

--- a/mRemoteNG/App/ProgramRoot.cs
+++ b/mRemoteNG/App/ProgramRoot.cs
@@ -128,7 +128,10 @@ namespace mRemoteNG.App
 
             // Match the OS dark mode for common controls (scrollbars, context menus, ...)
             // to the active theme. Applied once at startup; theme changes require a restart.
-            Application.SetColorMode(ThemeManager.getInstance().IsActiveThemeDark
+            // Read the persisted flag instead of constructing ThemeManager here, so we avoid
+            // any theme folder/file I/O before the splash is shown. The flag is kept in sync
+            // by ThemeManager whenever the active theme or theming state changes.
+            Application.SetColorMode(Properties.OptionsThemePage.Default.IsActiveThemeDark
                 ? SystemColorMode.Dark
                 : SystemColorMode.Classic);
 

--- a/mRemoteNG/Properties/OptionsThemePage.Designer.cs
+++ b/mRemoteNG/Properties/OptionsThemePage.Designer.cs
@@ -58,5 +58,17 @@ namespace mRemoteNG.Properties {
                 this["cbThemePageInOptionMenu"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool IsActiveThemeDark {
+            get {
+                return ((bool)(this["IsActiveThemeDark"]));
+            }
+            set {
+                this["IsActiveThemeDark"] = value;
+            }
+        }
     }
 }

--- a/mRemoteNG/Properties/OptionsThemePage.settings
+++ b/mRemoteNG/Properties/OptionsThemePage.settings
@@ -11,5 +11,8 @@
     <Setting Name="cbThemePageInOptionMenu" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="IsActiveThemeDark" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/mRemoteNG/Themes/ThemeManager.cs
+++ b/mRemoteNG/Themes/ThemeManager.cs
@@ -60,9 +60,14 @@ namespace mRemoteNG.Themes
 
         // Persist the dark/light state of the active theme so startup can read it
         // without loading any theme from disk (see ProgramRoot.StartApplication).
+        // Uses the raw _activeTheme, not the ThemingActive-gated ActiveTheme: during
+        // construction ThemingActive is still false, which would otherwise persist "light".
         private void PersistActiveThemeDarkFlag()
         {
-            Properties.OptionsThemePage.Default.IsActiveThemeDark = IsActiveThemeDark;
+            bool dark = IsThemeDark(_activeTheme);
+            if (Properties.OptionsThemePage.Default.IsActiveThemeDark == dark) return;
+            Properties.OptionsThemePage.Default.IsActiveThemeDark = dark;
+            Properties.OptionsThemePage.Default.Save();
         }
 
         #endregion
@@ -337,19 +342,19 @@ namespace mRemoteNG.Themes
         // Below this HSL lightness (Color.GetBrightness) the "Dialog_Background" is treated as dark.
         private const float DarkThemeBrightnessThreshold = 0.5f;
 
+        // True when the given theme has a dark background (HSL lightness of "Dialog_Background").
+        public static bool IsThemeDark(ThemeInfo? theme)
+        {
+            Color background = theme?.ExtendedPalette?.getColor("Dialog_Background") ?? SystemColors.Control;
+            return background.GetBrightness() < DarkThemeBrightnessThreshold;
+        }
+
         /// <summary>
         /// True when the active theme has a dark background (derived from the "Dialog_Background"
         /// brightness (HSL lightness via <see cref="Color.GetBrightness"/>), since there is no
         /// explicit dark flag).
         /// </summary>
-        public bool IsActiveThemeDark
-        {
-            get
-            {
-                Color background = ActiveTheme.ExtendedPalette?.getColor("Dialog_Background") ?? SystemColors.Control;
-                return background.GetBrightness() < DarkThemeBrightnessThreshold;
-            }
-        }
+        public bool IsActiveThemeDark => IsThemeDark(ActiveTheme);
 
         /// <summary>
         /// Applies a dark or light native title bar to the given form based on the active theme's

--- a/mRemoteNG/Themes/ThemeManager.cs
+++ b/mRemoteNG/Themes/ThemeManager.cs
@@ -334,22 +334,26 @@ namespace mRemoteNG.Themes
 
         public bool ActiveAndExtended => ThemingActive && ActiveTheme.IsExtended;
 
+        // Below this HSL lightness (Color.GetBrightness) the "Dialog_Background" is treated as dark.
+        private const float DarkThemeBrightnessThreshold = 0.5f;
+
         /// <summary>
-        /// True when the active theme has a dark background (derived from the
-        /// "Dialog_Background" luminance, since there is no explicit dark flag).
+        /// True when the active theme has a dark background (derived from the "Dialog_Background"
+        /// brightness (HSL lightness via <see cref="Color.GetBrightness"/>), since there is no
+        /// explicit dark flag).
         /// </summary>
         public bool IsActiveThemeDark
         {
             get
             {
                 Color background = ActiveTheme.ExtendedPalette?.getColor("Dialog_Background") ?? SystemColors.Control;
-                return background.GetBrightness() < 0.5;
+                return background.GetBrightness() < DarkThemeBrightnessThreshold;
             }
         }
 
         /// <summary>
         /// Applies a dark or light native title bar to the given form based on the active theme's
-        /// background luminance. Safe to call before the handle exists (no-op).
+        /// background brightness. Safe to call before the handle exists (no-op).
         /// </summary>
         public void ApplyThemeToTitleBar(Form form)
         {

--- a/mRemoteNG/Themes/ThemeManager.cs
+++ b/mRemoteNG/Themes/ThemeManager.cs
@@ -58,6 +58,13 @@ namespace mRemoteNG.Themes
             }
         }
 
+        // Persist the dark/light state of the active theme so startup can read it
+        // without loading any theme from disk (see ProgramRoot.StartApplication).
+        private void PersistActiveThemeDarkFlag()
+        {
+            Properties.OptionsThemePage.Default.IsActiveThemeDark = IsActiveThemeDark;
+        }
+
         #endregion
 
         #region Public Methods
@@ -285,6 +292,7 @@ namespace mRemoteNG.Themes
                 if (themes.Count == 0) return;
                 _themeActive = value;
                 Properties.OptionsThemePage.Default.ThemingActive = value;
+                PersistActiveThemeDarkFlag();
                 NotifyThemeChanged(this, new PropertyChangedEventArgs(""));
             }
         }
@@ -308,6 +316,7 @@ namespace mRemoteNG.Themes
 
                     Properties.OptionsThemePage.Default.ThemeName = DefaultTheme.Name;
                     _activeTheme = DefaultTheme;
+                    PersistActiveThemeDarkFlag();
 
                     if (changed)
                         NotifyThemeChanged(this, new PropertyChangedEventArgs("theme"));
@@ -318,6 +327,7 @@ namespace mRemoteNG.Themes
 
                 _activeTheme = value;
                 Properties.OptionsThemePage.Default.ThemeName = value.Name;
+                PersistActiveThemeDarkFlag();
                 NotifyThemeChanged(this, new PropertyChangedEventArgs("theme"));
             }
         }

--- a/mRemoteNG/Themes/ThemeManager.cs
+++ b/mRemoteNG/Themes/ThemeManager.cs
@@ -325,6 +325,19 @@ namespace mRemoteNG.Themes
         public bool ActiveAndExtended => ThemingActive && ActiveTheme.IsExtended;
 
         /// <summary>
+        /// True when the active theme has a dark background (derived from the
+        /// "Dialog_Background" luminance, since there is no explicit dark flag).
+        /// </summary>
+        public bool IsActiveThemeDark
+        {
+            get
+            {
+                Color background = ActiveTheme.ExtendedPalette?.getColor("Dialog_Background") ?? SystemColors.Control;
+                return background.GetBrightness() < 0.5;
+            }
+        }
+
+        /// <summary>
         /// Applies a dark or light native title bar to the given form based on the active theme's
         /// background luminance. Safe to call before the handle exists (no-op).
         /// </summary>
@@ -333,8 +346,7 @@ namespace mRemoteNG.Themes
             if (form == null || !form.IsHandleCreated)
                 return;
 
-            Color background = ActiveTheme.ExtendedPalette?.getColor("Dialog_Background") ?? SystemColors.Control;
-            NativeMethods.UseImmersiveDarkMode(form.Handle, background.GetBrightness() < 0.5);
+            NativeMethods.UseImmersiveDarkMode(form.Handle, IsActiveThemeDark);
         }
 
         public int ThemesCount => themes.Count;

--- a/mRemoteNG/Themes/ThemeManager.cs
+++ b/mRemoteNG/Themes/ThemeManager.cs
@@ -10,6 +10,8 @@ using mRemoteNG.Messages;
 using mRemoteNG.Properties;
 using WeifenLuo.WinFormsUI.Docking;
 using System.Runtime.Versioning;
+using System.Drawing;
+using System.Windows.Forms;
 
 namespace mRemoteNG.Themes
 {
@@ -321,6 +323,19 @@ namespace mRemoteNG.Themes
         }
 
         public bool ActiveAndExtended => ThemingActive && ActiveTheme.IsExtended;
+
+        /// <summary>
+        /// Applies a dark or light native title bar to the given form based on the active theme's
+        /// background luminance. Safe to call before the handle exists (no-op).
+        /// </summary>
+        public void ApplyThemeToTitleBar(Form form)
+        {
+            if (form == null || !form.IsHandleCreated)
+                return;
+
+            Color background = ActiveTheme.ExtendedPalette?.getColor("Dialog_Background") ?? SystemColors.Control;
+            NativeMethods.UseImmersiveDarkMode(form.Handle, background.GetBrightness() < 0.5);
+        }
 
         public int ThemesCount => themes.Count;
 

--- a/mRemoteNG/UI/Forms/FrmAbout.cs
+++ b/mRemoteNG/UI/Forms/FrmAbout.cs
@@ -44,8 +44,16 @@ namespace mRemoteNG.UI.Forms
         [Conditional("PORTABLE")]
         private void AddPortableString() => lblTitle.Text += $@" {Language.PortableEdition}";
 
+        // Apply the dark/light title bar before the window is shown to avoid a white flash.
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            ThemeManager.getInstance().ApplyThemeToTitleBar(this);
+        }
+
         private new void ApplyTheme()
         {
+            ThemeManager.getInstance().ApplyThemeToTitleBar(this);
             if (!ThemeManager.getInstance().ThemingActive) return;
             if (!ThemeManager.getInstance().ActiveAndExtended) return;
             pnlBottom.BackColor = ThemeManager.getInstance().ActiveTheme.ExtendedPalette.getColor("Dialog_Background");

--- a/mRemoteNG/UI/Forms/FrmExport.cs
+++ b/mRemoteNG/UI/Forms/FrmExport.cs
@@ -221,9 +221,17 @@ namespace mRemoteNG.UI.Forms
 
         #endregion
 
+        // Apply the dark/light title bar before the window is shown to avoid a white flash.
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            ThemeManager.getInstance().ApplyThemeToTitleBar(this);
+        }
+
         private void ApplyTheme()
         {
             _themeManager = ThemeManager.getInstance();
+            _themeManager.ApplyThemeToTitleBar(this);
             if (!_themeManager.ActiveAndExtended) return;
             BackColor = _themeManager.ActiveTheme.ExtendedPalette.getColor("Dialog_Background");
             ForeColor = _themeManager.ActiveTheme.ExtendedPalette.getColor("Dialog_Foreground");

--- a/mRemoteNG/UI/Forms/FrmInputBox.cs
+++ b/mRemoteNG/UI/Forms/FrmInputBox.cs
@@ -27,9 +27,17 @@ namespace mRemoteNG.UI.Forms
             buttonCancel.Text = Language._Cancel;
         }
 
+        // Apply the dark/light title bar before the window is shown to avoid a white flash.
+        protected override void OnHandleCreated(System.EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            ThemeManager.getInstance().ApplyThemeToTitleBar(this);
+        }
+
         private void ApplyTheme()
         {
             ThemeManager _themeManager = ThemeManager.getInstance();
+            _themeManager.ApplyThemeToTitleBar(this);
             if (!_themeManager.ActiveAndExtended) return;
             BackColor = _themeManager.ActiveTheme.ExtendedPalette.getColor("Dialog_Background");
             ForeColor = _themeManager.ActiveTheme.ExtendedPalette.getColor("Dialog_Foreground");

--- a/mRemoteNG/UI/Forms/FrmPassword.cs
+++ b/mRemoteNG/UI/Forms/FrmPassword.cs
@@ -113,8 +113,16 @@ namespace mRemoteNG.UI.Forms
             btnOK.Text = Language._Ok;
         }
 
+        // Apply the dark/light title bar before the window is shown to avoid a white flash.
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            ThemeManager.getInstance().ApplyThemeToTitleBar(this);
+        }
+
         private void ApplyTheme()
         {
+            ThemeManager.getInstance().ApplyThemeToTitleBar(this);
             if (!ThemeManager.getInstance().ActiveAndExtended)
                 return;
 

--- a/mRemoteNG/UI/Forms/OptionsPages/ThemePage.cs
+++ b/mRemoteNG/UI/Forms/OptionsPages/ThemePage.cs
@@ -99,6 +99,10 @@ namespace mRemoteNG.UI.Forms.OptionsPages
                 if (!Properties.OptionsThemePage.Default.ThemeName.Equals(((ThemeInfo)cboTheme.SelectedItem).Name))
                 {
                     Properties.OptionsThemePage.Default.ThemeName = ((ThemeInfo)cboTheme.SelectedItem).Name;
+                    // Keep the persisted dark flag in sync with the chosen theme so the next
+                    // startup picks the right color mode without loading themes (the theme is
+                    // only actually applied on restart).
+                    Properties.OptionsThemePage.Default.IsActiveThemeDark = ThemeManager.IsThemeDark((ThemeInfo)cboTheme.SelectedItem);
                     CTaskDialog.MessageBox("Theme Changed", "Restart Required.", "Please restart mRemoteNG to apply the selected theme.", ETaskDialogButtons.Ok, ESysIcons.Information);
                 }
             }

--- a/mRemoteNG/UI/Forms/frmChoosePanel.cs
+++ b/mRemoteNG/UI/Forms/frmChoosePanel.cs
@@ -40,8 +40,16 @@ namespace mRemoteNG.UI.Forms
             Text = Language.TitleSelectPanel;
         }
 
+        // Apply the dark/light title bar before the window is shown to avoid a white flash.
+        protected override void OnHandleCreated(System.EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            ThemeManager.getInstance().ApplyThemeToTitleBar(this);
+        }
+
         private void ApplyTheme()
         {
+            ThemeManager.getInstance().ApplyThemeToTitleBar(this);
             if (!ThemeManager.getInstance().ActiveAndExtended) return;
             BackColor = ThemeManager.getInstance().ActiveTheme.ExtendedPalette.getColor("Dialog_Background");
             ForeColor = ThemeManager.getInstance().ActiveTheme.ExtendedPalette.getColor("Dialog_Foreground");

--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -360,9 +360,18 @@ namespace mRemoteNG.UI.Forms
             toolsMenu.CredentialProviderCatalog = Runtime.CredentialProviderCatalog;
         }
 
+        // Apply the dark/light title bar before the window is shown to avoid a white flash.
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            _themeManager.ApplyThemeToTitleBar(this);
+        }
+
         //Theming support
         private void ApplyTheme()
         {
+            _themeManager.ApplyThemeToTitleBar(this);
+
             if (!_themeManager.ThemingActive)
             {
                 pnlDock.Theme = _themeManager.DefaultTheme.Theme;

--- a/mRemoteNG/UI/Forms/frmOptions.Designer.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.Designer.cs
@@ -65,6 +65,7 @@ namespace mRemoteNG.UI.Forms
             // btnApply
             // 
             this.btnApply._mice = mRemoteNG.UI.Controls.MrngButton.MouseState.OUT;
+            this.btnApply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnApply.Location = new System.Drawing.Point(677, 5);
             this.btnApply.Name = "btnApply";
             this.btnApply.Size = new System.Drawing.Size(75, 23);
@@ -76,6 +77,7 @@ namespace mRemoteNG.UI.Forms
             // btnCancel
             // 
             this.btnCancel._mice = mRemoteNG.UI.Controls.MrngButton.MouseState.OUT;
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.Location = new System.Drawing.Point(596, 5);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
@@ -87,6 +89,7 @@ namespace mRemoteNG.UI.Forms
             // btnOK
             // 
             this.btnOK._mice = mRemoteNG.UI.Controls.MrngButton.MouseState.OUT;
+            this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnOK.Location = new System.Drawing.Point(515, 5);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(75, 23);

--- a/mRemoteNG/UI/Forms/frmOptions.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.cs
@@ -75,8 +75,6 @@ namespace mRemoteNG.UI.Forms
         {
             Logger.Instance.Log?.Debug($"[FrmOptions_Load] START - IsInitialized: {_isInitialized}, Visible: {this.Visible}, Handle: {this.Handle}");
 
-            ThemeManager.getInstance().ApplyThemeToTitleBar(this);
-
             // Only initialize once to prevent multiple event subscriptions and page reloading
             if (_isInitialized)
             {
@@ -93,8 +91,7 @@ namespace mRemoteNG.UI.Forms
             btnOK.Text = Language._Ok;
             btnCancel.Text = Language._Cancel;
             btnApply.Text = Language.Apply;
-            //ApplyTheme();
-            //ThemeManager.getInstance().ThemeChanged += ApplyTheme;
+            ApplyTheme();
             lstOptionPages.SelectedIndexChanged += LstOptionPages_SelectedIndexChanged;
             lstOptionPages.SelectedIndex = 0;
             Logger.Instance.Log?.Debug($"[FrmOptions_Load] Selected index set to 0");
@@ -128,6 +125,8 @@ namespace mRemoteNG.UI.Forms
             if (!ThemeManager.getInstance().ActiveAndExtended) return;
             BackColor = ThemeManager.getInstance().ActiveTheme.ExtendedPalette.getColor("Dialog_Background");
             ForeColor = ThemeManager.getInstance().ActiveTheme.ExtendedPalette.getColor("Dialog_Foreground");
+            pnlBottom.BackColor = ThemeManager.getInstance().ActiveTheme.ExtendedPalette.getColor("Dialog_Background");
+            pnlBottom.ForeColor = ThemeManager.getInstance().ActiveTheme.ExtendedPalette.getColor("Dialog_Foreground");
         }
 
 #if false

--- a/mRemoteNG/UI/Forms/frmOptions.cs
+++ b/mRemoteNG/UI/Forms/frmOptions.cs
@@ -64,9 +64,18 @@ namespace mRemoteNG.UI.Forms
             InitOptionsPagesToListView();
         }
 
+        // Apply the dark/light title bar before the window is shown to avoid a white flash.
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            ThemeManager.getInstance().ApplyThemeToTitleBar(this);
+        }
+
         private void FrmOptions_Load(object sender, EventArgs e)
         {
             Logger.Instance.Log?.Debug($"[FrmOptions_Load] START - IsInitialized: {_isInitialized}, Visible: {this.Visible}, Handle: {this.Handle}");
+
+            ThemeManager.getInstance().ApplyThemeToTitleBar(this);
 
             // Only initialize once to prevent multiple event subscriptions and page reloading
             if (_isInitialized)

--- a/mRemoteNG/UI/Tabs/FloatWindowNG.cs
+++ b/mRemoteNG/UI/Tabs/FloatWindowNG.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Security.Permissions;
 using System.Windows.Forms;
 using WeifenLuo.WinFormsUI.Docking;
+using mRemoteNG.Themes;
 
 namespace mRemoteNG.UI.Tabs
 {
@@ -31,6 +32,13 @@ namespace mRemoteNG.UI.Tabs
 
             // Allow the Windows default behavior of maximizing/restoring the window
             DoubleClickTitleBarToDock = true;
+        }
+
+        // Apply the dark/light title bar before the window is shown to avoid a white flash.
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            ThemeManager.getInstance().ApplyThemeToTitleBar(this);
         }
 
         [DllImport("User32.dll", CharSet = CharSet.Auto)]

--- a/mRemoteNG/UI/TaskDialog/frmTaskDialog.cs
+++ b/mRemoteNG/UI/TaskDialog/frmTaskDialog.cs
@@ -405,6 +405,13 @@ namespace mRemoteNG.UI.TaskDialog
             ApplyTheme();
         }
 
+        // Apply the dark/light title bar before the window is shown to avoid a white flash.
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            ThemeManager.getInstance().ApplyThemeToTitleBar(this);
+        }
+
         private void ApplyTheme()
         {
             if (!ThemeManager.getInstance().ActiveAndExtended) return;


### PR DESCRIPTION
## Description
Makes the OS-drawn window chrome follow the active theme.

- **Dark native title bar** via `DwmSetWindowAttribute` (`DWMWA_USE_IMMERSIVE_DARK_MODE`). A single helper, `ThemeManager.ApplyThemeToTitleBar(Form)`, derives dark/light from the active theme's `Dialog_Background` luminance (there is no explicit dark flag). Applied in `OnHandleCreated` (before the window is shown, so there is no white flash) on: the main window, the top-level dialogs (About, Options, Password, Input box, Export, Choose panel), the DockPanelSuite floating windows (`FloatWindowNG` — a single hook covers all of them via the factory), and the generic task dialog.
- **App-wide dark mode for native controls** (scrollbars, context menus) via `Application.SetColorMode` at startup, matched to the active theme through the new `ThemeManager.IsActiveThemeDark`. Applied once at startup — consistent with the existing "theme change requires restart" behavior.
- **Options window**: themed the previously-light button panel and anchored the OK/Cancel/Apply buttons to the right so they stay aligned on resize.

## Motivation and Context
Fixes #2642.
With a dark theme active, the Windows title bar and native controls stayed light because the app never called the DWM dark-mode API nor `Application.SetColorMode`.

> Note for maintainers: `Application.SetColorMode` is **app-wide** and goes slightly beyond the title-bar scope of #2642. It was added to also darken scrollbars/context menus and was checked in both light and dark themes. Happy to drop or gate it differently if you prefer to keep this PR strictly to the title bar.

## How Has This Been Tested?
- Release build passes.
- Manual runtime check in light and dark themes: title bar, scrollbars and the Options button panel follow the theme; floating windows and task dialogs get a dark title bar with no white flash; the Options buttons stay right-aligned on resize; light theme is unchanged.

## Screenshots (if appropriate):
<img width="1133" height="683" alt="2026-07-02 19_33_01-mRemoteNG - SecureCRTFileDeserializerTests cs - Microsoft Visual Studio" src="https://github.com/user-attachments/assets/a0862012-ba5d-43f6-9b41-b9fe0f999a55" />


## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Changed feature (non-breaking change which changes functionality)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing  **(84 pre-existing failures on base; this PR adds none)**
- [x] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [x] I have updated the documentation accordingly, if necessary. (N/A)