### PR TITLE
security: fix command injection in Terminal protocol (#3335)

### DIFF
--- a/mRemoteNG/Connection/Protocol/Terminal/Connection.Protocol.Terminal.cs
+++ b/mRemoteNG/Connection/Protocol/Terminal/Connection.Protocol.Terminal.cs
@@ -37,8 +37,8 @@ namespace mRemoteNG.Connection.Protocol.Terminal
                     Padding = new Padding(0, 20, 0, 0)
                 };
 
-                string hostname = _connectionInfo.Hostname.Trim().ToLower();
-                bool useLocalHost = hostname == "" || hostname.Equals("localhost");
+                string hostname = _connectionInfo.Hostname.Trim();
+                bool useLocalHost = hostname.Length == 0 || hostname.Equals("localhost", StringComparison.OrdinalIgnoreCase);
 
                 string processExe;
                 string arguments;
@@ -152,11 +152,14 @@ namespace mRemoteNG.Connection.Protocol.Terminal
             string hostname = (rawHostname ?? string.Empty).Trim();
             string username = (rawUsername ?? string.Empty).Trim();
 
+            // Deliberately do NOT echo the offending value: it is attacker-controlled and, in the
+            // invalid case, may contain control characters/newlines that would be written verbatim into
+            // logs and UI messages (log forging / message spoofing).
             if (!IsSafeSshToken(hostname))
-                throw new ArgumentException($"Refusing to start SSH session: the hostname '{hostname}' contains characters that are not allowed.");
+                throw new ArgumentException("Refusing to start SSH session: the hostname contains characters that are not allowed.");
 
             if (username.Length > 0 && !IsSafeSshToken(username))
-                throw new ArgumentException($"Refusing to start SSH session: the username '{username}' contains characters that are not allowed.");
+                throw new ArgumentException("Refusing to start SSH session: the username contains characters that are not allowed.");
 
             string args = "";
 
@@ -173,8 +176,11 @@ namespace mRemoteNG.Connection.Protocol.Terminal
 
         /// <summary>
         /// Returns true only for values that are safe to place on the ssh.exe command line as a single
