### PR TITLE
fix: keep the active tab when a tab close is cancelled

### DIFF
--- a/mRemoteNG/UI/Tabs/DockPaneStripNG.cs
+++ b/mRemoteNG/UI/Tabs/DockPaneStripNG.cs
@@ -1183,7 +1183,35 @@ namespace mRemoteNG.UI.Tabs
             Point mousePos = PointToClient(MousePosition);
             Rectangle tabRect = GetTabBounds(Tabs[index]);
             if (tabRect.Contains(ActiveClose) && ActiveCloseHitTest(mousePos))
-                TryCloseTab(index);
+                CloseTab(index);
+        }
+
+        /// <summary>
+        /// Closes the tab at <paramref name="index"/>, keeping the current selection when
+        /// the tab does not actually close.
+        /// </summary>
+        /// <remarks>
+        /// DockPanelSuite's TryCloseTab selects the neighbouring tab afterwards without
+        /// checking whether the close happened, so dismissing the "are you sure" prompt
+        /// still switched the active connection.
+        /// </remarks>
+        private void CloseTab(int index)
+        {
+            IDockContent tabContent = Tabs[index].Content;
+            IDockContent? activeBeforeClose = DockPane.ActiveContent;
+
+            TryCloseTab(index);
+
+            if (activeBeforeClose == null || ReferenceEquals(DockPane.ActiveContent, activeBeforeClose))
+                return;
+
+            // The tab is still on display, so the close was refused and the selection
+            // moved for nothing.
+            if (DockPane.DisplayingContents.Contains(tabContent) &&
+                DockPane.DisplayingContents.Contains(activeBeforeClose))
+            {
+                activeBeforeClose.DockHandler.Activate();
+            }
         }
 
         private Rectangle GetCloseButtonRect(Rectangle rectTab)

