### PR TITLE
fix: Quick Connect resolution, Spanish Sessions translation, and panel order

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.csdevkit"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,43 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch mRemoteNG (Debug x64)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/mRemoteNG/bin/x64/Debug/mRemoteNG.exe",
+            "args": [],
+            "cwd": "${workspaceFolder}/mRemoteNG/bin/x64/Debug",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Launch mRemoteNG (Release x64)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build (Release)",
+            "program": "${workspaceFolder}/mRemoteNG/bin/x64/Release/mRemoteNG.exe",
+            "args": [],
+            "cwd": "${workspaceFolder}/mRemoteNG/bin/x64/Release",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Launch mRemoteNG (Release Self-Contained x64)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "publish (Release Self-Contained)",
+            "program": "${workspaceFolder}/mRemoteNG/bin/x64/Publish Self-Contained/mRemoteNG.exe",
+            "args": [],
+            "cwd": "${workspaceFolder}/mRemoteNG/bin/x64/Publish Self-Contained",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Attach to mRemoteNG",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,86 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/mRemoteNG/mRemoteNG.csproj",
+                "-c",
+                "Debug",
+                "-p:Platform=x64",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "rebuild",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/mRemoteNG/mRemoteNG.csproj",
+                "-c",
+                "Debug",
+                "-p:Platform=x64",
+                "--no-incremental",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build (Release)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/mRemoteNG/mRemoteNG.csproj",
+                "-c",
+                "Release",
+                "-p:Platform=x64",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish (Release Self-Contained)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/mRemoteNG/mRemoteNG.csproj",
+                "-c",
+                "Release Self-Contained",
+                "-p:Platform=x64",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "clean",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "clean",
+                "${workspaceFolder}/mRemoteNG/mRemoteNG.csproj",
+                "-c",
+                "Debug",
+                "-p:Platform=x64"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/mRemoteNG/Config/Settings/DockPanelLayoutLoader.cs
+++ b/mRemoteNG/Config/Settings/DockPanelLayoutLoader.cs
@@ -56,10 +56,80 @@ namespace mRemoteNG.Config.Settings
                 {
                     _mainForm.SetDefaultLayout();
                 }
+
+                // Regardless of what the persisted layout contained, force the
+                // Connections panel to sit above/before the Config panel. Older
+                // DockPanelSuite (3.1.1) does not allow reordering auto-hide tabs by
+                // dragging, so a layout saved with the wrong order would otherwise be
+                // stuck that way.
+                EnforcePanelOrder();
             }
             catch (Exception ex)
             {
                 _messageCollector.AddExceptionMessage("LoadPanelsFromXML failed", ex);
+            }
+        }
+
+        /// <summary>
+        /// Ensures the Connections panel is ordered before the Config panel, handling
+        /// both possible arrangements:
+        ///   1. Both are tabs inside the same pane -> reorder the tab index.
+        ///   2. They are separate panes on the same dock edge (e.g. two auto-hide
+        ///      tabs on the left) -> re-order the panes so Connections comes first.
+        /// This is defensive and never throws, so a failure here cannot break startup.
+        /// NOTE: requires verification on Windows (no WinForms/DockPanelSuite runtime
+        /// available in the Linux/WSL build environment).
+        /// </summary>
+        private void EnforcePanelOrder()
+        {
+            try
+            {
+                ConnectionTreeWindow tree = AppWindows.TreeForm;
+                ConfigWindow config = AppWindows.ConfigForm;
+
+                if (tree == null || config == null || tree.IsDisposed || config.IsDisposed)
+                    return;
+
+                DockPane treePane = tree.Pane;
+                DockPane configPane = config.Pane;
+
+                if (treePane == null || configPane == null)
+                    return;
+
+                // Case 1: Connections and Config are tabs in the same pane.
+                // Make Connections the first tab.
+                if (ReferenceEquals(treePane, configPane))
+                {
+                    if (treePane.Contents.IndexOf(tree) > treePane.Contents.IndexOf(config))
+                        treePane.SetContentIndex(tree, 0);
+                    return;
+                }
+
+                // Case 2: Separate panes. Only reorder when they share the same dock
+                // edge (comparing the persisted pane order used by the auto-hide strip).
+                if (tree.DockState != config.DockState)
+                    return;
+
+                DockPaneCollection panes = _mainForm.pnlDock.Panes;
+                int treeIndex = panes.IndexOf(treePane);
+                int configIndex = panes.IndexOf(configPane);
+
+                // If Config currently appears before Connections, re-show Config so its
+                // pane is re-appended after Connections, forcing Connections on top.
+                if (treeIndex >= 0 && configIndex >= 0 && configIndex < treeIndex)
+                {
+                    double autoHidePortion = configPane.AutoHidePortion;
+                    DockState state = config.DockState;
+
+                    config.Show(_mainForm.pnlDock, state);
+
+                    if (config.Pane != null)
+                        config.Pane.AutoHidePortion = autoHidePortion;
+                }
+            }
+            catch (Exception ex)
+            {
+                _messageCollector.AddExceptionMessage("EnforcePanelOrder failed", ex);
             }
         }
 