-        /// token: non-empty, no whitespace or control characters, and not starting with '-' (which ssh
-        /// would treat as an option switch).
+        /// token: non-empty, no whitespace or control characters, no double quotes, and not starting
+        /// with '-' (which ssh would treat as an option switch). Double quotes are rejected because
+        /// Windows argument parsing (CommandLineToArgvW) strips them, so a value such as
+        /// "-oProxyCommand=..." does not literally start with '-' here yet reaches ssh.exe as an argv
+        /// token that does — re-enabling option injection.
         /// </summary>
         private static bool IsSafeSshToken(string value)
         {
@@ -186,7 +192,7 @@ namespace mRemoteNG.Connection.Protocol.Terminal
 
             foreach (char c in value)
             {
-                if (char.IsWhiteSpace(c) || char.IsControl(c))
+                if (char.IsWhiteSpace(c) || char.IsControl(c) || c == '"')
                     return false;
             }
 
@@ -209,7 +215,17 @@ namespace mRemoteNG.Connection.Protocol.Terminal
             {
                 foreach (string dir in pathVar.Split(Path.PathSeparator))
                 {
-                    string candidate = Path.Combine(dir.Trim(), "ssh.exe");
+                    // PATH segments may be quoted, blank, or contain %VAR% placeholders. Normalize each
+                    // before probing so we don't build a quoted or relative "ssh.exe" candidate.
+                    string segment = dir.Trim().Trim('"');
+                    if (segment.Length == 0)
+                        continue;
+
+                    segment = Environment.ExpandEnvironmentVariables(segment);
+                    if (!Path.IsPathRooted(segment))
+                        continue;
+
+                    string candidate = Path.Combine(segment, "ssh.exe");
                     if (File.Exists(candidate))
                         return candidate;
                 }

--- a/mRemoteNG/Connection/Protocol/Terminal/Connection.Protocol.Terminal.cs
+++ b/mRemoteNG/Connection/Protocol/Terminal/Connection.Protocol.Terminal.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Drawing;
+using System.IO;
 using System.Runtime.Versioning;
 using System.Windows.Forms;
 using mRemoteNG.App;
@@ -36,50 +37,43 @@ namespace mRemoteNG.Connection.Protocol.Terminal
                     Padding = new Padding(0, 20, 0, 0)
                 };
 
-                // Path to command prompt - dynamically determined from system
-                // Using COMSPEC environment variable which points to the system's command processor
-                string terminalExe = Environment.GetEnvironmentVariable("COMSPEC") ?? @"C:\Windows\System32\cmd.exe";
-
-                // Setup arguments based on whether hostname is provided
-                string arguments = "";
                 string hostname = _connectionInfo.Hostname.Trim().ToLower();
                 bool useLocalHost = hostname == "" || hostname.Equals("localhost");
-                
+
+                string processExe;
+                string arguments;
+
                 if (!useLocalHost)
                 {
-                    // If hostname is provided, try to connect via SSH
-                    // Note: Domain field is not used for SSH as it's Windows-specific
-                    // SSH authentication will use standard SSH mechanisms (password prompt, keys, etc.)
-                    string username = _connectionInfo.Username;
-                    int port = _connectionInfo.Port;
-                    
-                    // Build SSH command
-                    string sshCommand = "ssh";
-                    
-                    // Add port if it's not the default SSH port (22)
-                    if (port > 0 && port != 22)
+                    // Remote session: launch the OpenSSH client (ssh.exe) DIRECTLY.
+                    //
+                    // The previous implementation ran "cmd.exe /K ssh <host>", concatenating the
+                    // attacker-controllable Hostname/Username connection fields into a string that
+                    // cmd.exe then re-parsed. That allowed command injection through shell
+                    // metacharacters (& | < > ^) — see issue #3335. Invoking ssh.exe directly means
+                    // no shell interprets the arguments, and BuildSshArguments rejects any value that
+                    // could be mis-parsed as an additional ssh argument.
+                    string sshExe = FindSshExe();
+                    if (sshExe == null)
                     {
-                        sshCommand += $" -p {port}";
+                        Runtime.MessageCollector?.AddMessage(MessageClass.ErrorMsg,
+                            "Windows OpenSSH client (ssh.exe) was not found. " +
+                            "Please install the OpenSSH Client optional feature via Settings > Apps > Optional Features.", true);
+                        return false;
                     }
-                    
-                    if (!string.IsNullOrEmpty(username))
-                    {
-                        sshCommand += $" {username}@{_connectionInfo.Hostname}";
-                    }
-                    else
-                    {
-                        sshCommand += $" {_connectionInfo.Hostname}";
-                    }
-                    
-                    arguments = $"/K {sshCommand}";
+
+                    processExe = sshExe;
+                    arguments = BuildSshArguments(_connectionInfo.Hostname, _connectionInfo.Username, _connectionInfo.Port);
                 }
                 else
                 {
-                    // For local sessions, just start cmd with /K to keep it open
+                    // Local session: open the system command processor. No user-controlled input is
+                    // passed, so there is nothing to inject.
+                    processExe = Environment.GetEnvironmentVariable("COMSPEC") ?? @"C:\Windows\System32\cmd.exe";
                     arguments = "/K";
                 }
 
-                _consoleControl.StartProcess(terminalExe, arguments);
+                _consoleControl.StartProcess(processExe, arguments);
 
                 // Wait for the console control to create its handle
                 int maxWaitMs = 5000; // 5 seconds timeout
@@ -139,6 +133,89 @@ namespace mRemoteNG.Connection.Protocol.Terminal
             {
                 Runtime.MessageCollector.AddExceptionMessage(Language.IntAppResizeFailed, ex);
             }
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        /// <summary>
+        /// Builds the argument string passed to ssh.exe. The hostname and username come straight from
+        /// the (potentially malicious) connections file, so both are validated: any value containing
+        /// whitespace/control characters or starting with '-' is rejected, because ssh.exe would parse
+        /// such a value as one or more additional arguments (e.g. -oProxyCommand=...) rather than as the
+        /// target. ssh.exe is launched directly with no intervening shell, so shell metacharacters
+        /// (&amp; | &lt; &gt; ^) carry no special meaning and cannot execute commands.
+        /// </summary>
+        private static string BuildSshArguments(string rawHostname, string rawUsername, int port)
+        {
+            string hostname = (rawHostname ?? string.Empty).Trim();
+            string username = (rawUsername ?? string.Empty).Trim();
+
+            if (!IsSafeSshToken(hostname))
+                throw new ArgumentException($"Refusing to start SSH session: the hostname '{hostname}' contains characters that are not allowed.");
+
+            if (username.Length > 0 && !IsSafeSshToken(username))
+                throw new ArgumentException($"Refusing to start SSH session: the username '{username}' contains characters that are not allowed.");
+
+            string args = "";
+
+            if (port > 0 && port != (int)Defaults.Port)
+                args += $"-p {port} ";
+
+            if (username.Length > 0)
+                args += $"{username}@{hostname}";
+            else
+                args += hostname;
+
+            return args.Trim();
+        }
+
+        /// <summary>
+        /// Returns true only for values that are safe to place on the ssh.exe command line as a single
+        /// token: non-empty, no whitespace or control characters, and not starting with '-' (which ssh
+        /// would treat as an option switch).
+        /// </summary>
+        private static bool IsSafeSshToken(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return false;
+
+            if (value[0] == '-')
+                return false;
+
+            foreach (char c in value)
+            {
+                if (char.IsWhiteSpace(c) || char.IsControl(c))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static string FindSshExe()
+        {
+            // Try the standard Windows OpenSSH location first
+            string systemSsh = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.System),
+                "OpenSSH", "ssh.exe");
+
+            if (File.Exists(systemSsh))
+                return systemSsh;
+
+            // Fallback: try to find ssh.exe on PATH
+            string pathVar = Environment.GetEnvironmentVariable("PATH");
+            if (pathVar != null)
+            {
+                foreach (string dir in pathVar.Split(Path.PathSeparator))
+                {
+                    string candidate = Path.Combine(dir.Trim(), "ssh.exe");
+                    if (File.Exists(candidate))
+                        return candidate;
+                }
+            }
+
+            return null;
         }
 
         #endregion

--- a/mRemoteNGTests/Connection/Protocol/ProtocolTerminalTests.cs
+++ b/mRemoteNGTests/Connection/Protocol/ProtocolTerminalTests.cs
@@ -106,6 +106,41 @@ public class ProtocolTerminalTests
         AssertRejected("", "admin");
     }
 