--- a/mRemoteNGTests/UI/Tabs/DockPaneStripNGTests.cs
+++ b/mRemoteNGTests/UI/Tabs/DockPaneStripNGTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Windows.Forms;
+using mRemoteNG.Themes;
+using NUnit.Framework;
+using WeifenLuo.WinFormsUI.Docking;
+using WeifenLuo.WinFormsUI.ThemeVS2015;
+
+namespace mRemoteNGTests.UI.Tabs
+{
+    [TestFixture]
+    public class DockPaneStripNGTests
+    {
+        private static void RunWithMessagePump(Action testAction)
+        {
+            Exception? caught = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    testAction();
+                }
+                catch (Exception ex)
+                {
+                    caught = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+
+            if (!thread.Join(TimeSpan.FromSeconds(30)))
+            {
+                thread.Interrupt();
+                Assert.Fail("Test timed out after 30 seconds");
+            }
+
+            if (caught != null)
+                throw caught;
+        }
+
+        [Test]
+        public void CancellingATabClose_LeavesTheActiveTabUnchanged() => RunWithMessagePump(() =>
+        {
+            // Arrange
+            using var hostForm = new Form
+            {
+                Width = 800,
+                Height = 600,
+                ShowInTaskbar = false,
+                StartPosition = FormStartPosition.Manual,
+                Location = new System.Drawing.Point(-10000, -10000)
+            };
+
+            var dockPanel = new DockPanel
+            {
+                Dock = DockStyle.Fill,
+                DocumentStyle = DocumentStyle.DockingWindow,
+                Theme = new VS2015LightTheme()
+            };
+
+            dockPanel.Theme.Extender.DockPaneStripFactory = new MremoteDockPaneStripFactory();
+
+            hostForm.Controls.Add(dockPanel);
+            hostForm.Show();
+
+            var doc1 = new DockContent { Text = "Doc1", CloseButton = true, CloseButtonVisible = true };
+            var doc2 = new DockContent { Text = "Doc2", CloseButton = true, CloseButtonVisible = true };
+            var doc3 = new DockContent { Text = "Doc3", CloseButton = true, CloseButtonVisible = true };
+
+            doc1.Show(dockPanel, DockState.Document);
+            doc2.Show(dockPanel, DockState.Document);
+            doc3.Show(dockPanel, DockState.Document);
+
+            Application.DoEvents();
+
+            // Stands in for the user dismissing the close confirmation. No dialog is shown,
+            // so the test stays headless.
+            doc2.FormClosing += (_, e) => e.Cancel = true;
+
+            doc2.DockHandler.Activate();
+            Application.DoEvents();
+            Assert.That(doc2.DockHandler.Pane.ActiveContent, Is.SameAs(doc2), "Doc2 should start out active");
+
+            Control dockPaneStrip = FindDockPaneStripNG(dockPanel);
+            Assert.That(dockPaneStrip, Is.Not.Null, "Could not find DockPaneStripNG control");
+
+            MethodInfo closeTabMethod = dockPaneStrip.GetType().GetMethod("CloseTab", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(closeTabMethod, Is.Not.Null, "Could not find CloseTab method");
+
+            // Act - close Doc2, which is not the first tab, so DockPanelSuite would otherwise
+            // select Doc1 once the close attempt returns.
+            closeTabMethod.Invoke(dockPaneStrip, new object[] { 1 });
+            Application.DoEvents();
+
+            // Assert
+            Assert.That(doc2.DockState, Is.EqualTo(DockState.Document), "Doc2 should still be open");
+            Assert.That(doc2.DockHandler.Pane.ActiveContent, Is.SameAs(doc2), "Doc2 should still be the active tab");
+        });
+
+        [Test]
+        public void ClosingATabThatIsNotCancelled_StillClosesIt() => RunWithMessagePump(() =>
+        {
+            using var hostForm = new Form
+            {
+                Width = 800,
+                Height = 600,
+                ShowInTaskbar = false,
+                StartPosition = FormStartPosition.Manual,
+                Location = new System.Drawing.Point(-10000, -10000)
+            };
+
+            var dockPanel = new DockPanel
+            {
+                Dock = DockStyle.Fill,
+                DocumentStyle = DocumentStyle.DockingWindow,
+                Theme = new VS2015LightTheme()
+            };
+
+            dockPanel.Theme.Extender.DockPaneStripFactory = new MremoteDockPaneStripFactory();
+
+            hostForm.Controls.Add(dockPanel);
+            hostForm.Show();
+
+            var doc1 = new DockContent { Text = "Doc1", CloseButton = true, CloseButtonVisible = true };
+            var doc2 = new DockContent { Text = "Doc2", CloseButton = true, CloseButtonVisible = true };
+
+            doc1.Show(dockPanel, DockState.Document);
+            doc2.Show(dockPanel, DockState.Document);
+
+            Application.DoEvents();
+
+            Control dockPaneStrip = FindDockPaneStripNG(dockPanel);
+            MethodInfo closeTabMethod = dockPaneStrip.GetType().GetMethod("CloseTab", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            closeTabMethod.Invoke(dockPaneStrip, new object[] { 1 });
+            Application.DoEvents();
+
+            Assert.That(doc2.IsDisposed || doc2.DockState != DockState.Document, Is.True, "Doc2 should be closed");
+            Assert.That(doc1.DockState, Is.EqualTo(DockState.Document), "Doc1 should still be open");
+        });
+
+        private static Control FindDockPaneStripNG(Control parent)
+        {
+            foreach (Control c in parent.Controls)
+            {
+                if (string.Equals(c.GetType().Name, "DockPaneStripNG", StringComparison.Ordinal))
+                    return c;
+
+                var result = FindDockPaneStripNG(c);
+                if (result != null) return result;
+            }
+
+            return null;
+        }
+    }
+}

--- a/mRemoteNGTests/UI/Tabs/DockPaneStripNGTests.cs
+++ b/mRemoteNGTests/UI/Tabs/DockPaneStripNGTests.cs
@@ -12,28 +12,75 @@ namespace mRemoteNGTests.UI.Tabs
     [TestFixture]
     public class DockPaneStripNGTests
     {
+        private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
+
+        /// <summary>
+        /// Runs <paramref name="testAction"/> on an STA thread with a real message loop, so
+        /// docking layout work that relies on posted messages completes.
+        /// </summary>
         private static void RunWithMessagePump(Action testAction)
         {
             Exception caught = null;
+            Form pump = null;
+            using var pumpReady = new ManualResetEventSlim(false);
+
             var thread = new Thread(() =>
             {
-                try
+                pump = new Form
                 {
-                    testAction();
-                }
-                catch (Exception ex)
+                    ShowInTaskbar = false,
+                    StartPosition = FormStartPosition.Manual,
+                    Location = new System.Drawing.Point(-10000, -10000)
+                };
+
+                _ = pump.Handle; // Force handle creation so the loop below can be posted to.
+                pumpReady.Set();
+
+                pump.BeginInvoke(new Action(() =>
                 {
-                    caught = ex;
-                }
-            });
+                    try
+                    {
+                        testAction();
+                    }
+                    catch (Exception ex)
+                    {
+                        caught = ex;
+                    }
+                    finally
+                    {
+                        Application.ExitThread();
+                    }
+                }));
+
+                Application.Run(new ApplicationContext());
+                pump.Dispose();
+            })
+            {
+                // Last-resort safety net: a wedged UI thread must never hold the test run open.
+                IsBackground = true
+            };
 
             thread.SetApartmentState(ApartmentState.STA);
             thread.Start();
+            pumpReady.Wait(ShutdownTimeout);
 
-            if (!thread.Join(TimeSpan.FromSeconds(30)))
+            if (!thread.Join(TestTimeout))
             {
-                thread.Interrupt();
-                Assert.Fail("Test timed out after 30 seconds");
+                // Ask the loop to unwind. This only lands if the thread is still pumping;
+                // when it is not, IsBackground keeps the timeout from hanging the run.
+                try
+                {
+                    pump?.BeginInvoke(new Action(Application.ExitThread));
+                }
+                catch (InvalidOperationException)
+                {
+                    // Handle was never created, or the form was disposed as the loop
+                    // unwound (ObjectDisposedException derives from this).
+                }
+
+                thread.Join(ShutdownTimeout);
+                Assert.Fail($"Test timed out after {TestTimeout.TotalSeconds} seconds");
             }
 
             if (caught != null)