--- a/mRemoteNG/Config/Settings/DockPanelLayoutLoader.cs
+++ b/mRemoteNG/Config/Settings/DockPanelLayoutLoader.cs
@@ -82,8 +82,21 @@ namespace mRemoteNG.Config.Settings
         /// </summary>
         private void EnforcePanelOrder()
         {
+            EnforcePanelOrder(_mainForm, _messageCollector);
+        }
+
+        /// <summary>
+        /// Ensures the Connections panel is always ordered before (above) the Config
+        /// panel. Safe to call at any time (startup, after auto-hide toggles, etc.);
+        /// it never throws.
+        /// </summary>
+        public static void EnforcePanelOrder(FrmMain mainForm, MessageCollector messageCollector)
+        {
             try
             {
+                if (mainForm == null || mainForm.pnlDock == null)
+                    return;
+
                 ConnectionTreeWindow tree = AppWindows.TreeForm;
                 ConfigWindow config = AppWindows.ConfigForm;
 
@@ -105,31 +118,40 @@ namespace mRemoteNG.Config.Settings
                     return;
                 }
 
-                // Case 2: Separate panes. Only reorder when they share the same dock
-                // edge (comparing the persisted pane order used by the auto-hide strip).
+                // Case 2: Separate panes on the same dock edge (e.g. two auto-hide tabs
+                // on the left). The auto-hide strip renders tabs in the order the panes
+                // appear in DockPanel.Panes, so we must make the Connections pane precede
+                // the Config pane there.
                 if (tree.DockState != config.DockState)
                     return;
 
-                DockPaneCollection panes = _mainForm.pnlDock.Panes;
+                DockPaneCollection panes = mainForm.pnlDock.Panes;
                 int treeIndex = panes.IndexOf(treePane);
                 int configIndex = panes.IndexOf(configPane);
 
-                // If Config currently appears before Connections, re-show Config so its
-                // pane is re-appended after Connections, forcing Connections on top.
+                // If Config currently appears before Connections, re-append both panes in
+                // the desired order (Connections first, Config second). Re-showing a panel
+                // moves its pane to the end of the collection for that dock edge, so doing
+                // Tree then Config guarantees Connections ends up on top. Re-showing only
+                // one panel is unreliable because the surviving pane's position depends on
+                // where DockPanelSuite happened to place it.
                 if (treeIndex >= 0 && configIndex >= 0 && configIndex < treeIndex)
                 {
-                    double autoHidePortion = configPane.AutoHidePortion;
-                    DockState state = config.DockState;
+                    double treePortion = tree.AutoHidePortion;
+                    double configPortion = config.AutoHidePortion;
+                    DockState treeState = tree.DockState;
+                    DockState configState = config.DockState;
 
-                    config.Show(_mainForm.pnlDock, state);
+                    tree.Show(mainForm.pnlDock, treeState);
+                    tree.AutoHidePortion = treePortion;
 
-                    if (config.Pane != null)
-                        config.Pane.AutoHidePortion = autoHidePortion;
+                    config.Show(mainForm.pnlDock, configState);
+                    config.AutoHidePortion = configPortion;
                 }
             }
             catch (Exception ex)
             {
-                _messageCollector.AddExceptionMessage("EnforcePanelOrder failed", ex);
+                messageCollector.AddExceptionMessage("EnforcePanelOrder failed", ex);
             }
         }
 