+    [Test]
+    public void BuildSshArguments_QuotedLeadingDashHostname_Throws()
+    {
+        // A leading '-' hidden behind double quotes: Windows CommandLineToArgvW strips the quotes, so
+        // ssh.exe still receives an argv token starting with '-'. The quote must be rejected.
+        AssertRejected("\"-oProxyCommand=calc.exe\"", "");
+    }
+
+    [Test]
+    public void BuildSshArguments_QuotedLeadingDashUsername_Throws()
+    {
+        AssertRejected("host", "\"-oProxyCommand=calc.exe\"");
+    }
+
+    [TestCase("ho\"st")]
+    [TestCase("\"host")]
+    [TestCase("host\"")]
+    public void BuildSshArguments_HostWithDoubleQuote_Throws(string hostname)
+    {
+        AssertRejected(hostname, "");
+    }
+
+    [Test]
+    public void BuildSshArguments_MessageDoesNotEchoOffendingValue()
+    {
+        // The exception must not embed the attacker-controlled token (control chars/newlines would
+        // otherwise reach logs and UI verbatim — log forging / message spoofing).
+        MethodInfo method = GetBuildMethod();
+        var ex = Assert.Throws<TargetInvocationException>(
+            () => method.Invoke(null, new object[] { "evil\r\nInjected-Log-Line", "", 22 }));
+        Assert.That(ex.InnerException, Is.TypeOf<ArgumentException>());
+        Assert.That(ex.InnerException.Message, Does.Not.Contain("Injected-Log-Line"));
+        Assert.That(ex.InnerException.Message, Does.Not.Contain("\n"));
+    }
+
     #endregion
 
     #region Helpers

