### PR TITLE
Add support for root group containers in tree UI

### DIFF
--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer28.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionNodeSerializer28.cs
@@ -38,7 +38,10 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
             element.Add(new XAttribute("UseEnhancedMode", connectionInfo.UseVmId));
             element.Add(new XAttribute("Type", connectionInfo.GetTreeNodeType().ToString()));
             if (nodeAsContainer != null)
+            {
                 element.Add(new XAttribute("Expanded", nodeAsContainer.IsExpanded.ToString().ToLowerInvariant()));
+                element.Add(new XAttribute("IsRootGroup", nodeAsContainer.IsRootGroup.ToString().ToLowerInvariant()));
+            }
             element.Add(new XAttribute("Descr", connectionInfo.Description));
             element.Add(new XAttribute("Icon", connectionInfo.Icon));
             element.Add(new XAttribute("Panel", connectionInfo.Panel));

--- a/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
+++ b/mRemoteNG/Config/Serializers/ConnectionSerializers/Xml/XmlConnectionsDeserializer.cs
@@ -169,6 +169,7 @@ namespace mRemoteNG.Config.Serializers.ConnectionSerializers.Xml
                             if (_confVersion >= 0.8)
                             {
                                 containerInfo.IsExpanded = xmlNode.GetAttributeAsBool("Expanded");
+                                containerInfo.IsRootGroup = xmlNode.GetAttributeAsBool("IsRootGroup");
                             }
 
                             parentContainer.AddChild(containerInfo);