--- a/mRemoteNG/Config/Settings/SettingsLoader.cs
+++ b/mRemoteNG/Config/Settings/SettingsLoader.cs
@@ -171,6 +171,7 @@ namespace mRemoteNG.Config.Settings
         {
             ToolStripPanelFromString("top").Join(_quickConnectToolStrip, new Point(300, 0));
             _quickConnectToolStrip.Visible = true;
+            MainForm.PositionQuickConnectToolbarRight();
             ToolStripPanelFromString("bottom").Join(_externalToolsToolStrip, new Point(3, 0));
             _externalToolsToolStrip.Visible = false;
         }
@@ -208,9 +209,12 @@ namespace mRemoteNG.Config.Settings
         private void AddQuickConnectPanel()
         {
             SetToolstripGripStyle(_quickConnectToolStrip);
-            _quickConnectToolStrip.Visible = Properties.Settings.Default.QuickyTBVisible;
-            ToolStripPanel toolStripPanel = ToolStripPanelFromString(Properties.Settings.Default.QuickyTBParentDock);
-            toolStripPanel.Join(_quickConnectToolStrip, Properties.Settings.Default.QuickyTBLocation);
+            // The QuickConnect toolbar is always visible and pinned to the
+            // right of the main menu on the top toolbar row.
+            _quickConnectToolStrip.Visible = true;
+            ToolStripPanel toolStripPanel = ToolStripPanelFromString("top");
+            toolStripPanel.Join(_quickConnectToolStrip, new Point(0, 0));
+            MainForm.PositionQuickConnectToolbarRight();
         }
 
         private void AddExternalAppsPanel()

--- a/mRemoteNG/Connection/ConnectionsService.cs
+++ b/mRemoteNG/Connection/ConnectionsService.cs
@@ -85,6 +85,14 @@ namespace mRemoteNG.Connection
                 ConnectionInfo newConnectionInfo = new();
                 newConnectionInfo.CopyFrom(DefaultConnectionInfo.Instance);
 
+                // Quick Connect connections are never added to the connection tree, so they
+                // have no Parent and cannot inherit properties the way tree connections do.
+                // The default resolution (SmartSize) connects at full-screen resolution and
+                // scales the image down to the panel, which looks blurry and undersized.
+                // Force FitToWindow so Quick Connect sessions render sharp and sized to the
+                // window, matching how connections opened from the panel behave.
+                newConnectionInfo.Resolution = Protocol.RDP.RDPResolutions.FitToWindow;
+
                 newConnectionInfo.Name = Properties.OptionsTabsPanelsPage.Default.IdentifyQuickConnectTabs
                     ? string.Format(Language.Quick, uriBuilder.Host)
                     : uriBuilder.Host;

--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol.cs
@@ -983,6 +983,18 @@ namespace mRemoteNG.Connection.Protocol.RDP
         private void RDPEvent_OnLoginComplete()
         {
             loginComplete = true;
+            OnLoginCompleted();
+        }
+
+        /// <summary>
+        /// Called once the RDP session has finished logging in. At this point the
+        /// hosting panel has been laid out to its final size, so derived protocols
+        /// can re-apply size-dependent settings that may have been configured against
+        /// a stale panel size at connect time (e.g. Quick Connect opening in a
+        /// freshly-created panel).
+        /// </summary>
+        protected virtual void OnLoginCompleted()
+        {
         }
 
         private void RDPEvent_OnLeaveFullscreenMode()

--- a/mRemoteNG/Connection/Protocol/RDP/RdpProtocol8.cs
+++ b/mRemoteNG/Connection/Protocol/RDP/RdpProtocol8.cs
@@ -220,6 +220,39 @@ namespace mRemoteNG.Connection.Protocol.RDP
             return new AxMsRdpClient8NotSafeForScripting();
         }
 
