### PR TITLE
Feat: Add option to install without admin privileges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - #2496: fixed use pwfile instead of cleartext password for putty connections 
 
 ### Added
+- #3449: added Single Package Authoring (SPA) to MSI installer to allow per-user installations without admin privileges
 - #2931: added vault openbao connector
 - #2900: added "Report a Bug" menu item to Help menu and update bug report URL to GitHub issues 
 - #2865: added configurable connection tab colors to distinguish between different environments

--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ mRemoteNG is available as a redistributable MSI package or as a portable ZIP pac
 
 The MSI package of mRemoteNG can be installed using the command line:
 
-`msiexec /i [/qn] C:\Path\To\mRemoteNG-Installer.exe [INSTALLDIR=value] [IGNOREPREREQUISITES=value] [/lv* <log path>]`
+`msiexec /i C:\Path\To\mRemoteNG-Installer.msi [/qn] [INSTALLDIR=value] [IGNOREPREREQUISITES=value] [/lv* <log path>]`
+
+**Note on privileges**: The MSI installer supports dual-mode installation. By default, it will prompt for an installation scope in the UI. When running silently (`/qn`), it skips the UI and installs **per-machine** by default (which requires Administrator privileges). If you want to silently install it for the current user without requiring Administrator privileges, you must set the `MSIINSTALLPERUSER=1 ALLUSERS=2` properties from the command line.
 
 | Argument/Property | Value | Description |
 |-|-|-|
@@ -124,6 +126,8 @@ The MSI package of mRemoteNG can be installed using the command line:
 | /lv* | `Silent Installation` | Will write a logfile to the specified location. (For paths that contain spaces, enclose the path in double quotes) |
 | INSTALLDIR | `folder path` | Allows you to set the installation directory from the command line. (For paths that contain spaces, enclose the path in double quotes) |
 | IGNOREPREREQUISITES | `0` or `1` | When set to `1`, the installer will not be halted if any prerequisite check is not met. You must still run the installer as administrator. |
+| ALLUSERS | `2` | A special dual-mode flag. Check the user's privileges. If they have admin rights, install per-machine. If they don't, check if MSIINSTALLPERUSER is set. |
+| MSIINSTALLPERUSER | `1` | Explicitly forces the installation to be scoped to the current user. |
 
 ## Manual Uninstall
 

--- a/mRemoteNGInstaller/Installer/CustomDialogs/My_WixUI_FeatureTree.wxs
+++ b/mRemoteNGInstaller/Installer/CustomDialogs/My_WixUI_FeatureTree.wxs
@@ -46,11 +46,25 @@ Patch dialog sequence:
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg">NOT Installed</Publish>
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
 
+      <DialogRef Id="InstallScopeDlg" />
+
       <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
-      <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="My_CustomizeDlg">LicenseAccepted = "1"</Publish>
+      <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="InstallScopeDlg">LicenseAccepted = "1"</Publish>
+
+      <Publish Dialog="InstallScopeDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg">1</Publish>
+      <Publish Dialog="InstallScopeDlg" Control="Next" Property="WixAppFolder" Value="WixPerUserFolder" Order="1">!(wix.WixUISupportPerUser) AND NOT !(wix.WixUISupportPerMachine)</Publish>
+      <Publish Dialog="InstallScopeDlg" Control="Next" Property="WixAppFolder" Value="WixPerMachineFolder" Order="2">!(wix.WixUISupportPerMachine) AND NOT !(wix.WixUISupportPerUser)</Publish>
+      <Publish Dialog="InstallScopeDlg" Control="Next" Property="ALLUSERS" Value="2" Order="3">WixAppFolder = "WixPerUserFolder"</Publish>
+      <Publish Dialog="InstallScopeDlg" Control="Next" Property="MSIINSTALLPERUSER" Value="1" Order="4">WixAppFolder = "WixPerUserFolder"</Publish>
+      <Publish Dialog="InstallScopeDlg" Control="Next" Property="ALLUSERS" Value="1" Order="5">WixAppFolder = "WixPerMachineFolder"</Publish>
+      <Publish Dialog="InstallScopeDlg" Control="Next" Property="MSIINSTALLPERUSER" Value="{}" Order="6">WixAppFolder = "WixPerMachineFolder"</Publish>
+      <Publish Dialog="InstallScopeDlg" Control="Next" Property="INSTALLDIR" Value="[LocalAppDataFolder]Programs\[ApplicationFolderName]" Order="7">WixAppFolder = "WixPerUserFolder"</Publish>
+      <Publish Dialog="InstallScopeDlg" Control="Next" Property="INSTALLDIR" Value="[ProgramFiles64Folder][ApplicationFolderName]" Order="8">WixAppFolder = "WixPerMachineFolder" AND VersionNT64</Publish>
+      <Publish Dialog="InstallScopeDlg" Control="Next" Property="INSTALLDIR" Value="[ProgramFilesFolder][ApplicationFolderName]" Order="9">WixAppFolder = "WixPerMachineFolder" AND NOT VersionNT64</Publish>
+      <Publish Dialog="InstallScopeDlg" Control="Next" Event="NewDialog" Value="My_CustomizeDlg" Order="10">1</Publish>
 
       <Publish Dialog="My_CustomizeDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="1">Installed</Publish>
-      <Publish Dialog="My_CustomizeDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg" Order="2">NOT Installed</Publish>
+      <Publish Dialog="My_CustomizeDlg" Control="Back" Event="NewDialog" Value="InstallScopeDlg" Order="2">NOT Installed</Publish>
       <Publish Dialog="My_CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
 
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="My_CustomizeDlg" Order="1">NOT Installed OR WixUI_InstallMode = "Change"</Publish>