--- a/mRemoteNG/Container/ContainerInfo.cs
+++ b/mRemoteNG/Container/ContainerInfo.cs
@@ -15,6 +15,7 @@ namespace mRemoteNG.Container
     public class ContainerInfo : ConnectionInfo, INotifyCollectionChanged
     {
         private bool _isExpanded;
+        private bool _isRootGroup;
 
         [Browsable(false)] public List<ConnectionInfo> Children { get; } = [];
 
@@ -23,6 +24,19 @@ namespace mRemoteNG.Container
         {
             get => _isExpanded;
             set => SetField(ref _isExpanded, value, "IsExpanded");
+        }
+
+        /// <summary>
+        /// When true, this container is displayed by the connection tree as a top-level
+        /// root group (a peer of the main "Connections" root) instead of being nested
+        /// under its actual parent. It remains a real child of its parent in the
+        /// underlying model for save/load purposes.
+        /// </summary>
+        [Category(""), Browsable(false), ReadOnly(false), Bindable(false), DefaultValue(""), DesignOnly(false)]
+        public bool IsRootGroup
+        {
+            get => _isRootGroup;
+            set => SetField(ref _isRootGroup, value, "IsRootGroup");
         }
 
         [Browsable(false)]

--- a/mRemoteNG/Language/Language.Designer.cs
+++ b/mRemoteNG/Language/Language.Designer.cs
@@ -3844,7 +3844,16 @@ namespace mRemoteNG.Resources.Language {
                 return ResourceManager.GetString("NewExternalTool", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Add Root.
+        /// </summary>
+        internal static string AddRoot {
+            get {
+                return ResourceManager.GetString("AddRoot", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to New Folder.
         /// </summary>

--- a/mRemoteNG/Language/Language.resx
+++ b/mRemoteNG/Language/Language.resx
@@ -899,6 +899,9 @@ See the Microsoft Support article at http://support.microsoft.com/kb/811833 for 
   <data name="NewConnection" xml:space="preserve">
     <value>New Connection</value>
   </data>
+  <data name="AddRoot" xml:space="preserve">
+    <value>Add Root</value>
+  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>New Folder</value>
   </data>

--- a/mRemoteNG/Properties/AssemblyInfo.cs
+++ b/mRemoteNG/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Resources;
 
 // Compute version values
 
-//Build nr: 3615
+//Build nr: 3621
 
 // General Information
 [assembly: AssemblyTitle("mRemoteNG")]
@@ -23,7 +23,7 @@ using System.Resources;
 [assembly: AssemblyCulture("")]
 
 // Version information
-[assembly: AssemblyVersion("1.78.2.3615")]
-[assembly: AssemblyFileVersion("1.78.2.3615")]
+[assembly: AssemblyVersion("1.78.2.3621")]
+[assembly: AssemblyFileVersion("1.78.2.3621")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]
-[assembly: AssemblyInformationalVersion("1.78.2 (Nightly Build 3615) x64")]
+[assembly: AssemblyInformationalVersion("1.78.2 (Nightly Build 3621) x64")]

--- a/mRemoteNG/Tree/ConnectionTreeDragAndDropHandler.cs
+++ b/mRemoteNG/Tree/ConnectionTreeDragAndDropHandler.cs
@@ -53,6 +53,7 @@ namespace mRemoteNG.Tree
         {
             if (!(dropTarget is ContainerInfo dropTargetAsContainer)) return;
             dropSource.SetParent(dropTargetAsContainer);
+            DemoteRootGroupIfNested(dropSource, dropTargetAsContainer);
         }
 
         private void DropModelAboveTarget(ConnectionInfo dropSource, ConnectionInfo dropTarget)
@@ -61,6 +62,7 @@ namespace mRemoteNG.Tree
                 dropTarget.Parent.AddChildAbove(dropSource, dropTarget);
             else
                 dropTarget.Parent.SetChildAbove(dropSource, dropTarget);
+            DemoteRootGroupIfNested(dropSource, dropTarget.Parent);
         }
 
         private void DropModelBelowTarget(ConnectionInfo dropSource, ConnectionInfo dropTarget)
@@ -69,6 +71,18 @@ namespace mRemoteNG.Tree
                 dropTarget.Parent.AddChildBelow(dropSource, dropTarget);
             else
                 dropTarget.Parent.SetChildBelow(dropSource, dropTarget);
+            DemoteRootGroupIfNested(dropSource, dropTarget.Parent);
+        }
+
+        /// <summary>
+        /// A container flagged as a top-level root group should only keep that flag while it
+        /// remains a direct child of the master root node. If it has been dropped into any
+        /// other container it becomes a normal nested folder again.
+        /// </summary>
+        private static void DemoteRootGroupIfNested(ConnectionInfo dropSource, ContainerInfo newParent)
+        {
+            if (dropSource is ContainerInfo { IsRootGroup: true } droppedContainer && newParent is not RootNodeInfo)
+                droppedContainer.IsRootGroup = false;
         }
 
         public void HandleEvent_ModelCanDrop(object? sender, ModelDropEventArgs e)

--- a/mRemoteNG/UI/Controls/ConnectionContextMenu.cs
+++ b/mRemoteNG/UI/Controls/ConnectionContextMenu.cs
@@ -29,6 +29,7 @@ namespace mRemoteNG.UI.Controls
     {
         private ToolStripMenuItem _cMenTreeAddConnection;
         private ToolStripMenuItem _cMenTreeAddFolder;
+        private ToolStripMenuItem _cMenTreeAddRoot;
         private ToolStripSeparator _cMenTreeSep1;
         private ToolStripMenuItem _cMenTreeConnect;
         private ToolStripMenuItem _cMenTreeConnectWithOptions;
@@ -121,6 +122,7 @@ namespace mRemoteNG.UI.Controls
             _cMenTreeSep4 = new ToolStripSeparator();
             _cMenTreeAddConnection = new ToolStripMenuItem();
             _cMenTreeAddFolder = new ToolStripMenuItem();
+            _cMenTreeAddRoot = new ToolStripMenuItem();
             _toolStripSeparator1 = new ToolStripSeparator();
             _cMenTreeToolsSort = new ToolStripMenuItem();
             _cMenTreeToolsSortAscending = new ToolStripMenuItem();
@@ -155,6 +157,7 @@ namespace mRemoteNG.UI.Controls
                 _cMenTreeSep4,
                 _cMenTreeAddConnection,
                 _cMenTreeAddFolder,
+                _cMenTreeAddRoot,
                 _toolStripSeparator1,
                 _cMenTreeToolsSort,
                 _cMenTreeMoveUp,
@@ -395,6 +398,14 @@ namespace mRemoteNG.UI.Controls
             _cMenTreeAddFolder.Text = "New Folder";
             _cMenTreeAddFolder.Click += OnAddFolderClicked;
             //
+            // cMenTreeAddRoot
+            //
+            _cMenTreeAddRoot.Image = Properties.Resources.ASPWebSite_16x;
+            _cMenTreeAddRoot.Name = "_cMenTreeAddRoot";
+            _cMenTreeAddRoot.Size = new System.Drawing.Size(199, 22);
+            _cMenTreeAddRoot.Text = "Add Root";
+            _cMenTreeAddRoot.Click += OnAddRootClicked;
+            //
             // ToolStripSeparator1
             //
             _toolStripSeparator1.Name = "_toolStripSeparator1";
@@ -500,6 +511,7 @@ namespace mRemoteNG.UI.Controls
 
             _cMenTreeAddConnection.Text = Language.NewConnection;
             _cMenTreeAddFolder.Text = Language.NewFolder;
+            _cMenTreeAddRoot.Text = Language.AddRoot;
 
             _cMenTreeToolsSort.Text = Language.Sort;
             _cMenTreeToolsSortAscending.Text = Language.SortAsc;
@@ -554,6 +566,7 @@ namespace mRemoteNG.UI.Controls
         {
             _cMenTreeAddConnection.Enabled = false;
             _cMenTreeAddFolder.Enabled = false;
+            _cMenTreeAddRoot.Enabled = false;
             _cMenTreeConnect.Enabled = false;
             _cMenTreeConnectWithOptions.Enabled = false;
             _cMenTreeDisconnect.Enabled = false;
@@ -610,6 +623,7 @@ namespace mRemoteNG.UI.Controls
         {
             _cMenTreeAddConnection.Enabled = false;
             _cMenTreeAddFolder.Enabled = false;
+            _cMenTreeAddRoot.Enabled = false;
 
             if (connectionInfo.OpenConnections.Count == 0)
                 _cMenTreeDisconnect.Enabled = false;
@@ -1022,6 +1036,11 @@ namespace mRemoteNG.UI.Controls
         private void OnAddFolderClicked(object sender, EventArgs e)
         {
             _connectionTree.AddFolder();
+        }
+
+        private void OnAddRootClicked(object sender, EventArgs e)
+        {
+            _connectionTree.AddRoot();
         }
 
         private void OnSortAscendingClicked(object sender, EventArgs e)

--- a/mRemoteNG/UI/Controls/ConnectionTree/ConnectionTree.cs
+++ b/mRemoteNG/UI/Controls/ConnectionTree/ConnectionTree.cs
@@ -145,9 +145,56 @@ namespace mRemoteNG.UI.Controls.ConnectionTree
             CanExpandGetter = item =>
             {
                 ContainerInfo itemAsContainer = item as ContainerInfo;
-                return itemAsContainer?.Children.Count > 0;
+                return GetVisibleChildren(itemAsContainer).Count > 0;
             };
-            ChildrenGetter = item => ((ContainerInfo)item).Children;
+            ChildrenGetter = item => GetVisibleChildren(item as ContainerInfo);
+        }
+
+        /// <summary>
+        /// Returns the children of the given container that should be displayed nested
+        /// beneath it. Children flagged as <see cref="ContainerInfo.IsRootGroup"/> are
+        /// excluded here because they are displayed flattened as top-level root peers instead.
+        /// </summary>
+        private static List<ConnectionInfo> GetVisibleChildren(ContainerInfo container)
+        {
+            if (container == null)
+                return new List<ConnectionInfo>();
+
+            return container.Children
+                             .Where(child => child is not ContainerInfo { IsRootGroup: true })
+                             .ToList();
+        }
+
+        /// <summary>
+        /// Returns the full set of objects that should be rendered as top-level roots in the
+        /// tree: the model's own root nodes, plus any descendant container flagged as
+        /// <see cref="ContainerInfo.IsRootGroup"/> (displayed flattened as an extra root).
+        /// </summary>
+        private static List<object> GetTreeRoots(ConnectionTreeModel model)
+        {
+            List<object> roots = new(model.RootNodes);
+
+            foreach (ContainerInfo rootNode in model.RootNodes)
+            {
+                roots.AddRange(GetRootGroupsRecursive(rootNode));
+            }
+
+            return roots;
+        }
+
+        private static IEnumerable<ContainerInfo> GetRootGroupsRecursive(ContainerInfo container)
+        {
+            foreach (ConnectionInfo child in container.Children)
+            {
+                if (child is not ContainerInfo childContainer)
+                    continue;
+
+                if (childContainer.IsRootGroup)
+                    yield return childContainer;
+
+                foreach (ContainerInfo nested in GetRootGroupsRecursive(childContainer))
+                    yield return nested;
+            }
         }
 
         private void SetupDropSink()
@@ -211,10 +258,20 @@ namespace mRemoteNG.UI.Controls.ConnectionTree
 
         private void PopulateTreeView(ConnectionTreeModel newModel)
         {
-            SetObjects(newModel.RootNodes);
+            SetObjects(GetTreeRoots(newModel));
             RegisterModelUpdateHandlers(newModel);
             NodeSearcher = new NodeSearcher(newModel);
             ExecutePostSetupActions();
+            AutoResizeColumn(Columns[0]);
+        }
+
+        /// <summary>
+        /// Recomputes the flattened root list (model root nodes + any IsRootGroup-flagged
+        /// descendants) and re-applies it to the tree, preserving expand/selection state.
+        /// </summary>
+        private void RefreshTreeRoots()
+        {
+            SetObjects(GetTreeRoots(ConnectionTreeModel));
             AutoResizeColumn(Columns[0]);
         }
 
@@ -246,6 +303,13 @@ namespace mRemoteNG.UI.Controls.ConnectionTree
             // for some reason property changed events are getting triggered twice for each changed property. should be just once. cant find source of duplication
             // Removed "TO DO" from above comment. Per #142 it apperas that this no longer occurs with ObjectListView 2.9.1
             string property = propertyChangedEventArgs.PropertyName;
+
+            if (property == nameof(ContainerInfo.IsRootGroup))
+            {
+                RefreshTreeRoots();
+                return;
+            }
+
             if (property != nameof(ConnectionInfo.Name)
              && property != nameof(ConnectionInfo.OpenConnections)
              && property != nameof(ConnectionInfo.Icon))
@@ -314,6 +378,36 @@ namespace mRemoteNG.UI.Controls.ConnectionTree
             try
             {
                 AddNode(new ContainerInfo());
+            }
+            catch (Exception ex)
+            {
+                Runtime.MessageCollector.AddExceptionStackTrace(Language.ErrorAddFolderFailed, ex);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new top-level root group, displayed as a peer of the main "Connections"
+        /// root node (similar to server groups in SSMS). The group is still stored as a real
+        /// child of the main root node so existing save/load logic is unaffected.
+        /// </summary>
+        public void AddRoot()
+        {
+            try
+            {
+                ContainerInfo newRoot = new() { IsRootGroup = true };
+
+                // the new node will survive filtering if filtering is active
+                _connectionTreeSearchTextFilter.SpecialInclusionList.Add(newRoot);
+
+                DefaultConnectionInfo.Instance.SaveTo(newRoot);
+                DefaultConnectionInheritance.Instance.SaveTo(newRoot.Inheritance);
+
+                newRoot.SetParent(GetRootConnectionNode());
+
+                SelectObject(newRoot, true);
+                EnsureModelVisible(newRoot);
+                _allowEdit = true;
+                SelectedItem.BeginEdit();
             }
             catch (Exception ex)
             {
@@ -446,6 +540,11 @@ namespace mRemoteNG.UI.Controls.ConnectionTree
                 ResetColumnFiltering();
             }
 
+            if (CollectionChangeAffectsRootGroups(args))
+            {
+                RefreshTreeRoots();
+            }
+
             RefreshObject(sender);
             AutoResizeColumn(Columns[0]);
 
@@ -453,6 +552,25 @@ namespace mRemoteNG.UI.Controls.ConnectionTree
             if (!filteringEnabled) return;
             ModelFilter = filter;
             UpdateFiltering();
+        }
+
+        private static bool CollectionChangeAffectsRootGroups(NotifyCollectionChangedEventArgs args)
+        {
+            return ContainsRootGroup(args.NewItems) || ContainsRootGroup(args.OldItems);
+        }
+
+        private static bool ContainsRootGroup(System.Collections.IList items)
+        {
+            if (items == null)
+                return false;
+
+            foreach (object item in items)
+            {
+                if (item is ContainerInfo { IsRootGroup: true })
+                    return true;
+            }
+
+            return false;
         }
 
         protected override void UpdateFiltering()

--- a/mRemoteNG/UI/StatusImageList.cs
+++ b/mRemoteNG/UI/StatusImageList.cs
@@ -46,6 +46,7 @@ namespace mRemoteNG.UI
             if (connectionInfo == null) return "";
             if (connectionInfo is RootPuttySessionsNodeInfo) return "PuttySessions";
             if (connectionInfo is RootNodeInfo) return "Root";
+            if (connectionInfo is ContainerInfo { IsRootGroup: true }) return "Root";
             if (connectionInfo is ContainerInfo) return "Folder";
 
             return GetConnectionIcon(connectionInfo);

--- a/mRemoteNG/UI/Window/ConnectionTreeWindow.Designer.cs
+++ b/mRemoteNG/UI/Window/ConnectionTreeWindow.Designer.cs
@@ -13,6 +13,7 @@ namespace mRemoteNG.UI.Window
 		internal System.Windows.Forms.ToolStripMenuItem mMenSort;
 		internal System.Windows.Forms.ToolStripMenuItem mMenAddConnection;
 		internal System.Windows.Forms.ToolStripMenuItem mMenAddFolder;
+		internal System.Windows.Forms.ToolStripMenuItem mMenAddRoot;
 		public System.Windows.Forms.TreeView tvConnections;
 		private void InitializeComponent()
 		{
@@ -25,6 +26,7 @@ namespace mRemoteNG.UI.Window
             this.msMain = new System.Windows.Forms.MenuStrip();
             this.mMenAddConnection = new System.Windows.Forms.ToolStripMenuItem();
             this.mMenAddFolder = new System.Windows.Forms.ToolStripMenuItem();
+            this.mMenAddRoot = new System.Windows.Forms.ToolStripMenuItem();
             this.mMenViewExpandAllFolders = new System.Windows.Forms.ToolStripMenuItem();
             this.mMenViewCollapseAllFolders = new System.Windows.Forms.ToolStripMenuItem();
             this.mMenSort = new System.Windows.Forms.ToolStripMenuItem();
@@ -79,6 +81,7 @@ namespace mRemoteNG.UI.Window
             this.msMain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mMenAddConnection,
             this.mMenAddFolder,
+            this.mMenAddRoot,
             this.mMenViewExpandAllFolders,
             this.mMenViewCollapseAllFolders,
             this.mMenSort,
@@ -107,6 +110,14 @@ namespace mRemoteNG.UI.Window
             this.mMenAddFolder.Name = "mMenAddFolder";
             this.mMenAddFolder.Size = new System.Drawing.Size(28, 20);
             this.mMenAddFolder.Click += new System.EventHandler(this.CMenTreeAddFolder_Click);
+            // 
+            // mMenAddRoot
+            // 
+            this.mMenAddRoot.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.mMenAddRoot.Image = global::mRemoteNG.Properties.Resources.ASPWebSite_16x;
+            this.mMenAddRoot.Name = "mMenAddRoot";
+            this.mMenAddRoot.Size = new System.Drawing.Size(28, 20);
+            this.mMenAddRoot.Click += new System.EventHandler(this.CMenTreeAddRoot_Click);
             // 
             // mMenViewExpandAllFolders
             // 

--- a/mRemoteNG/UI/Window/ConnectionTreeWindow.cs
+++ b/mRemoteNG/UI/Window/ConnectionTreeWindow.cs
@@ -92,6 +92,7 @@ namespace mRemoteNG.UI.Window
 
             mMenAddConnection.ToolTipText = Language.NewConnection;
             mMenAddFolder.ToolTipText = Language.NewFolder;
+            mMenAddRoot.ToolTipText = Language.AddRoot;
             mMenViewExpandAllFolders.ToolTipText = Language.ExpandAllFolders;
             mMenViewCollapseAllFolders.ToolTipText = Language.CollapseAllFolders;
             mMenSort.ToolTipText = Language.Sort;
@@ -255,6 +256,11 @@ namespace mRemoteNG.UI.Window
         private void CMenTreeAddFolder_Click(object sender, EventArgs e)
         {
             ConnectionTree.AddFolder();
+        }
+
+        private void CMenTreeAddRoot_Click(object sender, EventArgs e)
+        {
+            ConnectionTree.AddRoot();
         }
 
         #endregion

--- a/mRemoteNGTests/IntegrationTests/XmlSerializationLifeCycleTests.cs
+++ b/mRemoteNGTests/IntegrationTests/XmlSerializationLifeCycleTests.cs
@@ -162,6 +162,44 @@ namespace mRemoteNGTests.IntegrationTests
         }
 
 
+        [Test]
+        public void SerializeThenDeserializePreservesIsRootGroupFlag()
+        {
+            var rootGroup = new ContainerInfo { Name = "rootGroup1", IsRootGroup = true };
+            var masterRoot = (RootNodeInfo)_originalModel.RootNodes.First(node => node is RootNodeInfo);
+            masterRoot.AddChild(rootGroup);
+
+            var serializedContent = _serializer.Serialize(_originalModel);
+            var deserializedModel = _deserializer.Deserialize(serializedContent);
+
+            var deserializedRootGroup = deserializedModel
+                .GetRecursiveChildList()
+                .OfType<ContainerInfo>()
+                .First(node => node.Name == "rootGroup1");
+
+            Assert.That(deserializedRootGroup.IsRootGroup, Is.True);
+        }
+
+        [Test]
+        public void DeserializingOldXmlWithoutIsRootGroupAttributeDefaultsToFalse()
+        {
+            // Simulates a connections file saved by an older version of mRemoteNG that predates
+            // the IsRootGroup attribute, to ensure existing users still see a single root and
+            // do not lose any connections/folders on upgrade.
+            var serializedContent = _serializer.Serialize(_originalModel);
+            var xmlWithoutAttribute = serializedContent.Replace(" IsRootGroup=\"false\"", "");
+            Assert.That(xmlWithoutAttribute, Does.Not.Contain("IsRootGroup"));
+
+            var deserializedModel = _deserializer.Deserialize(xmlWithoutAttribute);
+
+            var allContainers = deserializedModel.GetRecursiveChildList().OfType<ContainerInfo>().ToList();
+            Assert.That(allContainers, Is.Not.Empty);
+            Assert.That(allContainers.All(container => !container.IsRootGroup), Is.True);
+
+            // The tree still exposes exactly one true root node, matching pre-upgrade behavior
+            Assert.That(deserializedModel.RootNodes.OfType<RootNodeInfo>().Count(), Is.EqualTo(1));
+        }
+
         private ConnectionTreeModel SetupConnectionTreeModel()
         {
             /*


### PR DESCRIPTION
This pull request introduces the concept of "root groups" to the connection tree, allowing users to create additional top-level groups (peers of the main "Connections" root) that are visually flattened in the tree but remain children of the main root node in the underlying model. The implementation includes UI changes, model updates, drag-and-drop handling, and persistence support to ensure root groups behave as expected.

**Root Group Feature Implementation**

* Added a new `IsRootGroup` property to `ContainerInfo`, which, when true, causes the container to be displayed as a top-level root group in the connection tree UI. [[1]](diffhunk://#diff-ced4e434f28aa41a5ffdbfddace11f6854ebb7a1250a542d37c0ec4932bcff35R18) [[2]](diffhunk://#diff-ced4e434f28aa41a5ffdbfddace11f6854ebb7a1250a542d37c0ec4932bcff35R29-R41)
* Updated the connection tree logic (`ConnectionTree.cs`) to:
  * Flatten all `IsRootGroup` containers to the top level in the tree view via `GetTreeRoots`, and exclude them from being displayed as children of their parent. [[1]](diffhunk://#diff-985aaec41f3e425a7f1dedc74487ae8b707f8cbdbda7abe7c373853bb593a0c7L148-R197) [[2]](diffhunk://#diff-985aaec41f3e425a7f1dedc74487ae8b707f8cbdbda7abe7c373853bb593a0c7L214-R277)
  * Monitor changes to `IsRootGroup` and collection changes to dynamically refresh the tree roots as needed. [[1]](diffhunk://#diff-985aaec41f3e425a7f1dedc74487ae8b707f8cbdbda7abe7c373853bb593a0c7R306-R312) [[2]](diffhunk://#diff-985aaec41f3e425a7f1dedc74487ae8b707f8cbdbda7abe7c373853bb593a0c7R543-R547) [[3]](diffhunk://#diff-985aaec41f3e425a7f1dedc74487ae8b707f8cbdbda7abe7c373853bb593a0c7R557-R575)
  * Provide an `AddRoot` method to create new root groups, and wire this up to the context menu.
  * Ensure root group nodes use the correct icon.

**UI Enhancements**

* Added an "Add Root" option to the connection tree context menu, with localization support and appropriate enable/disable logic. [[1]](diffhunk://#diff-8d91d9824f73291c6722379a8d579b1d2f3ff5b5c3bda9dbb77f5f30a54a05aeR32) [[2]](diffhunk://#diff-8d91d9824f73291c6722379a8d579b1d2f3ff5b5c3bda9dbb77f5f30a54a05aeR125) [[3]](diffhunk://#diff-8d91d9824f73291c6722379a8d579b1d2f3ff5b5c3bda9dbb77f5f30a54a05aeR160) [[4]](diffhunk://#diff-8d91d9824f73291c6722379a8d579b1d2f3ff5b5c3bda9dbb77f5f30a54a05aeR401-R408) [[5]](diffhunk://#diff-8d91d9824f73291c6722379a8d579b1d2f3ff5b5c3bda9dbb77f5f30a54a05aeR514) [[6]](diffhunk://#diff-8d91d9824f73291c6722379a8d579b1d2f3ff5b5c3bda9dbb77f5f30a54a05aeR569) [[7]](diffhunk://#diff-8d91d9824f73291c6722379a8d579b1d2f3ff5b5c3bda9dbb77f5f30a54a05aeR626) [[8]](diffhunk://#diff-8d91d9824f73291c6722379a8d579b1d2f3ff5b5c3bda9dbb77f5f30a54a05aeR1041-R1045) [[9]](diffhunk://#diff-2fe21ede3f968bbe8ee65e6f72c933043a745ed7440b994eb3c0c7ee82d62511R3848-R3856) [[10]](diffhunk://#diff-6fbfa022fb529fe72d1a1b41a66b51b321cf15b6391fbd557865aed149943ed6R902-R904)

**Persistence and Model Updates**

* Persisted the `IsRootGroup` property to XML and restored it on load, ensuring root group status is saved with the configuration. [[1]](diffhunk://#diff-6d7d91e40572106d740e3e2dfc3dc7cd52400bd1cc4abeff835612255e4274efR41-R44) [[2]](diffhunk://#diff-3736593b8fcfa18c0c8bf8a6e5bedea3f59d6ff584848c719003f9761ed42337R172)

**Drag-and-Drop Behavior**

* Implemented logic so that if a root group is dragged and dropped into a non-root container, it is demoted to a normal folder (i.e., `IsRootGroup` is set to false). [[1]](diffhunk://#diff-77df34980896a93736587f63b94533e64fba8ee57772d16f109d2e88ef2fc639R56) [[2]](diffhunk://#diff-77df34980896a93736587f63b94533e64fba8ee57772d16f109d2e88ef2fc639R65) [[3]](diffhunk://#diff-77df34980896a93736587f63b94533e64fba8ee57772d16f109d2e88ef2fc639R74-R85)

**Miscellaneous**

* Updated the assembly version and build number. [[1]](diffhunk://#diff-7092a21b776d1a26594d21505a6489e6b09bb2cbadf5dbe425b46c3222a30d78L13-R13) [[2]](diffhunk://#diff-7092a21b776d1a26594d21505a6489e6b09bb2cbadf5dbe425b46c3222a30d78L26-R29)

These changes collectively enable users to organize their connections into multiple top-level groups, improving flexibility and clarity in large environments.