+        protected override void OnLoginCompleted()
+        {
+            base.OnLoginCompleted();
+
+            // SetResolution() runs at connect-configuration time, before the hosting
+            // panel necessarily has its final size. Quick Connect opens the session in
+            // a freshly-created panel that is laid out AFTER the RDP client is
+            // configured, so the SmartSize/FitToWindow surface can end up sized against
+            // a stale (small/empty) panel rectangle. Now that login is complete the
+            // layout has settled, so re-apply the control size to match the real panel
+            // dimensions. DoResizeControl() is a no-op when the sizes already match, so
+            // this is safe for connections that were already sized correctly.
+            if (InterfaceControl == null || InterfaceControl.IsDisposed) return;
+
+            try
+            {
+                if (InterfaceControl.InvokeRequired)
+                    InterfaceControl.BeginInvoke(new Action(() => DoResizeControl()));
+                else
+                    DoResizeControl();
+            }
+            catch (ObjectDisposedException ex)
+            {
+                Runtime.MessageCollector?.AddMessage(MessageClass.DebugMsg,
+                    $"OnLoginCompleted: control disposed during resize ({ex.GetType().Name})");
+            }
+            catch (InvalidOperationException ex)
+            {
+                Runtime.MessageCollector?.AddMessage(MessageClass.DebugMsg,
+                    $"OnLoginCompleted: control handle unavailable during resize ({ex.GetType().Name})");
+            }
+        }
+
         private void DoResizeClient()
         {
             if (!loginComplete)

--- a/mRemoteNG/Language/Language.es.resx
+++ b/mRemoteNG/Language/Language.es.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="_Sessions" xml:space="preserve">
+    <value>&amp;Sesiones</value>
+  </data>
   <data name="MenuItem_About" xml:space="preserve">
     <value>Acerca de</value>
   </data>

--- a/mRemoteNG/UI/Forms/frmMain.cs
+++ b/mRemoteNG/UI/Forms/frmMain.cs
@@ -234,6 +234,8 @@ namespace mRemoteNG.UI.Forms
             else
                 SetLayout();
 
+            PositionQuickConnectToolbarRight();
+
             ShowHidePanelTabs();
 
             Runtime.ConnectionsService.ConnectionsLoaded += ConnectionsServiceOnConnectionsLoaded;
@@ -331,6 +333,32 @@ namespace mRemoteNG.UI.Forms
             {
                 toolbar.GripStyle = shouldBeLocked ? ToolStripGripStyle.Hidden : ToolStripGripStyle.Visible;
             }
+        }
+
+        /// <summary>
+        /// Keeps the QuickConnect toolbar pinned to the right edge of the top
+        /// toolbar row, on the same line as the main menu toolbar.
+        /// </summary>
+        public void PositionQuickConnectToolbarRight()
+        {
+            if (_quickConnectToolStrip == null || tsContainer == null)
+                return;
+
+            ToolStripPanel topPanel = tsContainer.TopToolStripPanel;
+            if (topPanel == null)
+                return;
+
+            // Always visible and docked on the top toolbar panel.
+            _quickConnectToolStrip.Visible = true;
+            if (_quickConnectToolStrip.Parent != topPanel)
+                topPanel.Join(_quickConnectToolStrip);
+
+            // Right align on row 0 (same line as the main menu).
+            int x = topPanel.Width - _quickConnectToolStrip.Width - topPanel.Padding.Right - 3;
+            if (x < 0)
+                x = 0;
+
+            topPanel.Join(_quickConnectToolStrip, new Point(x, 0));
         }
 
         private void ConnectionsServiceOnConnectionsLoaded(object? sender, ConnectionsLoadedEventArgs connectionsLoadedEventArgs)
@@ -574,6 +602,8 @@ namespace mRemoteNG.UI.Forms
             {
                 PreviousWindowState = WindowState;
             }
+
+            PositionQuickConnectToolbarRight();
         }
 
         private void FrmMain_ResizeEnd(object sender, EventArgs e)