--- a/mRemoteNGTests/UI/Tabs/DockPaneStripNGTests.cs
+++ b/mRemoteNGTests/UI/Tabs/DockPaneStripNGTests.cs
@@ -14,7 +14,7 @@ namespace mRemoteNGTests.UI.Tabs
     {
         private static void RunWithMessagePump(Action testAction)
         {
-            Exception? caught = null;
+            Exception caught = null;
             var thread = new Thread(() =>
             {
                 try
@@ -132,7 +132,10 @@ namespace mRemoteNGTests.UI.Tabs
             Application.DoEvents();
 
             Control dockPaneStrip = FindDockPaneStripNG(dockPanel);
+            Assert.That(dockPaneStrip, Is.Not.Null, "Could not find DockPaneStripNG control");
+
             MethodInfo closeTabMethod = dockPaneStrip.GetType().GetMethod("CloseTab", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(closeTabMethod, Is.Not.Null, "Could not find CloseTab method");
 
             closeTabMethod.Invoke(dockPaneStrip, new object[] { 1 });
             Application.DoEvents();


### PR DESCRIPTION
## Problem

Closing a connection tab shows the "are you sure you want to close" prompt. Clicking **Cancel** correctly keeps the tab open, but the active connection switches to the tab on its left.

## Root cause

Not in the confirmation logic — it is DockPanelSuite. `DockPaneStripBase.TryCloseTab`:

```csharp
DockPane.CloseContent(content);
if (PatchController.EnableSelectClosestOnClose == true)
    SelectClosestPane(index);        // DockPane.ActiveContent = Tabs[index - 1].Content
```

`SelectClosestPane` runs unconditionally — it never checks whether the close actually happened. `EnableSelectClosestOnClose` defaults to `true`, and `connDock.DocumentStyle` is `DockingWindow` whenever more than one tab is open, so both of its guards pass. When `ConnectionTab.OnFormClosing` sets `e.Cancel = true`, the tab survives but DPS has already moved the selection.

It only bites when the tab being closed is not the first one (`SelectClosestPane` is guarded by `index > 0`), which is why the bug can look intermittent.

## Fix

`DockPaneStripNG.TabCloseButtonHit` now goes through a wrapper that puts the selection back when the tab is still on display:

```csharp
private void CloseTab(int index)
{
    IDockContent tabContent = Tabs[index].Content;
    IDockContent? activeBeforeClose = DockPane.ActiveContent;

    TryCloseTab(index);

    if (activeBeforeClose == null || ReferenceEquals(DockPane.ActiveContent, activeBeforeClose))
        return;

    if (DockPane.DisplayingContents.Contains(tabContent) &&
        DockPane.DisplayingContents.Contains(activeBeforeClose))
    {
        activeBeforeClose.DockHandler.Activate();
    }
}
```

Keying off `DisplayingContents` rather than a cancel flag covers every refusal — the confirmation prompt, a protocol veto — and it deliberately does nothing on a successful close, so the existing selection behaviour is untouched. `Activate()` rather than a bare `ActiveContent` assignment also restores keyboard focus to the tab.

## Verification

`mRemoteNG.csproj` builds clean (MSBuild, `Release|x64`).

Behaviour was verified by driving the real `DockPaneStripNG` from a standalone STA harness against the built assembly:

```
PASS  Doc2 starts active
PASS  cancelled close leaves Doc2 open
PASS  cancelled close keeps Doc2 active
  (control) after raw TryCloseTab, Doc2 open=True, active=Doc1
PASS  uncancelled close still closes Doc3
```

The control line is the bug reproduced directly on this branch: calling DPS's `TryCloseTab` leaves the tab open but hands the selection to `Doc1`.

New tests in `mRemoteNGTests/UI/Tabs/DockPaneStripNGTests.cs` cover both the cancelled close and a normal close. They are headless — the cancel is simulated with a `FormClosing` handler, so no dialog is shown — and run on an STA thread with a message pump.

### Note on the test project

`mRemoteNGTests` does not currently compile on `v1.78.2-dev`, independently of this PR:

```
mRemoteNGTests/Config/Settings/OptionsRepositoryTests.cs(25,49): error CS1503:
Argument 1: cannot convert from 'mRemoteNG.Config.Settings.Store.OptionsStore'
to 'mRemoteNG.Config.Settings.Store.ISettingsStore'
```

`OptionsStore` implements `IDisposable` but not `ISettingsStore`, while `OptionsRepository` takes an `ISettingsStore`. That break predates this branch and is unrelated, so I have left it alone rather than widen the scope. With that one pre-existing file excluded, the test project — including the new tests — compiles cleanly.