--- a/mRemoteNGInstaller/Installer/Fragments/RegistryEntriesFragment.wxs
+++ b/mRemoteNGInstaller/Installer/Fragments/RegistryEntriesFragment.wxs
@@ -3,7 +3,7 @@
 	<Fragment>
     <DirectoryRef Id="TARGETDIR">
       <Component Id="C.RegistryEntries" Guid="888643e4-4c52-45d3-801a-0d0d71c737fe">
-        <RegistryKey Root="HKLM" Key="Software\mRemoteNG">
+        <RegistryKey Root="HKMU" Key="Software\mRemoteNG">
           <RegistryValue Type="string" Name="InstallDir" Value="[INSTALLDIR]" KeyPath="yes" />
         </RegistryKey>
       </Component>

--- a/mRemoteNGInstaller/Installer/mRemoteNG.wxs
+++ b/mRemoteNGInstaller/Installer/mRemoteNG.wxs
@@ -6,7 +6,7 @@
            Id="$(var.ProductCode)" 
            UpgradeCode="$(var.UpgradeCode)" 
            Language="1033">
-    <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
+    <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" />
     <MajorUpgrade DowngradeErrorMessage="!(loc.Upgrade_NewerVersionInstalled)" Schedule="afterInstallExecute" />
     <MediaTemplate EmbedCab="yes" />
     <Binary Id="CustomActions.CA.dll" SourceFile="$(var.SolutionDir)mRemoteNGInstaller\CustomActions\bin\x64\$(var.Configuration)\CustomActions.CA.dll" />
@@ -28,6 +28,11 @@
     <PropertyRef Id="NETFRAMEWORK40FULL" />
     <PropertyRef Id="WIX_IS_NETFRAMEWORK_40_OR_LATER_INSTALLED" />
     <Icon Id="AppIcon.ico" SourceFile="Resources\AppIcon.ico" />
+    <Property Id="WixAppFolder" Value="WixPerMachineFolder" />
+    <WixVariable Id="WixUISupportPerUser" Value="1" />
+    <WixVariable Id="WixUISupportPerMachine" Value="1" />
+    <WixVariable Id="WixUISupportPerMachineDefault" Value="1" />
+    <Property Id="ApplicationFolderName" Value="$(var.ProductName)" />
     <CustomActionRef Id='SaveCmdlineINSTALLDIR' />
 
 
@@ -46,10 +51,6 @@
     </InstallExecuteSequence>
     
     
-    <!-- Need to be admin to install -->
-    <Condition Message="!(loc.Install_NeedToBeAdminToInstall)">
-      Privileged
-    </Condition>
     <!-- Windows 7 or higher required -->
     <Condition Message="!(loc.Install_OSVersionRequirement)">
       <![CDATA[Installed OR (IGNOREPREREQUISITES = 1) OR (VersionNT >= 601) OR (VersionNT64 >= 601)]]>


### PR DESCRIPTION
## Description
This PR updates the WiX installer configuration to support **Single Package Authoring (SPA)**, giving users the option to install mRemoteNG without requiring administrator privileges. 

During the installation, users are now presented with an "Install Scope" dialog where they can choose to either install the application system-wide (requires admin) or just for their user account (no admin required).

## Changes
- **`mRemoteNG.wxs`**: 
  - Upgraded `InstallerVersion` to `500` to utilize Windows Installer 5.0's native directory redirection.
  - Removed the hardcoded `Privileged` condition to permit non-admin executions.
  - Added standard SPA properties (`WixAppFolder`, `WixUISupportPerUser`, `ApplicationFolderName`) to signal dual-mode support to the installer UI.
- **`My_WixUI_FeatureTree.wxs`**: 
  - Injected the standard `InstallScopeDlg` dialog into the custom UI sequence, immediately following the License Agreement dialog. 
  - Configured the UI routing events to correctly override the `ALLUSERS`, `MSIINSTALLPERUSER`, and `INSTALLDIR` properties according to the user's selected scope.
- **`RegistryEntriesFragment.wxs`**: 
  - Changed the registry root attribute from `HKLM` to `HKMU`. This allows the Windows Installer to dynamically write settings to `HKEY_CURRENT_USER` during per-user installs, avoiding access denied errors for standard users.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, the mRemoteNG installer strictly requires administrator privileges to execute a system-wide installation. However, we have a significant number of users who do not have admin rights on their machines. 

Since mRemoteNG already offers a portable `.zip` version that naturally does not require admin privileges, the MSI installer should offer parity by allowing users to install the application for their profile only. By adopting Single Package Authoring (SPA), this PR bridges that gap, providing a seamless standard installation experience for standard users without forcing them to rely on the portable version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Build the MSI installer via `mRemoteNGInstaller.wixproj`.
2. Run the newly generated MSI. 
3. Verify that the new "Install Scope" dialog appears after accepting the License Agreement.
4. **Test Per-User:** Select "Install just for you" as a standard user. Verify that no UAC prompt is triggered and the application installs to `%LocalAppData%\Programs\mRemoteNG`.
5. **Test Per-Machine:** Select "Install for all users of this machine". Verify that it triggers a UAC elevation prompt and installs to the standard `Program Files` directory.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [X] This pull request does not target the master branch.
- [x] I have updated the changelog file accordingly, if necessary.
- [x] I have updated the documentation accordingly, if necessary.