@@ -874,16 +904,10 @@ namespace mRemoteNG.UI.Forms
                 viewMenu._mMenViewMultiSshToolbar.Checked = false;
             }
 
-            if (Properties.Settings.Default.ViewMenuQuickConnect == true)
-            {
-                viewMenu.TsQuickConnect.Visible = true;
-                viewMenu._mMenViewQuickConnectToolbar.Checked = true;
-            }
-            else
-            {
-                viewMenu.TsQuickConnect.Visible = false;
-                viewMenu._mMenViewQuickConnectToolbar.Checked = false;
-            }
+            // The QuickConnect toolbar is always visible.
+            Properties.Settings.Default.ViewMenuQuickConnect = true;
+            viewMenu.TsQuickConnect.Visible = true;
+            viewMenu._mMenViewQuickConnectToolbar.Checked = true;
 
             if (Properties.Settings.Default.LockToolbars == true)
             {

--- a/mRemoteNG/UI/Menu/msMain/ViewMenu.cs
+++ b/mRemoteNG/UI/Menu/msMain/ViewMenu.cs
@@ -152,6 +152,10 @@ namespace mRemoteNG.UI.Menu
             _mMenViewQuickConnectToolbar.Name = "mMenViewQuickConnectToolbar";
             _mMenViewQuickConnectToolbar.Size = new System.Drawing.Size(228, 22);
             _mMenViewQuickConnectToolbar.Text = Language.QuickConnectToolbar;
+            // The QuickConnect toolbar is always visible, so the toggle is
+            // shown checked and disabled.
+            _mMenViewQuickConnectToolbar.Checked = true;
+            _mMenViewQuickConnectToolbar.Enabled = false;
             _mMenViewQuickConnectToolbar.Click += mMenViewQuickConnectToolbar_Click;
             // 
             // mMenViewExtAppsToolbar

--- a/mRemoteNG/UI/Panels/PanelBinder.cs
+++ b/mRemoteNG/UI/Panels/PanelBinder.cs
@@ -2,6 +2,7 @@
 using System.Runtime.Versioning;
 using mRemoteNG.App;
 using mRemoteNG.Properties;
+using mRemoteNG.UI.Forms;
 using WeifenLuo.WinFormsUI.Docking;
 using mRemoteNG.UI;
 using System.Windows.Forms;
@@ -129,6 +130,11 @@ namespace mRemoteNG.UI.Panels
                 // Save this auto-hide state
                 _configFormAutoHideState = AppWindows.ConfigForm.DockState;
             }
+
+            // Keep Connections above Config regardless of the order in which the
+            // panes were converted to auto-hide.
+            Config.Settings.DockPanelLayoutLoader.EnforcePanelOrder(
+                FrmMain.Default, Runtime.MessageCollector);
         }
         
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes three separate issues:

### 1. Quick Connect resolution / screen sizing
Connections opened from the Quick Connect toolbar rendered blurry and undersized (tiny icons/text) because they used the default `SmartSize` resolution, which connects at full-screen resolution and scales the image down to the panel. Quick Connect connections have no parent, so they cannot inherit the sharper `FitToWindow` resolution that tree/panel connections get from their container. They are now forced to `FitToWindow` so they render sharp and sized to the window, matching connections opened from the panel.

### 2. Missing Spanish translation
The `_Sessions` key was missing from `Language.es.resx`, so the main toolbar fell back to English ("Sessions" instead of "Sesiones"). Added the translation.

### 3. Connections/Config panel order
The Connections panel is now reliably ordered above the Config panel, including when they are separate auto-hide panes on the same edge. `EnforcePanelOrder` was made reusable and is now also re-applied by `PanelBinder` after toggling auto-hide, so the order stays correct at runtime.

## Testing
Verified manually on Windows:
- Quick Connect RDP sessions now render sharp and correctly sized, matching panel-opened connections.
- Main toolbar shows "Sesiones" in Spanish.
- Connections panel stays above Config panel across restarts and auto-hide toggles.
- Solution builds successfully (Release/x64).