--- a/mRemoteNGTests/Connection/Protocol/ProtocolTerminalTests.cs
+++ b/mRemoteNGTests/Connection/Protocol/ProtocolTerminalTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Reflection;
+using mRemoteNG.Connection.Protocol.Terminal;
+using NUnit.Framework;
+
+namespace mRemoteNGTests.Connection.Protocol;
+
+// Regression coverage for issue #3335: the Terminal protocol used to build "cmd.exe /K ssh <host>"
+// by concatenating the unsanitized Hostname/Username connection fields, letting a malicious .xml
+// inject arbitrary commands through cmd.exe metacharacters. It now launches ssh.exe directly and
+// rejects any host/user value that ssh could mis-parse as an extra argument.
+[TestFixture]
+public class ProtocolTerminalTests
+{
+    #region Valid targets
+
+    [Test]
+    public void BuildSshArguments_HostnameOnly_ReturnsHost()
+    {
+        Assert.That(InvokeBuild("server.example.com", "", 22), Is.EqualTo("server.example.com"));
+    }
+
+    [Test]
+    public void BuildSshArguments_WithUsername_ReturnsUserAtHost()
+    {
+        Assert.That(InvokeBuild("server.example.com", "admin", 22), Is.EqualTo("admin@server.example.com"));
+    }
+
+    [Test]
+    public void BuildSshArguments_DefaultPort_OmitsPortFlag()
+    {
+        Assert.That(InvokeBuild("host", "", 22), Is.EqualTo("host"));
+    }
+
+    [Test]
+    public void BuildSshArguments_ZeroPort_OmitsPortFlag()
+    {
+        Assert.That(InvokeBuild("host", "", 0), Is.EqualTo("host"));
+    }
+
+    [Test]
+    public void BuildSshArguments_NonDefaultPort_PrependsPortFlag()
+    {
+        Assert.That(InvokeBuild("host", "admin", 2222), Is.EqualTo("-p 2222 admin@host"));
+    }
+
+    [Test]
+    public void BuildSshArguments_TrimsWhitespaceAroundValues()
+    {
+        Assert.That(InvokeBuild("  host  ", "  admin  ", 22), Is.EqualTo("admin@host"));
+    }
+
+    [Test]
+    public void BuildSshArguments_Ipv6Address_IsAllowed()
+    {
+        Assert.That(InvokeBuild("[fe80::1]", "root", 22), Is.EqualTo("root@[fe80::1]"));
+    }
+
+    #endregion
+
+    #region Injection attempts are rejected
+
+    [Test]
+    public void BuildSshArguments_AmpersandCommandInjection_Throws()
+    {
+        // The exact payload from issue #3335.
+        AssertRejected(@"a & cmd /c echo pwned > C:\Users\Public\poc.txt & rem", "");
+    }
+
+    [TestCase("host | calc.exe")]
+    [TestCase("host & calc.exe")]
+    [TestCase("host > out.txt")]
+    [TestCase("host < in.txt")]
+    [TestCase("host ^ escape")]
+    [TestCase("host with space")]
+    [TestCase("host\ttab")]
+    [TestCase("host\nnewline")]
+    [TestCase("host\rreturn")]
+    public void BuildSshArguments_HostWithShellMetacharactersOrWhitespace_Throws(string hostname)
+    {
+        AssertRejected(hostname, "");
+    }
+
+    [Test]
+    public void BuildSshArguments_HostStartingWithDash_Throws()
+    {
+        // ssh would treat a leading '-' value as an option (e.g. -oProxyCommand=...) — argument injection.
+        AssertRejected("-oProxyCommand=calc.exe", "");
+    }
+
+    [Test]
+    public void BuildSshArguments_UsernameStartingWithDash_Throws()
+    {
+        AssertRejected("host", "-oProxyCommand=calc.exe");
+    }
+
+    [Test]
+    public void BuildSshArguments_UsernameWithSpace_Throws()
+    {
+        AssertRejected("host", "admin -oProxyCommand=calc.exe");
+    }
+
+    [Test]
+    public void BuildSshArguments_EmptyHostname_Throws()
+    {
+        AssertRejected("", "admin");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string InvokeBuild(string hostname, string username, int port)
+    {
+        MethodInfo method = GetBuildMethod();
+        return (string)method.Invoke(null, new object[] { hostname, username, port });
+    }
+
+    private static void AssertRejected(string hostname, string username)
+    {
+        MethodInfo method = GetBuildMethod();
+        TargetInvocationException ex = Assert.Throws<TargetInvocationException>(
+            () => method.Invoke(null, new object[] { hostname, username, 22 }));
+        Assert.That(ex.InnerException, Is.TypeOf<ArgumentException>());
+    }
+
+    private static MethodInfo GetBuildMethod()
+    {
+        MethodInfo method = typeof(ProtocolTerminal).GetMethod("BuildSshArguments",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        if (method == null)
+            throw new InvalidOperationException("BuildSshArguments method not found. The method may have been renamed or removed.");
+
+        return method;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Fixes #3335

## Problem

The Terminal protocol built `cmd.exe /K ssh <user>@<host>` by concatenating the **unsanitized** `Hostname`/`Username` connection fields into a single argument string that `cmd.exe` then re-parsed. Because `%COMSPEC%` is a shell, its metacharacters (`&  |  <  >  ^`) are interpreted, so a malicious `.xml` connections file achieves arbitrary command execution as the logged-in user.

Example `Hostname`:

```
a & cmd /c echo pwned > C:\Users\Public\poc.txt & rem
```

produces:

```
cmd.exe /K ssh a & cmd /c echo pwned > C:\Users\Public\poc.txt & rem
```

`ssh a` fails; the injected command runs unconditionally via `&`. With **Reconnect to previously opened sessions** enabled (`OpenConsFromLastSession`), `PreviousSessionOpener` fires the connection automatically on file load — zero clicks. The console is launched with `CreateNoWindow = true`, so nothing is visible.

I reproduced this locally against the exact argument construction: the injected command executed and wrote the PoC file.

## Fix

Launch **`ssh.exe` directly** instead of routing through `cmd.exe`, so no shell interprets the arguments.

- `BuildSshArguments` validates `Hostname` and `Username` and rejects any value that contains whitespace/control characters or starts with `-` (which `ssh` would treat as an option — e.g. `-oProxyCommand=...` argument injection). It builds a properly tokenized `[-p <port>] [user@]host` argument.
- `FindSshExe` locates the Windows OpenSSH client (`%SystemRoot%\System32\OpenSSH\ssh.exe`, then `PATH`); if absent, the connection fails with an actionable message instead of falling back to a shell.
- Local sessions (empty/`localhost` hostname) still open `%COMSPEC%` with a fixed `/K` and **no** user-controlled input.

This mirrors the existing `ProtocolOpenSSH` approach of invoking `ssh.exe` directly.

## Tests

Adds `ProtocolTerminalTests` (21 cases) covering:

- **Valid targets:** `host`, `user@host`, non-default port (`-p 2222 ...`), default/zero port omission, whitespace trimming, IPv6 (`[fe80::1]`).
- **Rejected:** the issue's `&` payload, shell metacharacters (`| & > < ^`), embedded whitespace/tab/newline/CR, and leading-`-` option injection in both hostname and username.

All 21 pass. The main `mRemoteNG` project compiles cleanly against `v1.78.2-dev`.

> Note: the test project on `v1.78.2-dev` has a **pre-existing, unrelated** compile error in `OptionsRepositoryTests.cs` (`OptionsRepository(OptionsStore)` vs `ISettingsStore`) that predates this change; I left it untouched. The new tests were verified green on an equivalent base.
